### PR TITLE
Refactor: stable id tokens for event loop registries

### DIFF
--- a/src/eventloops/io.jl
+++ b/src/eventloops/io.jl
@@ -214,7 +214,7 @@ mutable struct IoHandle
     additional_data::Ptr{Cvoid}
     # set_queue callback - for Apple Network Framework
     set_queue::Ptr{Cvoid}
-    # Keep Julia-side handle data alive when additional_data stores pointer_from_objref
+    # Keep Julia-side handle data alive while the backend stores an opaque token in `additional_data`.
     additional_ref::Any
 end
 

--- a/src/eventloops/kqueue_event_loop_types.jl
+++ b/src/eventloops/kqueue_event_loop_types.jl
@@ -84,7 +84,7 @@
         state::HandleState.T
         subscribe_task::Union{Nothing, ScheduledTask}  # nullable
         cleanup_task::Union{Nothing, ScheduledTask}  # nullable
-        registry_key::Ptr{Cvoid}
+        registry_id::UInt64
     end
 
     function KqueueHandleData(
@@ -104,7 +104,7 @@
             HandleState.SUBSCRIBING,
             nothing,
             nothing,
-            C_NULL,
+            UInt64(0),
         )
     end
 
@@ -152,7 +152,9 @@
         cross_thread_data::KqueueCrossThreadData
         thread_data::KqueueThreadData
         thread_options::ThreadOptions
-        handle_registry::Dict{Ptr{Cvoid}, Any}
+        handle_registry_lock::ReentrantLock
+        next_handle_id::UInt64
+        handle_registry::Dict{UInt64, KqueueHandleData}
         nw_queue::Ptr{Cvoid}  # dispatch_queue_t for Apple NW sockets
     end
 
@@ -168,7 +170,9 @@
             KqueueCrossThreadData(),
             KqueueThreadData(),
             ThreadOptions(),
-            Dict{Ptr{Cvoid}, Any}(),
+            ReentrantLock(),
+            UInt64(1),
+            Dict{UInt64, KqueueHandleData}(),
             C_NULL,
         )
     end

--- a/src/sockets/io/apple_nw_socket_types.jl
+++ b/src/sockets/io/apple_nw_socket_types.jl
@@ -144,5 +144,8 @@
         socket::NWSocket
         written_fn::Union{Function, Nothing}
         user_data::Any
+        registry_key::Ptr{Cvoid}
     end
+
+    NWSendContext(socket::NWSocket, written_fn, user_data) = NWSendContext(socket, written_fn, user_data, C_NULL)
 end

--- a/test/event_loop_tests.jl
+++ b/test/event_loop_tests.jl
@@ -1698,8 +1698,7 @@ end
                     fetched_value = Ref{Any}(nothing)
                     removed_value = Ref{Any}(nothing)
 
-                    key_obj = Ref(0)
-                    key = pointer_from_objref(key_obj)
+                    key = Ref(0)
 
                     ctx = (
                         el = el,


### PR DESCRIPTION
This replaces `pointer_from_objref` usage in the event-loop and Apple NW socket registries with stable, monotonic `UInt64` ids.

Key changes:
- kqueue/epoll: use `UInt64` ids (stored in `udata`/epoll data) instead of raw Julia object pointers
- Avoid `unsafe_pointer_to_objref` in these paths; keep Julia objects alive via registries/refs
- Apple NW sockets: switch socket + send registries to id-based keys; use `objectid` only as a logging fallback
- Tests: remove `pointer_from_objref` usage

Test status (local):
- Reseau: `Pkg.test` passed
- AwsHTTP: `Pkg.test` passed
- HTTP: `Pkg.test` passed
