### PR TITLE
Reseau: type-parameter cleanup

### DIFF
--- a/src/common/task_scheduler.jl
+++ b/src/common/task_scheduler.jl
@@ -10,15 +10,15 @@ const _TASK_STATUS_STRINGS = (
     "<Canceled>", # TaskStatus.CANCELED == 1
 )
 
-struct TaskFn{F, Ctx}
-    f::F
-    ctx::Ctx
+struct TaskFn
+    f::Any
+    ctx::Any
 end
 
 (task::TaskFn)(status::TaskStatus.T) = Base.invokelatest(task.f, task.ctx, status)
 
-mutable struct ScheduledTask{F, Ctx}
-    fn::TaskFn{F, Ctx}
+mutable struct ScheduledTask
+    fn::TaskFn
     type_tag::String
     timestamp::UInt64
     scheduled::Bool

--- a/src/io/bufferio.jl
+++ b/src/io/bufferio.jl
@@ -12,7 +12,7 @@ mutable struct BufferIOChannel <: IO
     port::Int
     tls_enabled::Bool
     event_loop_group::EventLoopGroup
-    host_resolver::DefaultHostResolver
+    host_resolver::HostResolver
     bootstrap::ClientBootstrap
     owns_event_loop_group::Bool
     owns_host_resolver::Bool
@@ -43,7 +43,7 @@ end
 
 const _BUFFERIOCHANNEL_DEFAULT_LOCK = ReentrantLock()
 const _BUFFERIOCHANNEL_DEFAULT_ELG = Ref{Union{EventLoopGroup, Nothing}}(nothing)
-const _BUFFERIOCHANNEL_DEFAULT_RESOLVER = Ref{Union{DefaultHostResolver, Nothing}}(nothing)
+const _BUFFERIOCHANNEL_DEFAULT_RESOLVER = Ref{Union{HostResolver, Nothing}}(nothing)
 
 function _bufferiochannel_default_resources()
     lock(_BUFFERIOCHANNEL_DEFAULT_LOCK)
@@ -51,11 +51,11 @@ function _bufferiochannel_default_resources()
         if _BUFFERIOCHANNEL_DEFAULT_ELG[] === nothing
             elg = EventLoopGroup(EventLoopGroupOptions(; loop_count = 1))
             elg isa ErrorResult && error("Failed to create EventLoopGroup: $(elg.code)")
-            resolver = DefaultHostResolver(elg)
+            resolver = HostResolver(elg)
             _BUFFERIOCHANNEL_DEFAULT_ELG[] = elg
             _BUFFERIOCHANNEL_DEFAULT_RESOLVER[] = resolver
         end
-        return _BUFFERIOCHANNEL_DEFAULT_ELG[]::EventLoopGroup, _BUFFERIOCHANNEL_DEFAULT_RESOLVER[]::DefaultHostResolver
+        return _BUFFERIOCHANNEL_DEFAULT_ELG[]::EventLoopGroup, _BUFFERIOCHANNEL_DEFAULT_RESOLVER[]::HostResolver
     finally
         unlock(_BUFFERIOCHANNEL_DEFAULT_LOCK)
     end
@@ -196,7 +196,7 @@ function BufferIOChannel(
         elg, resolver = _bufferiochannel_default_resources()
     else
         if resolver === nothing
-            resolver = DefaultHostResolver(elg)
+            resolver = HostResolver(elg)
             owns_resolver = true
         end
     end

--- a/src/io/epoll_event_loop_types.jl
+++ b/src/io/epoll_event_loop_types.jl
@@ -50,20 +50,20 @@
     const O_CLOEXEC = Cint(0o2000000)
 
     # Handle data attached to IoHandle while subscribed
-    mutable struct EpollEventHandleData{F <: OnEventCallback, U}
+    mutable struct EpollEventHandleData
         handle::IoHandle
-        on_event::F
-        user_data::U
+        on_event::OnEventCallback
+        user_data::Any
         cleanup_task::Union{Nothing, ScheduledTask}  # nullable
         is_subscribed::Bool  # false when handle is unsubscribed but struct not cleaned up yet
     end
 
     function EpollEventHandleData(
             handle::IoHandle,
-            on_event::F,
-            user_data::U,
-        ) where {F <: OnEventCallback, U}
-        return EpollEventHandleData{F, U}(
+            on_event::OnEventCallback,
+            user_data,
+        )
+        return EpollEventHandleData(
             handle,
             on_event,
             user_data,

--- a/src/io/event_loop_types.jl
+++ b/src/io/event_loop_types.jl
@@ -12,16 +12,17 @@ end
 # Callback type for IO events
 const OnEventCallback = Function  # signature: (event_loop, io_handle, events::Int, user_data) -> Nothing
 
-# Event loop local object for thread-local storage
-mutable struct EventLoopLocalObject{T}
+# Event loop local object for event-loop-local storage.
+#
+# This is intentionally *not* parametric: local objects are stored in an
+# `IdDict{Any, EventLoopLocalObject}` and typically handled without specialization.
+mutable struct EventLoopLocalObject
     key::Any
-    object::T
+    object::Any
     on_object_removed::Union{Function, Nothing}
 end
 
-function EventLoopLocalObject(key, object::T) where {T}
-    return EventLoopLocalObject{T}(key, object, nothing)
-end
+EventLoopLocalObject(key, object) = EventLoopLocalObject(key, object, nothing)
 
 function _event_loop_local_object_destroy(obj)
     if obj isa EventLoopLocalObject && obj.on_object_removed !== nothing

--- a/src/io/future.jl
+++ b/src/io/future.jl
@@ -13,9 +13,9 @@ end
 const OnFutureCompleteFn = Function  # (future, user_data) -> nothing
 
 # Future waiter - for tracking pending callbacks
-mutable struct FutureWaiter{F, U}
-    callback::F
-    user_data::U
+mutable struct FutureWaiter
+    callback::OnFutureCompleteFn
+    user_data::Any
     next::Union{FutureWaiter, Nothing}  # nullable
 end
 

--- a/src/io/io.jl
+++ b/src/io/io.jl
@@ -229,7 +229,6 @@ end
 io_handle_is_valid(handle::IoHandle) = handle.fd >= 0 || handle.handle != C_NULL
 
 # Forward declarations for types defined in other io files
-abstract type AbstractChannel end
 abstract type AbstractChannelHandler end
 
 # IO Message - data unit flowing through channel pipeline
@@ -238,7 +237,7 @@ mutable struct IoMessage
     message_type::IoMessageType.T
     message_tag::Int32
     copy_mark::Csize_t
-    owning_channel::Union{AbstractChannel, Nothing}  # nullable
+    owning_channel::Any  # Channel or nothing
     on_completion::Union{Function, Nothing}
     user_data::Any
     # Intrusive list node for queueing
@@ -597,4 +596,3 @@ function io_error_code_is_tls(error_code::Integer)::Bool
         error_code == ERROR_IO_TLS_INVALID_CERTIFICATE_CHAIN ||
         error_code == ERROR_IO_TLS_HOST_NAME_MISMATCH
 end
-

--- a/src/io/kqueue_event_loop_types.jl
+++ b/src/io/kqueue_event_loop_types.jl
@@ -74,11 +74,11 @@
     end
 
     # Handle data attached to IoHandle while subscribed
-    mutable struct KqueueHandleData{F <: OnEventCallback, U}
+    mutable struct KqueueHandleData
         owner::IoHandle
         event_loop::Any  # EventLoop (not yet defined at include time)
-        on_event::F
-        on_event_user_data::U
+        on_event::OnEventCallback
+        on_event_user_data::Any
         events_subscribed::Int  # IoEventType bitmask
         events_this_loop::Int   # Events received during current loop iteration
         state::HandleState.T
@@ -90,11 +90,11 @@
     function KqueueHandleData(
             owner::IoHandle,
             event_loop,
-            on_event::F,
-            user_data::U,
+            on_event::OnEventCallback,
+            user_data,
             events::Int,
-        ) where {F <: OnEventCallback, U}
-        return KqueueHandleData{F, U}(
+        )
+        return KqueueHandleData(
             owner,
             event_loop,
             on_event,

--- a/src/io/pipe.jl
+++ b/src/io/pipe.jl
@@ -6,19 +6,19 @@ const OnPipeReadableFn = Function  # (pipe, error_code, user_data) -> nothing
 const OnPipeWriteCompleteFn = Function  # (pipe, error_code, bytes_written, user_data) -> nothing
 
 # Pipe read end
-# Note: user_data is parameterized as U (typically Any) since it can hold any user-provided value
-# and is set dynamically after creation via pipe_read_end_subscribe!
-mutable struct PipeReadEnd{U}
+# Note: user_data can hold any user-provided value and is set dynamically after
+# creation via pipe_read_end_subscribe!.
+mutable struct PipeReadEnd
     io_handle::IoHandle
     event_loop::Union{EventLoop, Nothing}  # nullable
     on_readable::Union{OnPipeReadableFn, Nothing}  # nullable
-    user_data::U
+    user_data::Any
     is_subscribed::Bool
     impl::Any  # platform-specific impl data (e.g. IOCP on Windows)
 end
 
 function PipeReadEnd(fd::Integer)
-    return PipeReadEnd{Any}(
+    return PipeReadEnd(
         IoHandle(Int32(fd)),
         nothing,
         nothing,

--- a/src/io/socket.jl
+++ b/src/io/socket.jl
@@ -170,12 +170,12 @@ const SocketOnWriteCompletedFn = Function    # (socket, error_code, bytes_writte
 const SocketOnReadableFn = Function          # (socket, error_code, user_data) -> Nothing
 
 # Socket connect options
-struct SocketConnectOptions{TO}
+struct SocketConnectOptions
     remote_endpoint::SocketEndpoint
     event_loop::Union{EventLoop, Nothing}
     on_connection_result::Union{Function, Nothing}
     user_data::Any
-    tls_connection_options::TO
+    tls_connection_options::Any  # TlsConnectionOptions or nothing
 end
 
 function SocketConnectOptions(
@@ -185,7 +185,7 @@ function SocketConnectOptions(
         user_data = nothing,
         tls_connection_options = nothing,
     )
-    return SocketConnectOptions{typeof(tls_connection_options)}(
+    return SocketConnectOptions(
         remote_endpoint,
         event_loop,
         on_connection_result,
@@ -195,11 +195,11 @@ function SocketConnectOptions(
 end
 
 # Socket bind options
-struct SocketBindOptions{TO}
+struct SocketBindOptions
     local_endpoint::SocketEndpoint
     user_data::Any
     event_loop::Union{EventLoop, Nothing}
-    tls_connection_options::TO
+    tls_connection_options::Any  # TlsConnectionOptions or nothing
 end
 
 function SocketBindOptions(
@@ -208,7 +208,7 @@ function SocketBindOptions(
         event_loop = nothing,
         tls_connection_options = nothing,
     )
-    return SocketBindOptions{typeof(tls_connection_options)}(
+    return SocketBindOptions(
         local_endpoint,
         user_data,
         event_loop,

--- a/src/io/socket_channel_handler.jl
+++ b/src/io/socket_channel_handler.jl
@@ -7,9 +7,9 @@
 # It receives write messages and sends them out the socket (write direction)
 
 # Socket channel handler structure
-mutable struct SocketChannelHandler{S, SlotRef <: Union{ChannelSlot, Nothing}} <: AbstractChannelHandler
-    socket::S
-    slot::SlotRef
+mutable struct SocketChannelHandler <: AbstractChannelHandler
+    socket::Socket
+    slot::Union{ChannelSlot, Nothing}
     max_rw_size::Csize_t
     read_task_storage::ChannelTask
     shutdown_task_storage::ChannelTask
@@ -20,12 +20,12 @@ mutable struct SocketChannelHandler{S, SlotRef <: Union{ChannelSlot, Nothing}} <
 end
 
 function SocketChannelHandler(
-        socket::S;
+        socket::Socket;
         max_read_size::Integer = 16384,
-    ) where {S}
+    )
     stats = SocketHandlerStatistics()
     crt_statistics_socket_init!(stats)
-    return SocketChannelHandler{S, Union{ChannelSlot, Nothing}}(
+    return SocketChannelHandler(
         socket,
         nothing,
         Csize_t(max_read_size),

--- a/src/io/tls/s2n_tls_handler.jl
+++ b/src/io/tls/s2n_tls_handler.jl
@@ -268,8 +268,8 @@ end
 
 S2nTlsCtx() = S2nTlsCtx(C_NULL, C_NULL, nothing)
 
-mutable struct S2nTlsHandler{SlotRef <: Union{ChannelSlot, Nothing}} <: TlsChannelHandler
-    slot::SlotRef
+mutable struct S2nTlsHandler <: TlsChannelHandler
+    slot::Union{ChannelSlot, Nothing}
     tls_timeout_ms::UInt32
     stats::TlsHandlerStatistics
     timeout_task::ChannelTask
@@ -1361,7 +1361,7 @@ function _s2n_handler_new(
     s2n_ctx = ctx.impl isa S2nTlsCtx ? ctx.impl : nothing
     s2n_ctx === nothing && return ErrorResult(raise_error(ERROR_IO_TLS_CTX_ERROR))
 
-    handler = S2nTlsHandler{Union{ChannelSlot, Nothing}}(
+    handler = S2nTlsHandler(
         slot,
         options.timeout_ms,
         TlsHandlerStatistics(),

--- a/src/io/tls/secure_transport_tls_handler.jl
+++ b/src/io/tls/secure_transport_tls_handler.jl
@@ -98,8 +98,8 @@ mutable struct SecureTransportCtx
     secitem_identity::Ptr{Cvoid}
 end
 
-mutable struct SecureTransportTlsHandler{SlotRef <: Union{ChannelSlot, Nothing}} <: TlsChannelHandler
-    slot::SlotRef
+mutable struct SecureTransportTlsHandler <: TlsChannelHandler
+    slot::Union{ChannelSlot, Nothing}
     tls_timeout_ms::UInt32
     stats::TlsHandlerStatistics
     timeout_task::ChannelTask
@@ -1049,7 +1049,7 @@ function _secure_transport_handler_new(
     st_ctx = ctx.impl isa SecureTransportCtx ? ctx.impl : nothing
     st_ctx === nothing && return ErrorResult(raise_error(ERROR_IO_TLS_CTX_ERROR))
 
-    handler = SecureTransportTlsHandler{Union{ChannelSlot, Nothing}}(
+    handler = SecureTransportTlsHandler(
         slot,
         options.timeout_ms,
         TlsHandlerStatistics(),

--- a/test/channel_bootstrap_tests.jl
+++ b/test/channel_bootstrap_tests.jl
@@ -35,7 +35,7 @@ end
 
 @testset "client/server bootstrap callbacks" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
 
     server_setup_called = Ref(false)
     server_setup_error = Ref{Int}(-1)
@@ -147,7 +147,7 @@ end
 
 @testset "client bootstrap attempts multiple resolved addresses" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
     cfg = _bootstrap_test_config()
 
     server_setup_called = Ref(false)
@@ -245,7 +245,7 @@ end
 
 @testset "client bootstrap requested event loop mismatch" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
     client_bootstrap = Reseau.ClientBootstrap(Reseau.ClientBootstrapOptions(
         event_loop_group = elg,
         host_resolver = resolver,
@@ -272,7 +272,7 @@ end
 
 @testset "client bootstrap on_setup runs on requested event loop" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
     client_bootstrap = Reseau.ClientBootstrap(Reseau.ClientBootstrapOptions(
         event_loop_group = elg,
         host_resolver = resolver,
@@ -316,7 +316,7 @@ end
 if tls_tests_enabled()
 @testset "bootstrap tls negotiation" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
 
     cert_path = joinpath(dirname(@__DIR__), "aws-c-io", "tests", "resources", "unittests.crt")
     key_path = joinpath(dirname(@__DIR__), "aws-c-io", "tests", "resources", "unittests.key")
@@ -419,7 +419,7 @@ end
 
 @testset "server bootstrap destroy callback waits for channels" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
     cfg = _bootstrap_test_config()
 
     destroy_called = Ref(false)
@@ -505,7 +505,7 @@ end
 
 @testset "server bootstrap destroy callback without channels" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
     cfg = _bootstrap_test_config()
 
     destroy_called = Ref(false)

--- a/test/crypto_tests.jl
+++ b/test/crypto_tests.jl
@@ -103,7 +103,7 @@ end
 
 @testset "BYO crypto handler integration" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
 
     incoming_rw_args = ByoCryptoRwArgs(ReentrantLock(), Reseau.ByteBuffer(128), false, nothing)
     outgoing_rw_args = ByoCryptoRwArgs(ReentrantLock(), Reseau.ByteBuffer(128), false, nothing)

--- a/test/host_resolver_tests.jl
+++ b/test/host_resolver_tests.jl
@@ -70,7 +70,7 @@ end
 
 @testset "host resolver ipv6 address variations" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
 
     config = Reseau.HostResolutionConfig(max_ttl_secs = 10)
 
@@ -99,7 +99,7 @@ end
 @testset "host resolver background refresh stress" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
     resolver_config = Reseau.HostResolverConfig(; max_ttl_secs = 2, resolve_frequency_ns = 100_000_000)
-    resolver = Reseau.DefaultHostResolver(elg, resolver_config)
+    resolver = Reseau.HostResolver(elg, resolver_config)
 
     host = "refresh.example"
     addr1_ipv4 = Reseau.HostAddress("address1ipv4", Reseau.HostAddressType.A, host, 0)
@@ -137,7 +137,7 @@ end
 
 @testset "host resolver literal address lookups" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
     config = Reseau.HostResolutionConfig(max_ttl_secs = 10)
 
     result_v4 = resolve_and_wait(resolver, "127.0.0.1"; config = config)
@@ -171,7 +171,7 @@ end
 if get(ENV, "RESEAU_RUN_NETWORK_TESTS", "0") == "1"
     @testset "host resolver default dns lookups (network)" begin
         elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-        resolver = Reseau.DefaultHostResolver(elg)
+        resolver = Reseau.HostResolver(elg)
         config = Reseau.HostResolutionConfig(max_ttl_secs = 10)
 
         @testset "ipv6 dualstack lookup" begin
@@ -204,7 +204,7 @@ end
     clock_fn = () -> clock_ref[]
 
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(
+    resolver = Reseau.HostResolver(
         elg,
         Reseau.HostResolverConfig(; max_entries = 10, clock_override = clock_fn),
     )
@@ -281,7 +281,7 @@ end
 
 @testset "host resolver connection failure handling" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
 
     host = "host_address"
     addr1_ipv4 = Reseau.HostAddress("address1ipv4", Reseau.HostAddressType.A, host, 0)
@@ -350,7 +350,7 @@ end
     clock_fn = () -> clock_ref[]
 
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(
+    resolver = Reseau.HostResolver(
         elg,
         Reseau.HostResolverConfig(; max_entries = 10, clock_override = clock_fn),
     )
@@ -410,7 +410,7 @@ end
     clock_fn = () -> clock_ref[]
 
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(
+    resolver = Reseau.HostResolver(
         elg,
         Reseau.HostResolverConfig(; max_entries = 10, clock_override = clock_fn),
     )
@@ -471,7 +471,7 @@ end
 
 @testset "host resolver low frequency starvation" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
 
     host = "host_address"
     addr1_ipv4 = Reseau.HostAddress("address1ipv4", Reseau.HostAddressType.A, host, 0)
@@ -511,7 +511,7 @@ end
 
 @testset "host resolver cached results" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
 
     resolve_calls = Ref(0)
     impl = (host, data) -> begin
@@ -549,7 +549,7 @@ end
 
 @testset "host resolver purge and count" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
 
     resolved = Ref(false)
     addrs = Ref{Vector{Reseau.HostAddress}}(Reseau.HostAddress[])
@@ -619,7 +619,7 @@ end
 
 @testset "host resolver record failure moves address" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
 
     resolved = Ref(false)
     addrs = Ref{Vector{Reseau.HostAddress}}(Reseau.HostAddress[])

--- a/test/pkcs11_tests.jl
+++ b/test/pkcs11_tests.jl
@@ -1076,7 +1076,7 @@ end
             @test pkcs11_reload_hsm!(tester) isa Reseau.Pkcs11Lib
 
             elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-            resolver = Reseau.DefaultHostResolver(elg)
+            resolver = Reseau.HostResolver(elg)
 
             server_tls_opts = Reseau.tls_ctx_options_init_default_server_from_path(cert_path, key_path)
             maybe_apply_test_keychain!(server_tls_opts)
@@ -1192,7 +1192,7 @@ end
             @test pkcs11_reload_hsm!(tester) isa Reseau.Pkcs11Lib
 
             elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-            resolver = Reseau.DefaultHostResolver(elg)
+            resolver = Reseau.HostResolver(elg)
 
             server_tls_opts = Reseau.tls_ctx_options_init_default_server_from_path(cert_path, key_path)
             maybe_apply_test_keychain!(server_tls_opts)

--- a/test/tls_tests_impl.jl
+++ b/test/tls_tests_impl.jl
@@ -145,7 +145,7 @@ function _tls_network_connect(
         ctx_options_override::Union{Function, Nothing} = nothing,
     )
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
 
     ctx_opts = Reseau.tls_ctx_options_init_default_client()
     if ctx_options_override !== nothing
@@ -1814,7 +1814,7 @@ end
 
 function _tls_local_handshake_with_min_version(min_version::Reseau.TlsVersion.T)
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
 
     server_opts = Reseau.tls_ctx_options_init_default_server(
         Reseau.ByteCursor(TEST_PEM_CERT),
@@ -1967,7 +1967,7 @@ end
 
 @testset "TLS server multiple connections" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
 
     server_opts = Reseau.tls_ctx_options_init_default_server(
         Reseau.ByteCursor(TEST_PEM_CERT),
@@ -2099,7 +2099,7 @@ end
 
 @testset "TLS server hangup during negotiation" begin
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
 
     server_opts = Reseau.tls_ctx_options_init_default_server(
         Reseau.ByteCursor(TEST_PEM_CERT),
@@ -2187,7 +2187,7 @@ end
     end
 
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
 
     server_opts = if Sys.isapple()
         Reseau.tls_ctx_options_init_server_pkcs12_from_path(_resource_path("unittests.p12"), "1234")
@@ -2365,7 +2365,7 @@ end
     Reseau.g_aws_channel_max_fragment_size[] = 4096
 
     elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-    resolver = Reseau.DefaultHostResolver(elg)
+    resolver = Reseau.HostResolver(elg)
 
     server_ctx = _test_server_ctx()
     client_ctx = Reseau.tls_context_new_client(; verify_peer = false)
@@ -2511,7 +2511,7 @@ end
         Reseau.g_aws_channel_max_fragment_size[] = 4096
 
         elg = Reseau.EventLoopGroup(Reseau.EventLoopGroupOptions(; loop_count = 1))
-        resolver = Reseau.DefaultHostResolver(elg)
+        resolver = Reseau.HostResolver(elg)
 
         server_ctx = _test_server_ctx()
         client_ctx = Reseau.tls_context_new_client(; verify_peer = false)


### PR DESCRIPTION
This refactors several internal types to reduce unnecessary type parameters and abstract-field usage.

Changes:
- Drop TLS options type params in bootstrap/socket option structs (store as `Any`; treated as `TlsConnectionOptions` or `nothing`).
- Rename `DefaultHostResolver` -> `HostResolver` and remove the abstract resolver type.
- De-parameterize `EventLoopLocalObject`, `ScheduledTask`/`TaskFn`, pipe read-end user_data, and epoll/kqueue handle-data.
- Simplify Channel/ChannelSlot cycle by removing `AbstractChannel` and making slot->channel backrefs `Any`; add `slot_channel(slot)::Channel` helper.

Local testing:
- `Reseau`: `Pkg.test` (default suite, no TLS/network).
- Downstream: `AwsHTTP` and `HTTP` test suites (both pass with `Reseau` as a path dependency).
