### PR TITLE
Replace libuv-backed timers and filesystem helpers

### DIFF
--- a/src/common/condition_variable.jl
+++ b/src/common/condition_variable.jl
@@ -104,9 +104,9 @@ function condition_variable_wait_for_pred(
         end
         remaining = deadline - now_ref[]
         unlock(mutex)
-        ok = Base.timedwait(() -> (@atomic cond.seq) != local_seq, remaining / 1_000_000_000)
+        ok = timedwait_poll_ns(() -> (@atomic cond.seq) != local_seq, remaining)
         lock(mutex)
-        if ok == false || ok == :timed_out
+        if ok == :timed_out
             return raise_error(ERROR_COND_VARIABLE_TIMED_OUT)
         end
         local_seq = @atomic cond.seq

--- a/src/common/file.jl
+++ b/src/common/file.jl
@@ -18,6 +18,26 @@ const _SEEK_END = Cint(2)
 @static if _PLATFORM_WINDOWS
     const _WIN_FILE_ATTRIBUTE_DIRECTORY = UInt32(0x10)
     const _WIN_INVALID_FILE_ATTRIBUTES = UInt32(0xffffffff)
+    const _WIN_CRT_LIBS = ("ucrtbase", "msvcrt")
+
+    @inline function _win_crt_ccall(sym::Symbol, rettype::Type, argtypes::Tuple, args...)
+        # Windows CRT functions may not be imported into the Julia binary. Prefer the CRT dlls
+        # explicitly, falling back to the default search if needed.
+        for lib in _WIN_CRT_LIBS
+            try
+                return ccall((sym, lib), rettype, argtypes, args...)
+            catch err
+                if err isa ErrorException
+                    msg = err.msg
+                    if occursin("could not load", msg) || occursin("could not find", msg)
+                        continue
+                    end
+                end
+                rethrow()
+            end
+        end
+        return ccall(sym, rettype, argtypes, args...)
+    end
 end
 
 @inline function _c_str_is_empty(c_str::Ptr{UInt8})
@@ -34,13 +54,20 @@ end
 
 function _fs_file_length(file::Libc.FILE)::Union{Int64, Nothing}
     @static if _PLATFORM_WINDOWS
-        pos = ccall(:_ftelli64, Int64, (Ptr{Cvoid},), file.ptr)
-        pos < 0 && return nothing
-        ccall(:_fseeki64, Cint, (Ptr{Cvoid}, Int64, Cint), file.ptr, 0, _SEEK_END) == 0 || return nothing
-        len = ccall(:_ftelli64, Int64, (Ptr{Cvoid},), file.ptr)
-        _ = ccall(:_fseeki64, Cint, (Ptr{Cvoid}, Int64, Cint), file.ptr, pos, _SEEK_SET)
-        len < 0 && return nothing
-        return len
+        try
+            pos = _win_crt_ccall(:_ftelli64, Int64, (Ptr{Cvoid},), file.ptr)
+            pos < 0 && return nothing
+            _win_crt_ccall(:_fseeki64, Cint, (Ptr{Cvoid}, Int64, Cint), file.ptr, 0, _SEEK_END) == 0 || return nothing
+            len = _win_crt_ccall(:_ftelli64, Int64, (Ptr{Cvoid},), file.ptr)
+            _ = _win_crt_ccall(:_fseeki64, Cint, (Ptr{Cvoid}, Int64, Cint), file.ptr, pos, _SEEK_SET)
+            len < 0 && return nothing
+            return len
+        catch err
+            if err isa ErrorException && occursin("could not load", err.msg)
+                return nothing
+            end
+            rethrow()
+        end
     else
         pos = ccall(:ftello, Int64, (Ptr{Cvoid},), file.ptr)
         pos < 0 && return nothing

--- a/src/common/file.jl
+++ b/src/common/file.jl
@@ -3,14 +3,53 @@ const FILE_TYPE_SYM_LINK = 2
 const FILE_TYPE_DIRECTORY = 4
 
 const _FILE_READ_MODE = "rb"
+const _FILE_WRITE_MODE = "wb"
+const _FILE_APPEND_MODE = "ab"
 const _MIN_BUFFER_GROWTH_READING_FILES = 32
 const _MAX_BUFFER_GROWTH_READING_FILES = 4096
 
 const PATH_DELIM = _PLATFORM_WINDOWS ? UInt8('\\') : UInt8('/')
 const PATH_DELIM_STR = _PLATFORM_WINDOWS ? "\\" : "/"
 
+# POSIX fseek/ftell whence values.
+const _SEEK_SET = Cint(0)
+const _SEEK_END = Cint(2)
+
+@static if _PLATFORM_WINDOWS
+    const _WIN_FILE_ATTRIBUTE_DIRECTORY = UInt32(0x10)
+    const _WIN_INVALID_FILE_ATTRIBUTES = UInt32(0xffffffff)
+end
+
 @inline function _c_str_is_empty(c_str::Ptr{UInt8})
     return c_str == C_NULL || unsafe_load(c_str) == 0x00
+end
+
+@inline function _getenv_string(name::AbstractString)::Union{Nothing, String}
+    ptr = ccall(:getenv, Ptr{UInt8}, (Cstring,), name)
+    if ptr == C_NULL || unsafe_load(ptr) == 0x00
+        return nothing
+    end
+    return unsafe_string(ptr)
+end
+
+function _fs_file_length(file::Libc.FILE)::Union{Int64, Nothing}
+    @static if _PLATFORM_WINDOWS
+        pos = ccall(:_ftelli64, Int64, (Ptr{Cvoid},), file.ptr)
+        pos < 0 && return nothing
+        ccall(:_fseeki64, Cint, (Ptr{Cvoid}, Int64, Cint), file.ptr, 0, _SEEK_END) == 0 || return nothing
+        len = ccall(:_ftelli64, Int64, (Ptr{Cvoid},), file.ptr)
+        _ = ccall(:_fseeki64, Cint, (Ptr{Cvoid}, Int64, Cint), file.ptr, pos, _SEEK_SET)
+        len < 0 && return nothing
+        return len
+    else
+        pos = ccall(:ftello, Int64, (Ptr{Cvoid},), file.ptr)
+        pos < 0 && return nothing
+        ccall(:fseeko, Cint, (Ptr{Cvoid}, Int64, Cint), file.ptr, 0, _SEEK_END) == 0 || return nothing
+        len = ccall(:ftello, Int64, (Ptr{Cvoid},), file.ptr)
+        _ = ccall(:fseeko, Cint, (Ptr{Cvoid}, Int64, Cint), file.ptr, pos, _SEEK_SET)
+        len < 0 && return nothing
+        return len
+    end
 end
 
 function byte_buf_init_from_file(out_buf::Base.RefValue{<:ByteBuffer}, filename::Ptr{UInt8})
@@ -62,30 +101,14 @@ function _byte_buf_init_from_file_impl(
     file = Libc.FILE(file_ptr)
     try
         if use_file_size_as_hint
-            fd = @static if _PLATFORM_WINDOWS
-                ccall(:_fileno, Cint, (Ptr{Cvoid},), file.ptr)
-            else
-                ccall(:fileno, Cint, (Ptr{Cvoid},), file.ptr)
+            len64 = _fs_file_length(file)
+            if len64 !== nothing
+                if len64 >= 0 && UInt64(len64) >= UInt64(SIZE_MAX)
+                    raise_error(ERROR_OVERFLOW_DETECTED)
+                    return OP_ERR
+                end
+                size_hint = len64 + 1
             end
-            if fd == -1
-                raise_error(ERROR_INVALID_FILE_HANDLE)
-                return OP_ERR
-            end
-
-            st = try
-                stat(RawFD(fd))
-            catch
-                err = Libc.errno()
-                translate_and_raise_io_error_or(err, ERROR_FILE_READ_FAILURE)
-                return OP_ERR
-            end
-
-            len64 = filesize(st)
-            if len64 >= SIZE_MAX
-                raise_error(ERROR_OVERFLOW_DETECTED)
-                return OP_ERR
-            end
-            size_hint = len64 + 1
         end
 
         if byte_buf_init(out_buf, size_hint) != OP_SUCCESS
@@ -154,6 +177,115 @@ function _byte_buf_init_from_file_impl(
 end
 
 function get_home_directory()
-    home = homedir()
+    home = @static if _PLATFORM_WINDOWS
+        something(
+            _getenv_string("USERPROFILE"),
+            let drive = _getenv_string("HOMEDRIVE"), path = _getenv_string("HOMEPATH")
+                (drive !== nothing && path !== nothing) ? string(drive, path) : nothing
+            end,
+        )
+    else
+        _getenv_string("HOME")
+    end
+    if home === nothing || isempty(home)
+        raise_error(ERROR_GET_HOME_DIRECTORY_FAILED)
+        return string_new_from_array(Ptr{UInt8}(0), 0)
+    end
     return string_new_from_c_str(home)
+end
+
+function get_temp_directory()::String
+    @static if _PLATFORM_WINDOWS
+        tmp = something(_getenv_string("TMP"), _getenv_string("TEMP"), nothing)
+        if tmp !== nothing && !isempty(tmp)
+            return tmp
+        end
+        # Best-effort fallback.
+        return "C:\\\\Windows\\\\Temp"
+    else
+        tmp = something(_getenv_string("TMPDIR"), _getenv_string("TMP"), _getenv_string("TEMP"), nothing)
+        if tmp !== nothing && !isempty(tmp)
+            return tmp
+        end
+        return "/tmp"
+    end
+end
+
+function tempname(dir::AbstractString = get_temp_directory())::String
+    base = isempty(dir) ? "." : dir
+    # Avoid a leading '.' in the filename (some tooling treats it as hidden).
+    hex = string(rand(UInt128); base = 16)
+    return joinpath(base, string("tmp-", hex))
+end
+
+function fs_isdir(path::AbstractString)::Bool
+    @static if _PLATFORM_WINDOWS
+        attrs = ccall((:GetFileAttributesW, "kernel32"), UInt32, (Cwstring,), path)
+        attrs == _WIN_INVALID_FILE_ATTRIBUTES && return false
+        return (attrs & _WIN_FILE_ATTRIBUTE_DIRECTORY) != 0
+    else
+        dirp = ccall(:opendir, Ptr{Cvoid}, (Cstring,), path)
+        dirp == C_NULL && return false
+        _ = ccall(:closedir, Cint, (Ptr{Cvoid},), dirp)
+        return true
+    end
+end
+
+function fs_open_write(path::AbstractString)::Union{Libc.FILE, ErrorResult}
+    file_ptr = ccall(:fopen, Ptr{Cvoid}, (Cstring, Cstring), path, _FILE_WRITE_MODE)
+    if file_ptr == C_NULL
+        err = Libc.errno()
+        translate_and_raise_io_error_or(err, ERROR_FILE_OPEN_FAILURE)
+        return ErrorResult(last_error())
+    end
+    return Libc.FILE(file_ptr)
+end
+
+function fs_open_append(path::AbstractString)::Union{Libc.FILE, ErrorResult}
+    file_ptr = ccall(:fopen, Ptr{Cvoid}, (Cstring, Cstring), path, _FILE_APPEND_MODE)
+    if file_ptr == C_NULL
+        err = Libc.errno()
+        translate_and_raise_io_error_or(err, ERROR_FILE_OPEN_FAILURE)
+        return ErrorResult(last_error())
+    end
+    return Libc.FILE(file_ptr)
+end
+
+function fs_write(file::Libc.FILE, data::AbstractVector{UInt8})::Union{Int, ErrorResult}
+    len = length(data)
+    len == 0 && return 0
+    wrote = GC.@preserve data file begin
+        ccall(
+            :fwrite,
+            Csize_t,
+            (Ptr{Cvoid}, Csize_t, Csize_t, Ptr{Cvoid}),
+            pointer(data),
+            1,
+            len,
+            file.ptr,
+        )
+    end
+    if wrote != len
+        err = ccall(:ferror, Cint, (Ptr{Cvoid},), file.ptr) != 0 ? Libc.errno() : 0
+        translate_and_raise_io_error_or(err, ERROR_FILE_WRITE_FAILURE)
+        return ErrorResult(last_error())
+    end
+    return Int(wrote)
+end
+
+function fs_write(file::Libc.FILE, s::AbstractString)::Union{Int, ErrorResult}
+    bytes = codeunits(s)
+    GC.@preserve bytes begin
+        return fs_write(file, bytes)
+    end
+end
+
+function fs_flush(file::Libc.FILE)::Union{Nothing, ErrorResult}
+    ret = ccall(:fflush, Cint, (Ptr{Cvoid},), file.ptr)
+    if ret != 0
+        err = Libc.errno()
+        translate_and_raise_io_error_or(err, ERROR_FILE_WRITE_FAILURE)
+        return ErrorResult(last_error())
+    end
+    return nothing
 end

--- a/src/common/log_writer.jl
+++ b/src/common/log_writer.jl
@@ -5,6 +5,10 @@ struct FileLogWriter{I <: IO} <: AbstractLogWriter
     close_on_cleanup::Bool
 end
 
+struct CFileLogWriter <: AbstractLogWriter
+    file::Libc.FILE
+end
+
 @inline function write!(writer::FileLogWriter, line::AbstractString)
     print(writer.io, line)
     flush(writer.io)
@@ -17,6 +21,30 @@ end
     return nothing
 end
 
+@inline function write!(writer::CFileLogWriter, line::AbstractString)
+    bytes = codeunits(line)
+    wrote = GC.@preserve bytes writer begin
+        ccall(
+            :fwrite,
+            Csize_t,
+            (Ptr{Cvoid}, Csize_t, Csize_t, Ptr{Cvoid}),
+            pointer(bytes),
+            1,
+            length(bytes),
+            writer.file.ptr,
+        )
+    end
+    if wrote == length(bytes)
+        _ = ccall(:fflush, Cint, (Ptr{Cvoid},), writer.file.ptr)
+    end
+    return nothing
+end
+
+@inline function close!(writer::CFileLogWriter)
+    close(writer.file)
+    return nothing
+end
+
 @inline function log_writer_stdout()
     return FileLogWriter(stdout, false)
 end
@@ -26,8 +54,10 @@ end
 end
 
 function log_writer_file(path::AbstractString)
-    io = open(path, "a+")
-    return FileLogWriter(io, true)
+    file_ptr = ccall(:fopen, Ptr{Cvoid}, (Cstring, Cstring), path, "ab")
+    file_ptr == C_NULL && throw(ErrorException("failed to open log file: $(path)"))
+    file = Libc.FILE(file_ptr)
+    return CFileLogWriter(file)
 end
 
 @inline function log_writer_file(io::IO; close_on_cleanup::Bool = false)

--- a/src/common/thread.jl
+++ b/src/common/thread.jl
@@ -164,7 +164,7 @@ end
 
 function thread_current_sleep(nanos::Integer)
     nanos <= 0 && return nothing
-    sleep(nanos / 1_000_000_000)
+    thread_sleep_ns(nanos)
     return nothing
 end
 

--- a/src/io/epoll_event_loop_types.jl
+++ b/src/io/epoll_event_loop_types.jl
@@ -78,6 +78,8 @@
         thread_created_on::Union{Nothing, ThreadHandle}
         thread_joined_to::UInt64
         @atomic running_thread_id::UInt64
+        startup_event::Threads.Event
+        @atomic startup_error::Int
         read_task_handle::IoHandle
         write_task_handle::IoHandle
         task_pre_queue_mutex::ReentrantLock
@@ -97,6 +99,8 @@
             nothing,
             UInt64(0),
             UInt64(0),
+            Threads.Event(),
+            0,
             IoHandle(),
             IoHandle(),
             ReentrantLock(),

--- a/src/io/host_resolver.jl
+++ b/src/io/host_resolver.jl
@@ -967,3 +967,13 @@ function _native_getaddrinfo(hostname::String; flags::Cint = Cint(0))::Vector{Tu
     end
     return addresses
 end
+
+"""
+    getalladdrinfo(hostname; flags=0) -> Vector{Tuple{String, Cint}}
+
+Public wrapper for the libuv-free `getaddrinfo()` implementation used by the
+host resolver. This exists primarily so downstream packages can avoid `Sockets`.
+"""
+function getalladdrinfo(hostname::AbstractString; flags::Cint = Cint(0))::Vector{Tuple{String, Cint}}
+    return _native_getaddrinfo(String(hostname); flags = flags)
+end

--- a/src/io/iocp_event_loop_types.jl
+++ b/src/io/iocp_event_loop_types.jl
@@ -43,6 +43,8 @@
         thread_created_on::Union{Nothing, ThreadHandle}
         thread_joined_to::UInt64
         @atomic running_thread_id::UInt64
+        startup_event::Threads.Event
+        @atomic startup_error::Int
         synced_data::IocpSyncedData
         thread_data::IocpThreadData
         thread_options::ThreadOptions
@@ -54,6 +56,8 @@
             nothing,
             UInt64(0),
             UInt64(0),
+            Threads.Event(),
+            0,
             IocpSyncedData(),
             IocpThreadData(),
             ThreadOptions(),
@@ -61,4 +65,3 @@
     end
 
 end # @static if Sys.iswindows()
-

--- a/src/io/kqueue_event_loop.jl
+++ b/src/io/kqueue_event_loop.jl
@@ -208,6 +208,11 @@
 
         logf(LogLevel.INFO, LS_IO_EVENT_LOOP, "starting event-loop thread")
 
+        # Thread startup synchronization (avoid libuv-backed `sleep`/`time_ns` polling).
+        impl.startup_event = Threads.Event()
+        @atomic impl.startup_error = 0
+        @atomic impl.running_thread_id = UInt64(0)
+
         # Verify state
         if impl.cross_thread_data.state != EventThreadState.READY_TO_RUN
             return ErrorResult(raise_error(ERROR_INVALID_STATE))
@@ -233,12 +238,10 @@
         event_loop.thread = impl.thread_created_on
         @atomic event_loop.running = true
 
-        wait_start = time_ns()
-        while (@atomic impl.running_thread_id) == 0
-            if time_ns() - wait_start > 1_000_000_000
-                return ErrorResult(raise_error(ERROR_IO_EVENT_LOOP_SHUTDOWN))
-            end
-            sleep(0.001)
+        wait(impl.startup_event)
+        startup_error = @atomic impl.startup_error
+        if startup_error != 0 || (@atomic impl.running_thread_id) == 0
+            return ErrorResult(raise_error(startup_error != 0 ? startup_error : ERROR_IO_EVENT_LOOP_SHUTDOWN))
         end
 
         return nothing
@@ -671,6 +674,7 @@
         # Set running thread ID
         @atomic impl.running_thread_id = thread_current_thread_id()
         impl.thread_data.state = EventThreadState.RUNNING
+        notify(impl.startup_event)
 
         _ = thread_current_at_exit(() -> LibAwsCal.aws_cal_thread_clean_up())
 

--- a/src/io/kqueue_event_loop_types.jl
+++ b/src/io/kqueue_event_loop_types.jl
@@ -145,6 +145,8 @@
         thread_created_on::Union{Nothing, ThreadHandle}
         thread_joined_to::UInt64
         @atomic running_thread_id::UInt64
+        startup_event::Threads.Event
+        @atomic startup_error::Int
         kq_fd::Int32
         cross_thread_signal_pipe::NTuple{2, Int32}
         cross_thread_data::KqueueCrossThreadData
@@ -159,6 +161,8 @@
             nothing,
             UInt64(0),
             UInt64(0),
+            Threads.Event(),
+            0,
             Int32(-1),
             (Int32(-1), Int32(-1)),
             KqueueCrossThreadData(),

--- a/todo/libuv-replacements.md
+++ b/todo/libuv-replacements.md
@@ -26,7 +26,7 @@ Local verification (macOS):
 - `HTTP` tests pass
 
 CI verification:
-- `Reseau` PR #1 CI is green on macOS/Linux/Windows (`gh` run `21787880109`).
+- `Reseau` PR #1 CI is green on macOS/Linux/Windows (last checked 2026-02-07).
 
 Invariant checks:
 - `Reseau/src/` has no `sleep(` / `time_ns` / `Base.timedwait` / `stat(` call sites (comments/docstrings may still mention them).

--- a/todo/libuv-replacements.md
+++ b/todo/libuv-replacements.md
@@ -25,6 +25,9 @@ Local verification (macOS):
 - `AwsHTTP` tests pass
 - `HTTP` tests pass
 
+CI verification:
+- `Reseau` PR #1 CI is green on macOS/Linux/Windows (`gh` run `21787880109`).
+
 Invariant checks:
 - `Reseau/src/` has no `sleep(` / `time_ns` / `Base.timedwait` / `stat(` call sites (comments/docstrings may still mention them).
 - `AwsHTTP/src/` has no `time_ns(` call sites.


### PR DESCRIPTION
Implements the libuv-replacement surface described in `todo/libuv-replacements.md`.

Key changes:
- Add libuv-free monotonic clock + timedwait polling + thread sleep (clock.jl)
- Add task-friendly sleep by scheduling wakeups on the aws event loop (event_loop.jl)
- Remove Base `sleep`/`timedwait`/`time_ns` usage from event loop startup + condition variable + Future waiting
- Replace Base filesystem helpers (`open`/`stat`/`homedir`/`tempdir`/`tempname`/`isdir`) with libc-based wrappers (file.jl + log_writer.jl)

Local verification:
- `Pkg.test` passes for Reseau on macOS (Julia 1.12)
- Downstream `AwsHTTP` + `HTTP` tests pass locally on macOS against this checkout