### PR TITLE
refactor(logging): enforce single-message logf API

### DIFF
--- a/src/common/log_formatter.jl
+++ b/src/common/log_formatter.jl
@@ -1,4 +1,3 @@
-using Printf
 import Dates
 
 abstract type AbstractLogFormatter end
@@ -31,11 +30,6 @@ const _LOG_LEVEL_LABELS = (
     return 1 <= idx <= length(_LOG_LEVEL_LABELS) ? _LOG_LEVEL_LABELS[idx] : "UNKNOWN"
 end
 
-@inline function _format_user_content(fmt::AbstractString, args::Tuple)
-    isempty(args) && return fmt
-    return Printf.format(Printf.Format(fmt), args...)
-end
-
 const _TS_FMT_ISO_8601_UTC = Dates.DateFormat("yyyy-mm-dd\\THH:MM:SS")
 const _TS_FMT_ISO_8601_BASIC_UTC = Dates.DateFormat("yyyymmdd\\THHMMSS")
 
@@ -51,12 +45,11 @@ function _timestamp_string(fmt::date_format)
     end
 end
 
-function format_line(formatter::StandardLogFormatter, level::LogLevel.T, subject::LogSubject, fmt::AbstractString, args...)
-    user_content = _format_user_content(fmt, args)
+function format_line(formatter::StandardLogFormatter, level::LogLevel.T, subject::LogSubject, msg::AbstractString)
     timestamp = _timestamp_string(formatter.date_format)
     level_str = _log_level_label(level)
     subject_name = log_subject_name(subject)
     subject_segment = subject_name == "" ? "" : string("[", subject_name, "] ")
     thread_id = string(Threads.threadid())
-    return string("[", level_str, "] [", timestamp, "] [", thread_id, "] ", subject_segment, "- ", user_content, "\n")
+    return string("[", level_str, "] [", timestamp, "] [", thread_id, "] ", subject_segment, "- ", msg, "\n")
 end

--- a/src/common/unused/cross_process_lock.jl
+++ b/src/common/unused/cross_process_lock.jl
@@ -34,10 +34,7 @@ end
         if byte_cursor_find_exact(Ref(instance_nonce), Ref(to_find), found) == OP_SUCCESS
             logf(
                 Cint(LL_ERROR),
-                LS_COMMON_GENERAL,
-                "static: Lock %s creation has illegal character \\",
-                _nonce_string(instance_nonce),
-            )
+                LS_COMMON_GENERAL,string("static: Lock %s creation has illegal character \\", " ", string(_nonce_string(instance_nonce)), " ", ))
             raise_error(ERROR_INVALID_ARGUMENT)
             return Ptr{cross_process_lock}(C_NULL)
         end
@@ -53,11 +50,7 @@ end
             last_error = ccall((:GetLastError, "kernel32"), UInt32, ())
             logf(
                 Cint(LL_WARN),
-                LS_COMMON_GENERAL,
-                "static: Lock %s creation failed with error %d",
-                unsafe_string(pointer(nonce_buf[].mem)),
-                last_error,
-            )
+                LS_COMMON_GENERAL,string("static: Lock %s creation failed with error %d", " ", string(unsafe_string(pointer(nonce_buf[].mem))), " ", string(last_error), " ", ))
             translate_and_raise_io_error_or(last_error, ERROR_MUTEX_FAILED)
             byte_buf_clean_up(nonce_buf)
             return Ptr{cross_process_lock}(C_NULL)
@@ -66,10 +59,7 @@ end
         if ccall((:GetLastError, "kernel32"), UInt32, ()) == _ERROR_ALREADY_EXISTS
             logf(
                 Cint(LL_TRACE),
-                LS_COMMON_GENERAL,
-                "static: Lock %s is already acquired by another instance",
-                unsafe_string(pointer(nonce_buf[].mem)),
-            )
+                LS_COMMON_GENERAL,string("static: Lock %s is already acquired by another instance", " ", string(unsafe_string(pointer(nonce_buf[].mem))), " ", ))
             ccall((:CloseHandle, "kernel32"), UInt8, (Ptr{Cvoid},), mutex)
             raise_error(ERROR_MUTEX_CALLER_NOT_OWNER)
             byte_buf_clean_up(nonce_buf)
@@ -86,11 +76,7 @@ end
         unsafe_store!(instance_lock, cross_process_lock(mutex))
         logf(
             Cint(LL_TRACE),
-            LS_COMMON_GENERAL,
-            "static: Lock %s acquired by this instance with HANDLE %p",
-            unsafe_string(pointer(nonce_buf[].mem)),
-            mutex,
-        )
+            LS_COMMON_GENERAL,string("static: Lock %s acquired by this instance with HANDLE %p", " ", string(unsafe_string(pointer(nonce_buf[].mem))), " ", string(mutex), " ", ))
 
         byte_buf_clean_up(nonce_buf)
         return instance_lock
@@ -103,10 +89,7 @@ end
         ccall((:CloseHandle, "kernel32"), UInt8, (Ptr{Cvoid},), unsafe_load(instance_lock).mutex)
         logf(
             Cint(LL_TRACE),
-            LS_COMMON_GENERAL,
-            "static: Lock released for handle %p",
-            unsafe_load(instance_lock).mutex,
-        )
+            LS_COMMON_GENERAL,string("static: Lock released for handle %p", " ", string(unsafe_load(instance_lock).mutex), " ", ))
         _cpl_free(Ptr{UInt8}(instance_lock))
         return nothing
     end
@@ -137,10 +120,7 @@ else
         if byte_cursor_find_exact(Ref(instance_nonce), Ref(to_find), found) == OP_SUCCESS
             logf(
                 Cint(LL_ERROR),
-                LS_COMMON_GENERAL,
-                "static: Lock %s creation has illegal character /",
-                _nonce_string(instance_nonce),
-            )
+                LS_COMMON_GENERAL,string("static: Lock %s creation has illegal character /", " ", string(_nonce_string(instance_nonce)), " ", ))
             raise_error(ERROR_INVALID_ARGUMENT)
             return Ptr{cross_process_lock}(C_NULL)
         end
@@ -181,11 +161,7 @@ else
         if fd < 0
             logf(
                 Cint(LL_DEBUG),
-                LS_COMMON_GENERAL,
-                "static: Lock file %s failed to open with errno %d",
-                unsafe_string(pointer(nonce_buf[].mem)),
-                err,
-            )
+                LS_COMMON_GENERAL,string("static: Lock file %s failed to open with errno %d", " ", string(unsafe_string(pointer(nonce_buf[].mem))), " ", string(err), " ", ))
             translate_and_raise_io_error_or(err, ERROR_MUTEX_FAILED)
             if last_error() == ERROR_NO_PERMISSION
                 if ccall(:chmod, Cint, (Ptr{UInt8}, Cint), pointer(nonce_buf[].mem), mode) == 0
@@ -194,21 +170,14 @@ else
                 if fd < 0
                     logf(
                         Cint(LL_DEBUG),
-                        LS_COMMON_GENERAL,
-                        "static: Lock file %s couldn't be opened due to file ownership permissions. Attempting to open as read only",
-                        unsafe_string(pointer(nonce_buf[].mem)),
-                    )
+                        LS_COMMON_GENERAL,string("static: Lock file %s couldn't be opened due to file ownership permissions. Attempting to open as read only", " ", string(unsafe_string(pointer(nonce_buf[].mem))), " ", ))
                     fd = ccall(:open, Cint, (Ptr{UInt8}, Cint), pointer(nonce_buf[].mem), _O_RDONLY)
                 end
                 if fd < 0
                     err = Libc.errno()
                     logf(
                         Cint(LL_ERROR),
-                        LS_COMMON_GENERAL,
-                        "static: Lock file %s failed to open with read-only permissions with errno %d",
-                        unsafe_string(pointer(nonce_buf[].mem)),
-                        err,
-                    )
+                        LS_COMMON_GENERAL,string("static: Lock file %s failed to open with read-only permissions with errno %d", " ", string(unsafe_string(pointer(nonce_buf[].mem))), " ", string(err), " ", ))
                     translate_and_raise_io_error_or(err, ERROR_MUTEX_FAILED)
                     byte_buf_clean_up(nonce_buf)
                     return Ptr{cross_process_lock}(C_NULL)
@@ -216,10 +185,7 @@ else
             else
                 logf(
                     Cint(LL_ERROR),
-                    LS_COMMON_GENERAL,
-                    "static: Lock file %s failed to open. The lock cannot be acquired.",
-                    unsafe_string(pointer(nonce_buf[].mem)),
-                )
+                    LS_COMMON_GENERAL,string("static: Lock file %s failed to open. The lock cannot be acquired.", " ", string(unsafe_string(pointer(nonce_buf[].mem))), " ", ))
                 byte_buf_clean_up(nonce_buf)
                 return Ptr{cross_process_lock}(C_NULL)
             end
@@ -231,10 +197,7 @@ else
         if ccall(:flock, Cint, (Cint, Cint), fd, _LOCK_EX | _LOCK_NB) == -1
             logf(
                 Cint(LL_TRACE),
-                LS_COMMON_GENERAL,
-                "static: Lock file %s already acquired by another instance",
-                unsafe_string(pointer(nonce_buf[].mem)),
-            )
+                LS_COMMON_GENERAL,string("static: Lock file %s already acquired by another instance", " ", string(unsafe_string(pointer(nonce_buf[].mem))), " ", ))
             ccall(:close, Cint, (Cint,), fd)
             raise_error(ERROR_MUTEX_CALLER_NOT_OWNER)
             byte_buf_clean_up(nonce_buf)
@@ -251,11 +214,7 @@ else
         unsafe_store!(instance_lock, cross_process_lock(fd))
         logf(
             Cint(LL_TRACE),
-            LS_COMMON_GENERAL,
-            "static: Lock file %s acquired by this instance with fd %d",
-            unsafe_string(pointer(nonce_buf[].mem)),
-            fd,
-        )
+            LS_COMMON_GENERAL,string("static: Lock file %s acquired by this instance with fd %d", " ", string(unsafe_string(pointer(nonce_buf[].mem))), " ", string(fd), " ", ))
 
         byte_buf_clean_up(nonce_buf)
         return instance_lock
@@ -268,10 +227,7 @@ else
         ccall(:close, Cint, (Cint,), unsafe_load(instance_lock).locked_fd)
         logf(
             Cint(LL_TRACE),
-            LS_COMMON_GENERAL,
-            "static: Lock file released for fd %d",
-            unsafe_load(instance_lock).locked_fd,
-        )
+            LS_COMMON_GENERAL,string("static: Lock file released for fd %d", " ", string(unsafe_load(instance_lock).locked_fd), " ", ))
         _cpl_free(Ptr{UInt8}(instance_lock))
         return nothing
     end

--- a/src/eventloops/epoll_event_loop.jl
+++ b/src/eventloops/epoll_event_loop.jl
@@ -103,7 +103,7 @@
             impl.use_eventfd = true
             impl.write_task_handle = IoHandle(eventfd_result)
             impl.read_task_handle = IoHandle(eventfd_result)  # Same fd for eventfd
-            logf(LogLevel.TRACE, LS_IO_EVENT_LOOP, "eventfd descriptor %d", eventfd_result)
+            logf(LogLevel.TRACE, LS_IO_EVENT_LOOP,string("eventfd descriptor %d", " ", eventfd_result))
         else
             logf(LogLevel.DEBUG, LS_IO_EVENT_LOOP, "Eventfd not available, falling back to pipe")
             impl.use_eventfd = false
@@ -117,11 +117,7 @@
 
             logf(
                 LogLevel.TRACE,
-                LS_IO_EVENT_LOOP,
-                "pipe descriptors read %d, write %d",
-                pipe_result[READ_FD],
-                pipe_result[WRITE_FD],
-            )
+                LS_IO_EVENT_LOOP,string("pipe descriptors read %d, write %d", " ", pipe_result[READ_FD], " ", pipe_result[WRITE_FD], " ", ))
             impl.read_task_handle = IoHandle(pipe_result[READ_FD])
             impl.write_task_handle = IoHandle(pipe_result[WRITE_FD])
         end
@@ -239,11 +235,7 @@
 
         logf(
             LogLevel.TRACE,
-            LS_IO_EVENT_LOOP,
-            "Scheduling %s task cross-thread for timestamp %d",
-            task.type_tag,
-            run_at_nanos,
-        )
+            LS_IO_EVENT_LOOP,string("Scheduling %s task cross-thread for timestamp %d", " ", task.type_tag, " ", run_at_nanos, " ", ))
 
         task.timestamp = run_at_nanos
         task.scheduled = true
@@ -274,11 +266,7 @@
         if event_loop_thread_is_callers_thread(event_loop)
             logf(
                 LogLevel.TRACE,
-                LS_IO_EVENT_LOOP,
-                "scheduling %s task in-thread for timestamp %d",
-                task.type_tag,
-                run_at_nanos,
-            )
+                LS_IO_EVENT_LOOP,string("scheduling %s task in-thread for timestamp %d", " ", task.type_tag, " ", run_at_nanos, " ", ))
             if run_at_nanos == 0
                 task_scheduler_schedule_now!(impl.scheduler, task)
             else
@@ -311,7 +299,7 @@
     function event_loop_cancel_task!(event_loop::EventLoop, task::ScheduledTask)
         debug_assert(event_loop_thread_is_callers_thread(event_loop))
         impl = event_loop.impl_data
-        logf(LogLevel.TRACE, LS_IO_EVENT_LOOP, "cancelling %s task", task.type_tag)
+        logf(LogLevel.TRACE, LS_IO_EVENT_LOOP,string("cancelling %s task", " ", task.type_tag))
         if !task.scheduled
             return nothing
         end
@@ -349,7 +337,7 @@
             events::Int,
             on_event::EventCallable,
         )::Nothing
-        logf(LogLevel.TRACE, LS_IO_EVENT_LOOP, "subscribing to events on fd %d", handle.fd)
+        logf(LogLevel.TRACE, LS_IO_EVENT_LOOP,string("subscribing to events on fd %d", " ", handle.fd))
 
         epoll_event_data = EpollEventHandleData(handle, on_event)
 
@@ -382,7 +370,7 @@
         )::Cint
 
         if ret != 0
-            logf(LogLevel.ERROR, LS_IO_EVENT_LOOP, "failed to subscribe to events on fd %d", handle.fd)
+            logf(LogLevel.ERROR, LS_IO_EVENT_LOOP,string("failed to subscribe to events on fd %d", " ", handle.fd))
             handle.additional_data = C_NULL
             handle.additional_ref = nothing
             throw_error(ERROR_SYS_CALL_FAILURE)
@@ -409,7 +397,7 @@
         if (@atomic event_loop.running) && !event_loop_thread_is_callers_thread(event_loop)
             throw_error(ERROR_IO_EVENT_LOOP_THREAD_ONLY)
         end
-        logf(LogLevel.TRACE, LS_IO_EVENT_LOOP, "un-subscribing from events on fd %d", handle.fd)
+        logf(LogLevel.TRACE, LS_IO_EVENT_LOOP,string("un-subscribing from events on fd %d", " ", handle.fd))
 
         impl = event_loop.impl_data
 
@@ -431,7 +419,7 @@
         )::Cint
 
         if ret != 0
-            logf(LogLevel.ERROR, LS_IO_EVENT_LOOP, "failed to un-subscribe from events on fd %d", handle.fd)
+            logf(LogLevel.ERROR, LS_IO_EVENT_LOOP,string("failed to un-subscribe from events on fd %d", " ", handle.fd))
             throw_error(ERROR_SYS_CALL_FAILURE)
         end
 
@@ -506,10 +494,7 @@
             task === nothing && break
             logf(
                 LogLevel.TRACE,
-                LS_IO_EVENT_LOOP,
-                "task %s pulled to event-loop, scheduling now",
-                task.type_tag,
-            )
+                LS_IO_EVENT_LOOP,string("task %s pulled to event-loop, scheduling now", " ", task.type_tag, " ", ))
             if task.timestamp == 0
                 task_scheduler_schedule_now!(impl.scheduler, task)
             else
@@ -553,14 +538,10 @@
 
         logf(
             LogLevel.INFO,
-            LS_IO_EVENT_LOOP,
-            "default timeout %d ms, and max events to process per tick %d",
-            timeout,
-            MAX_EVENTS,
-        )
+            LS_IO_EVENT_LOOP,string("default timeout %d ms, and max events to process per tick %d", " ", timeout, " ", MAX_EVENTS, " ", ))
 
         while impl.should_continue
-            logf(LogLevel.TRACE, LS_IO_EVENT_LOOP, "waiting for a maximum of %d ms", timeout)
+            logf(LogLevel.TRACE, LS_IO_EVENT_LOOP,string("waiting for a maximum of %d ms", " ", timeout))
 
             # Call epoll_wait
             event_count = @ccall gc_safe = true epoll_wait(
@@ -572,7 +553,7 @@
 
             event_loop_register_tick_start!(event_loop)
 
-            logf(LogLevel.TRACE, LS_IO_EVENT_LOOP, "wake up with %d events to process", event_count)
+            logf(LogLevel.TRACE, LS_IO_EVENT_LOOP,string("wake up with %d events to process", " ", event_count))
 
             # Process events
             if event_count > 0
@@ -616,10 +597,7 @@
                     if event_data.is_subscribed
                         logf(
                             LogLevel.TRACE,
-                            LS_IO_EVENT_LOOP,
-                            "activity on fd %d, invoking handler",
-                            event_data.handle.fd,
-                        )
+                            LS_IO_EVENT_LOOP,string("activity on fd %d, invoking handler", " ", event_data.handle.fd, " ", ))
                         try
                             event_data.on_event(event_mask)
                         catch e
@@ -629,11 +607,7 @@
                                      e.code == ERROR_IO_READ_WOULD_BLOCK)
                                 logf(
                                     LogLevel.DEBUG,
-                                    LS_IO_EVENT_LOOP,
-                                    "ignoring non-fatal IO callback error on fd %d: %d",
-                                    event_data.handle.fd,
-                                    e.code,
-                                )
+                                    LS_IO_EVENT_LOOP,string("ignoring non-fatal IO callback error on fd %d: %d", " ", event_data.handle.fd, " ", e.code, " ", ))
                             else
                                 rethrow()
                             end
@@ -693,11 +667,7 @@
 
                 logf(
                     LogLevel.TRACE,
-                    LS_IO_EVENT_LOOP,
-                    "detected more scheduled tasks with the next occurring at %d ns, using timeout of %d ms",
-                    timeout_ns,
-                    timeout_ms,
-                )
+                    LS_IO_EVENT_LOOP,string("detected more scheduled tasks with the next occurring at %d ns, using timeout of %d ms", " ", timeout_ns, " ", timeout_ms, " ", ))
                 timeout = Cint(timeout_ms)
             end
 

--- a/src/eventloops/event_loop.jl
+++ b/src/eventloops/event_loop.jl
@@ -366,10 +366,7 @@ function event_loop_group_release!(elg::EventLoopGroup)
     elseif new_count < 0
         logf(
             LogLevel.ERROR,
-            LS_IO_EVENT_LOOP,
-            "Event loop group ref_count underflow (ref_count=%d)",
-            new_count,
-        )
+            LS_IO_EVENT_LOOP,string("Event loop group ref_count underflow (ref_count=%d)", " ", new_count, " ", ))
         return nothing
     end
 

--- a/src/eventloops/iocp_event_loop.jl
+++ b/src/eventloops/iocp_event_loop.jl
@@ -206,10 +206,7 @@
         if !ok
             logf(
                 LogLevel.ERROR,
-                LS_IO_EVENT_LOOP,
-                "PostQueuedCompletionStatus() failed with error %d",
-                _win_get_last_error(),
-            )
+                LS_IO_EVENT_LOOP,string("PostQueuedCompletionStatus() failed with error %d", " ", _win_get_last_error(), " ", ))
         end
         return nothing
     end
@@ -229,10 +226,7 @@
         if iocp_handle == C_NULL
             logf(
                 LogLevel.FATAL,
-                LS_IO_EVENT_LOOP,
-                "CreateIoCompletionPort() failed with error %d",
-                _win_get_last_error(),
-            )
+                LS_IO_EVENT_LOOP,string("CreateIoCompletionPort() failed with error %d", " ", _win_get_last_error(), " ", ))
             throw_error(ERROR_SYS_CALL_FAILURE)
         end
         impl.iocp_handle = iocp_handle
@@ -595,10 +589,7 @@
         if !associated
             logf(
                 LogLevel.ERROR,
-                LS_IO_EVENT_LOOP,
-                "CreateIoCompletionPort() failed with error %d",
-                _win_get_last_error(),
-            )
+                LS_IO_EVENT_LOOP,string("CreateIoCompletionPort() failed with error %d", " ", _win_get_last_error(), " ", ))
             throw_error(ERROR_SYS_CALL_FAILURE)
         end
 

--- a/src/sockets/io/alpn_handler.jl
+++ b/src/sockets/io/alpn_handler.jl
@@ -46,11 +46,7 @@ function handler_process_read_message(handler::AlpnHandler, slot::ChannelSlot, m
     chan_id = chan === nothing ? -1 : chan.channel_id
     logf(
         LogLevel.DEBUG,
-        LS_IO_ALPN,
-        "ALPN negotiated protocol: %s (channel %d)",
-        isempty(protocol_str) ? "<empty>" : protocol_str,
-        chan_id,
-    )
+        LS_IO_ALPN,string("ALPN negotiated protocol: %s (channel %d)", " ", string(isempty(protocol_str) ? "<empty>" : protocol_str), " ", string(chan_id), " ", ))
 
     channel = slot.channel
     if channel === nothing

--- a/src/sockets/io/apple_nw_socket_impl.jl
+++ b/src/sockets/io/apple_nw_socket_impl.jl
@@ -126,7 +126,7 @@
         nw_socket = socket.impl::NWSocket
         nw_socket.event_loop !== nothing && throw_error(ERROR_INVALID_STATE)
         if event_loop_group_acquire_from_event_loop(event_loop) === nothing
-            logf(LogLevel.ERROR, LS_IO_SOCKET, "nw_socket=%p: failed to acquire event loop group.", _nw_socket_ptr(nw_socket))
+            logf(LogLevel.ERROR, LS_IO_SOCKET,string("nw_socket=%p: failed to acquire event loop group.", " ", _nw_socket_ptr(nw_socket)))
             throw_error(ERROR_INVALID_STATE)
         end
         nw_socket.event_loop = event_loop
@@ -185,12 +185,7 @@
         state_masked = UInt16(state & 0xFFFF)
         logf(
             LogLevel.DEBUG,
-            LS_IO_SOCKET,
-            "nw_socket=%p: set state from %s to %s",
-            _nw_socket_ptr(nw_socket),
-            _nw_state_string(nw_socket.state),
-            _nw_state_string(state_masked),
-        )
+            LS_IO_SOCKET,string("nw_socket=%p: set state from %s to %s", " ", _nw_socket_ptr(nw_socket), " ", _nw_state_string(nw_socket.state), " ", _nw_state_string(state_masked), " ", ))
 
         current = nw_socket.state
         read_write_bits = state_masked & (_nw_state_mask(NWSocketState.CONNECTED_WRITE) | _nw_state_mask(NWSocketState.CONNECTED_READ))
@@ -212,11 +207,7 @@
 
         logf(
             LogLevel.DEBUG,
-            LS_IO_SOCKET,
-            "nw_socket=%p: state now %s",
-            _nw_socket_ptr(nw_socket),
-            _nw_state_string(nw_socket.state),
-        )
+            LS_IO_SOCKET,string("nw_socket=%p: state now %s", " ", _nw_socket_ptr(nw_socket), " ", _nw_state_string(nw_socket.state), " ", ))
         return nothing
     end
 
@@ -381,10 +372,7 @@
         if !transport_ctx.verify_peer
             logf(
                 LogLevel.WARN,
-                LS_IO_TLS,
-                "nw_socket=%p: x.509 validation has been disabled. If this is not running in a test environment, this is likely a security vulnerability.",
-                _nw_socket_ptr(nw_socket),
-            )
+                LS_IO_TLS,string("nw_socket=%p: x.509 validation has been disabled. If this is not running in a test environment, this is likely a security vulnerability.", " ", _nw_socket_ptr(nw_socket), " ", ))
             return true
         end
 
@@ -402,11 +390,7 @@
             if status != 0
                 logf(
                     LogLevel.ERROR,
-                    LS_IO_TLS,
-                    "nw_socket=%p: SecTrustSetAnchorCertificates failed with OSStatus %d",
-                    _nw_socket_ptr(nw_socket),
-                    Int(status),
-                )
+                    LS_IO_TLS,string("nw_socket=%p: SecTrustSetAnchorCertificates failed with OSStatus %d", " ", _nw_socket_ptr(nw_socket), " ", Int(status), " ", ))
                 raise_error(ERROR_IO_TLS_ERROR_NEGOTIATION_FAILURE)
                 ccall((:CFRelease, _COREFOUNDATION_LIB), Cvoid, (CFTypeRef,), trust_ref)
                 return false
@@ -438,7 +422,7 @@
                 policy,
             )
             if status != 0
-                logf(LogLevel.ERROR, LS_IO_TLS, "nw_socket=%p: SecTrustSetPolicies failed %d", _nw_socket_ptr(nw_socket), Int(status))
+                logf(LogLevel.ERROR, LS_IO_TLS,string("nw_socket=%p: SecTrustSetPolicies failed %d", " ", _nw_socket_ptr(nw_socket), " ", Int(status)))
                 raise_error(ERROR_IO_TLS_ERROR_NEGOTIATION_FAILURE)
                 ccall((:CFRelease, _COREFOUNDATION_LIB), Cvoid, (CFTypeRef,), policy)
                 ccall((:CFRelease, _COREFOUNDATION_LIB), Cvoid, (CFTypeRef,), trust_ref)
@@ -475,14 +459,7 @@
             crt_error = _nw_determine_socket_error(err_code)
             logf(
                 LogLevel.DEBUG,
-                LS_IO_TLS,
-                "nw_socket=%p: SecTrustEvaluateWithError failed with crt error %d: %s (CF error %d: %s)",
-                _nw_socket_ptr(nw_socket),
-                crt_error,
-                error_name(crt_error),
-                err_code,
-                err_desc,
-            )
+                LS_IO_TLS,string("nw_socket=%p: SecTrustEvaluateWithError failed with crt error %d: %s (CF error %d: %s)", " ", _nw_socket_ptr(nw_socket), " ", crt_error, " ", error_name(crt_error), " ", err_code, " ", err_desc, " ", ))
         end
 
         policy != C_NULL && ccall((:CFRelease, _COREFOUNDATION_LIB), Cvoid, (CFTypeRef,), policy)
@@ -576,10 +553,7 @@
         if nw_socket.event_loop === nothing
             logf(
                 LogLevel.ERROR,
-                LS_IO_TLS,
-                "nw_socket=%p: TLS verify block requires event loop with dispatch queue",
-                _nw_socket_ptr(nw_socket),
-            )
+                LS_IO_TLS,string("nw_socket=%p: TLS verify block requires event loop with dispatch queue", " ", _nw_socket_ptr(nw_socket), " ", ))
         else
             _nw_ensure_callbacks!()
             dispatch_queue = nw_socket.event_loop.impl_data.dispatch_queue
@@ -1112,12 +1086,7 @@
         if nw_socket.base_socket !== nothing
             logf(
                 LogLevel.TRACE,
-                LS_IO_SOCKET,
-                "NW receive complete: is_complete=%d is_final=%d err=%d",
-                is_complete ? 1 : 0,
-                complete ? 1 : 0,
-                err_code,
-            )
+                LS_IO_SOCKET,string("NW receive complete: is_complete=%d is_final=%d err=%d", " ", is_complete ? 1 : 0, " ", complete ? 1 : 0, " ", err_code, " ", ))
         end
 
         _nw_handle_incoming_data(nw_socket, err_code, data, complete)
@@ -1235,10 +1204,7 @@
         else
             logf(
                 LogLevel.TRACE,
-                LS_IO_SOCKET,
-                "nw_socket=%p: connection ready but no connect callback set",
-                _nw_socket_ptr(nw_socket),
-            )
+                LS_IO_SOCKET,string("nw_socket=%p: connection ready but no connect callback set", " ", _nw_socket_ptr(nw_socket), " ", ))
         end
         return nothing
     end
@@ -1282,12 +1248,7 @@
                     if err_code != 0
                         logf(
                             LogLevel.ERROR,
-                            LS_IO_SOCKET,
-                            "nw_connection error (domain=%d raw=%d mapped=%d)",
-                            Int(raw_domain),
-                            Int(raw_code),
-                            err_code,
-                        )
+                            LS_IO_SOCKET,string("nw_connection error (domain=%d raw=%d mapped=%d)", " ", Int(raw_domain), " ", Int(raw_code), " ", err_code, " ", ))
                         nw_socket.last_error = err_code
                         _nw_lock_synced(nw_socket)
                         _nw_set_socket_state!(nw_socket, Int(_nw_state_mask(NWSocketState.ERROR)))
@@ -1341,12 +1302,7 @@
                     elseif state == 3 # nw_listener_state_failed
                         logf(
                             LogLevel.ERROR,
-                            LS_IO_SOCKET,
-                            "nw_listener failed (domain=%d raw=%d mapped=%d)",
-                            Int(raw_domain),
-                            Int(raw_code),
-                            err_code,
-                        )
+                            LS_IO_SOCKET,string("nw_listener failed (domain=%d raw=%d mapped=%d)", " ", Int(raw_domain), " ", Int(raw_code), " ", err_code, " ", ))
                         _nw_lock_synced(nw_socket)
                         _nw_set_socket_state!(nw_socket, Int(_nw_state_mask(NWSocketState.ERROR)))
                         _nw_unlock_synced(nw_socket)
@@ -1733,17 +1689,11 @@
             nw_socket.on_connection_result = options.on_connection_result
             logf(
                 LogLevel.TRACE,
-                LS_IO_SOCKET,
-                "nw_socket=%p: connect callback set",
-                _nw_socket_ptr(nw_socket),
-            )
+                LS_IO_SOCKET,string("nw_socket=%p: connect callback set", " ", _nw_socket_ptr(nw_socket), " ", ))
         else
             logf(
                 LogLevel.TRACE,
-                LS_IO_SOCKET,
-                "nw_socket=%p: connect callback missing",
-                _nw_socket_ptr(nw_socket),
-            )
+                LS_IO_SOCKET,string("nw_socket=%p: connect callback missing", " ", _nw_socket_ptr(nw_socket), " ", ))
         end
 
         event_loop_connect_to_io_completion_port!(event_loop, socket.io_handle)

--- a/src/sockets/io/channel_bootstrap.jl
+++ b/src/sockets/io/channel_bootstrap.jl
@@ -665,10 +665,7 @@ function _connection_request_invoke_on_setup(
         request.on_setup(error_code)
     catch err
         logf(
-            LogLevel.ERROR, LS_IO_CHANNEL_BOOTSTRAP,
-            "ClientBootstrap: on_setup callback threw: %s",
-            sprint(showerror, err, catch_backtrace()),
-        )
+            LogLevel.ERROR, LS_IO_CHANNEL_BOOTSTRAP,string("ClientBootstrap: on_setup callback threw: %s", " ", string(sprint(showerror, err, catch_backtrace())), " ", ))
     end
     return nothing
 end
@@ -678,11 +675,7 @@ function _connection_request_complete(request::SocketConnectionRequest, error_co
         request.on_shutdown = nothing
     end
     logf(
-        LogLevel.DEBUG, LS_IO_CHANNEL_BOOTSTRAP,
-        "ClientBootstrap: connection request complete error=%d on_setup=%s",
-        error_code,
-        request.on_setup === nothing ? "nothing" : "set",
-    )
+        LogLevel.DEBUG, LS_IO_CHANNEL_BOOTSTRAP,string("ClientBootstrap: connection request complete error=%d on_setup=%s", " ", string(error_code), " ", string(request.on_setup === nothing ? "nothing" : "set"), " ", ))
     if request.on_setup !== nothing
         requested_loop = request.requested_event_loop
         if requested_loop !== nothing && !event_loop_thread_is_callers_thread(requested_loop)
@@ -842,9 +835,7 @@ function ServerBootstrap(options::ServerBootstrapOptions)
         if event_loop === nothing
             logf(
                 LogLevel.ERROR,
-                LS_IO_CHANNEL_BOOTSTRAP,
-                "ServerBootstrap: no event loop available",
-            )
+                LS_IO_CHANNEL_BOOTSTRAP,string("ServerBootstrap: no event loop available", " ", ))
             throw_error(ERROR_IO_SOCKET_MISSING_EVENT_LOOP)
         end
 
@@ -864,10 +855,7 @@ function ServerBootstrap(options::ServerBootstrapOptions)
         err = e isa ReseauError ? e.code : ERROR_UNKNOWN
         logf(
             LogLevel.ERROR,
-            LS_IO_CHANNEL_BOOTSTRAP,
-            "ServerBootstrap: setup failed with error %d",
-            err,
-        )
+            LS_IO_CHANNEL_BOOTSTRAP,string("ServerBootstrap: setup failed with error %d", " ", string(err), " ", ))
         if listener !== nothing
             try
                 socket_close(listener)

--- a/src/sockets/io/host_resolver.jl
+++ b/src/sockets/io/host_resolver.jl
@@ -646,7 +646,7 @@ function _host_resolver_thread(entry::HostEntry)
     catch err
         logf(LogLevel.ERROR, LS_IO_DNS, "Host resolver: thread failed for '$(entry.host_name)': $err")
         bt = catch_backtrace()
-        logf(LogLevel.ERROR, LS_IO_DNS, "%s", sprint(showerror, err, bt))
+        logf(LogLevel.ERROR, LS_IO_DNS,string("%s", " ", string(sprint(showerror, err, bt))))
     end
 
     return nothing

--- a/src/sockets/io/pkcs11.jl
+++ b/src/sockets/io/pkcs11.jl
@@ -431,9 +431,7 @@ function pkcs11_lib_release(lib::Pkcs11Lib)
             if rv != CKR_OK
                 logf(
                     LogLevel.ERROR,
-                    LS_IO_PKCS11,
-                    "PKCS11 finalize failed: $(pkcs11_error_code_str(pkcs11_error_from_ckr(rv)))",
-                )
+                    LS_IO_PKCS11,string("PKCS11 finalize failed: $(pkcs11_error_code_str(pkcs11_error_from_ckr(rv)))", " ", ))
             end
         end
     end
@@ -779,9 +777,7 @@ function pkcs11_lib_find_private_key(
         if key_type != CKK_RSA && key_type != CKK_EC
             logf(
                 LogLevel.ERROR,
-                LS_IO_PKCS11,
-                "PKCS11: Unsupported private key type 0x$(string(UInt64(key_type), base = 16))",
-            )
+                LS_IO_PKCS11,string("PKCS11: Unsupported private key type 0x$(string(UInt64(key_type), base = 16))", " ", ))
             throw_error(ERROR_IO_PKCS11_KEY_TYPE_UNSUPPORTED)
         end
 
@@ -939,9 +935,7 @@ function _pkcs11_sign_rsa(
     if sig_val != TLS_SIGNATURE_RSA
         logf(
             LogLevel.ERROR,
-            LS_IO_PKCS11,
-            "PKCS11: Signature algorithm unsupported for RSA key",
-        )
+            LS_IO_PKCS11,string("PKCS11: Signature algorithm unsupported for RSA key", " ", ))
         throw_error(ERROR_IO_TLS_SIGNATURE_ALGORITHM_UNSUPPORTED)
     end
 
@@ -1024,9 +1018,7 @@ function _pkcs11_sign_ecdsa(
     if sig_val != TLS_SIGNATURE_ECDSA
         logf(
             LogLevel.ERROR,
-            LS_IO_PKCS11,
-            "PKCS11: Signature algorithm unsupported for EC key",
-        )
+            LS_IO_PKCS11,string("PKCS11: Signature algorithm unsupported for EC key", " ", ))
         throw_error(ERROR_IO_TLS_SIGNATURE_ALGORITHM_UNSUPPORTED)
     end
 

--- a/src/sockets/io/posix_socket_impl.jl
+++ b/src/sockets/io/posix_socket_impl.jl
@@ -348,12 +348,7 @@ function set_posix_socket_options!(sock::Socket, options::SocketOptions)::Nothin
     if iface_len >= NETWORK_INTERFACE_NAME_MAX
         logf(
             LogLevel.ERROR,
-            LS_IO_SOCKET,
-            "id=%p fd=%d: network_interface_name max length must be less or equal than %d bytes including NULL terminated",
-            sock,
-            fd,
-            NETWORK_INTERFACE_NAME_MAX,
-        )
+            LS_IO_SOCKET,string("id=%p fd=%d: network_interface_name max length must be less or equal than %d bytes including NULL terminated", " ", string(sock), " ", string(fd), " ", string(NETWORK_INTERFACE_NAME_MAX), " ", ))
         throw_error(ERROR_IO_SOCKET_INVALID_OPTIONS)
     end
 
@@ -380,13 +375,7 @@ function set_posix_socket_options!(sock::Socket, options::SocketOptions)::Nothin
                 iface_name = String(Vector{UInt8}(iface_bytes))
                 logf(
                     LogLevel.ERROR,
-                    LS_IO_SOCKET,
-                    "id=%p fd=%d: setsockopt() with SO_BINDTODEVICE for \"%s\" failed with errno %d.",
-                    sock,
-                    fd,
-                    iface_name,
-                    errno_val,
-                )
+                    LS_IO_SOCKET,string("id=%p fd=%d: setsockopt() with SO_BINDTODEVICE for \"%s\" failed with errno %d.", " ", string(sock), " ", string(fd), " ", string(iface_name), " ", string(errno_val), " ", ))
                 throw_error(ERROR_IO_SOCKET_INVALID_OPTIONS)
             end
         elseif IP_BOUND_IF != 0
@@ -396,13 +385,7 @@ function set_posix_socket_options!(sock::Socket, options::SocketOptions)::Nothin
                 errno_val = get_errno()
                 logf(
                     LogLevel.ERROR,
-                    LS_IO_SOCKET,
-                    "id=%p fd=%d: network_interface_name \"%s\" not found. if_nametoindex() failed with errno %d.",
-                    sock,
-                    fd,
-                    iface_name,
-                    errno_val,
-                )
+                    LS_IO_SOCKET,string("id=%p fd=%d: network_interface_name \"%s\" not found. if_nametoindex() failed with errno %d.", " ", string(sock), " ", string(fd), " ", string(iface_name), " ", string(errno_val), " ", ))
                 throw_error(ERROR_IO_SOCKET_INVALID_OPTIONS)
             end
 
@@ -422,13 +405,7 @@ function set_posix_socket_options!(sock::Socket, options::SocketOptions)::Nothin
                     errno_val = get_errno()
                     logf(
                         LogLevel.ERROR,
-                        LS_IO_SOCKET,
-                        "id=%p fd=%d: setsockopt() with IPV6_BOUND_IF for \"%s\" failed with errno %d.",
-                        sock,
-                        fd,
-                        iface_name,
-                        errno_val,
-                    )
+                        LS_IO_SOCKET,string("id=%p fd=%d: setsockopt() with IPV6_BOUND_IF for \"%s\" failed with errno %d.", " ", string(sock), " ", string(fd), " ", string(iface_name), " ", string(errno_val), " ", ))
                     throw_error(ERROR_IO_SOCKET_INVALID_OPTIONS)
                 end
             else
@@ -446,24 +423,14 @@ function set_posix_socket_options!(sock::Socket, options::SocketOptions)::Nothin
                     errno_val = get_errno()
                     logf(
                         LogLevel.ERROR,
-                        LS_IO_SOCKET,
-                        "id=%p fd=%d: setsockopt() with IP_BOUND_IF for \"%s\" failed with errno %d.",
-                        sock,
-                        fd,
-                        iface_name,
-                        errno_val,
-                    )
+                        LS_IO_SOCKET,string("id=%p fd=%d: setsockopt() with IP_BOUND_IF for \"%s\" failed with errno %d.", " ", string(sock), " ", string(fd), " ", string(iface_name), " ", string(errno_val), " ", ))
                     throw_error(ERROR_IO_SOCKET_INVALID_OPTIONS)
                 end
             end
         else
             logf(
                 LogLevel.ERROR,
-                LS_IO_SOCKET,
-                "id=%p fd=%d: network_interface_name is not supported on this platform.",
-                sock,
-                fd,
-            )
+                LS_IO_SOCKET,string("id=%p fd=%d: network_interface_name is not supported on this platform.", " ", string(sock), " ", string(fd), " ", ))
             throw_error(ERROR_PLATFORM_NOT_SUPPORTED)
         end
     end

--- a/src/sockets/io/socket.jl
+++ b/src/sockets/io/socket.jl
@@ -480,11 +480,7 @@ function is_network_interface_name_valid(interface_name::AbstractString)::Bool
             err = Libc.errno()
             logf(
                 LogLevel.ERROR,
-                LS_IO_SOCKET,
-                "network_interface_name(%s) is invalid with errno: %d",
-                interface_name,
-                err,
-            )
+                LS_IO_SOCKET,string("network_interface_name(%s) is invalid with errno: %d", " ", string(interface_name), " ", string(err), " ", ))
             return false
         end
         return true

--- a/src/sockets/io/tls/s2n_tls_handler.jl
+++ b/src/sockets/io/tls/s2n_tls_handler.jl
@@ -483,9 +483,7 @@ function _s2n_drive_negotiation(handler::S2nTlsHandler)::Nothing
             end
             logf(
                 LogLevel.WARN,
-                LS_IO_TLS,
-                "s2n negotiate failed: $(_s2n_strerror(s2n_error)) ($(_s2n_strerror_debug(s2n_error)))",
-            )
+                LS_IO_TLS,string("s2n negotiate failed: $(_s2n_strerror(s2n_error)) ($(_s2n_strerror_debug(s2n_error)))", " ", ))
             handler.state = TlsNegotiationState.FAILED
             _s2n_on_negotiation_result(handler, handler.slot, ERROR_IO_TLS_ERROR_NEGOTIATION_FAILURE)
             throw_error(ERROR_IO_TLS_ERROR_NEGOTIATION_FAILURE)
@@ -536,15 +534,11 @@ end
 function _s2n_initialize_read_delay_shutdown(handler::S2nTlsHandler, slot::ChannelSlot, error_code::Int)
     logf(
         LogLevel.DEBUG,
-        LS_IO_TLS,
-        "TLS handler pending data during shutdown, waiting for downstream read window.",
-    )
+        LS_IO_TLS,string("TLS handler pending data during shutdown, waiting for downstream read window.", " ", ))
     if channel_slot_downstream_read_window(slot) == 0
         logf(
             LogLevel.WARN,
-            LS_IO_TLS,
-            "TLS shutdown delayed; pending data cannot be processed until read window opens.",
-        )
+            LS_IO_TLS,string("TLS shutdown delayed; pending data cannot be processed until read window opens.", " ", ))
     end
     handler.read_state = TlsHandlerReadState.SHUTTING_DOWN
     handler.shutdown_error_code = error_code
@@ -767,9 +761,7 @@ function handler_process_read_message(
             end
             logf(
                 LogLevel.ERROR,
-                LS_IO_TLS,
-                "s2n recv failed: $(_s2n_strerror(_s2n_errno())) ($(_s2n_strerror_debug(_s2n_errno())))",
-            )
+                LS_IO_TLS,string("s2n recv failed: $(_s2n_strerror(_s2n_errno())) ($(_s2n_strerror_debug(_s2n_errno())))", " ", ))
             shutdown_error_code = ERROR_IO_TLS_ERROR_READ_FAILURE
             break
         end
@@ -1049,9 +1041,7 @@ function _s2n_async_pkey_callback(conn::Ptr{Cvoid}, s2n_op::Ptr{Cvoid})::Cint
 
     logf(
         LogLevel.DEBUG,
-        LS_IO_TLS,
-        "Begin TLS key operation. type=$(tls_key_operation_type_str(operation.operation_type)) input_len=$(operation.input.len) signature=$(tls_signature_algorithm_str(operation.signature_algorithm)) digest=$(tls_hash_algorithm_str(operation.digest_algorithm))",
-    )
+        LS_IO_TLS,string("Begin TLS key operation. type=$(tls_key_operation_type_str(operation.operation_type)) input_len=$(operation.input.len) signature=$(tls_signature_algorithm_str(operation.signature_algorithm)) digest=$(tls_hash_algorithm_str(operation.digest_algorithm))", " ", ))
 
     if handler.s2n_ctx !== nothing && handler.s2n_ctx.custom_key_handler !== nothing
         custom_key_op_handler_perform_operation(handler.s2n_ctx.custom_key_handler, operation)
@@ -1159,9 +1149,7 @@ function _s2n_context_new(options::TlsContextOptions)::TlsContext
             S2N_SUCCESS
         logf(
             LogLevel.ERROR,
-            LS_IO_TLS,
-            "s2n: failed to set security policy '$policy': $(_s2n_strerror(_s2n_errno()))",
-        )
+            LS_IO_TLS,string("s2n: failed to set security policy '$policy': $(_s2n_strerror(_s2n_errno()))", " ", ))
         _s2n_ctx_destroy!(ctx_impl)
         throw_error(ERROR_IO_TLS_CTX_ERROR)
     end

--- a/src/sockets/io/tls/secure_transport_tls_handler.jl
+++ b/src/sockets/io/tls/secure_transport_tls_handler.jl
@@ -308,11 +308,7 @@ function _secure_transport_get_protocol(handler::SecureTransportTlsHandler)::Byt
         is_server = handler.ctx_obj !== nothing && handler.ctx_obj.options.is_server
         logf(
             LogLevel.DEBUG,
-            LS_IO_TLS,
-            "SecureTransport SSLCopyALPNProtocols unavailable (server=%s status=%d)",
-            is_server ? "true" : "false",
-            status,
-        )
+            LS_IO_TLS,string("SecureTransport SSLCopyALPNProtocols unavailable (server=%s status=%d)", " ", string(is_server ? "true" : "false"), " ", string(status), " ", ))
         return null_buffer()
     end
 
@@ -376,10 +372,7 @@ function _secure_transport_handle_would_block(handler::SecureTransportTlsHandler
     _ = handler
     logf(
         LogLevel.DEBUG,
-        LS_IO_TLS,
-        "SecureTransport SSLHandshake would block (server=%s)",
-        is_server ? "true" : "false",
-    )
+        LS_IO_TLS,string("SecureTransport SSLHandshake would block (server=%s)", " ", string(is_server ? "true" : "false"), " ", ))
     return nothing
 end
 
@@ -395,10 +388,7 @@ function _secure_transport_drive_negotiation(handler::SecureTransportTlsHandler)
     if status == _errSecSuccess
         logf(
             LogLevel.DEBUG,
-            LS_IO_TLS,
-            "SecureTransport SSLHandshake success (server=%s)",
-            is_server ? "true" : "false",
-        )
+            LS_IO_TLS,string("SecureTransport SSLHandshake success (server=%s)", " ", string(is_server ? "true" : "false"), " ", ))
         handler.negotiation_finished = true
         handler.protocol = _secure_transport_get_protocol(handler)
         if handler.protocol.len > 0
@@ -410,9 +400,7 @@ function _secure_transport_drive_negotiation(handler::SecureTransportTlsHandler)
     elseif status == _errSSLPeerAuthCompleted
         logf(
             LogLevel.DEBUG,
-            LS_IO_TLS,
-            "SecureTransport SSLHandshake peer auth completed",
-        )
+            LS_IO_TLS,string("SecureTransport SSLHandshake peer auth completed", " ", ))
         if handler.verify_peer
             if handler.ca_certs == C_NULL
                 _secure_transport_on_negotiation_result(handler, ERROR_IO_TLS_ERROR_NEGOTIATION_FAILURE)
@@ -482,9 +470,7 @@ function _secure_transport_drive_negotiation(handler::SecureTransportTlsHandler)
 
             logf(
                 LogLevel.WARN,
-                LS_IO_TLS,
-                "SecureTransport custom CA validation failed with OSStatus $status and Trust Eval $(trust_eval[])",
-            )
+                LS_IO_TLS,string("SecureTransport custom CA validation failed with OSStatus $status and Trust Eval $(trust_eval[])", " ", ))
             throw_error(ERROR_IO_TLS_ERROR_NEGOTIATION_FAILURE)
         end
 
@@ -495,9 +481,7 @@ function _secure_transport_drive_negotiation(handler::SecureTransportTlsHandler)
     else
         logf(
             LogLevel.WARN,
-            LS_IO_TLS,
-            "SecureTransport SSLHandshake failed with OSStatus $status",
-        )
+            LS_IO_TLS,string("SecureTransport SSLHandshake failed with OSStatus $status", " ", ))
         handler.negotiation_finished = false
         _secure_transport_on_negotiation_result(handler, ERROR_IO_TLS_ERROR_NEGOTIATION_FAILURE)
         throw_error(ERROR_IO_TLS_ERROR_NEGOTIATION_FAILURE)
@@ -646,15 +630,11 @@ end
 function _secure_transport_initialize_read_delay_shutdown(handler::SecureTransportTlsHandler, slot::ChannelSlot, error_code::Int)
     logf(
         LogLevel.DEBUG,
-        LS_IO_TLS,
-        "TLS handler pending data during shutdown, waiting for downstream read window.",
-    )
+        LS_IO_TLS,string("TLS handler pending data during shutdown, waiting for downstream read window.", " ", ))
     if channel_slot_downstream_read_window(slot) == 0
         logf(
             LogLevel.WARN,
-            LS_IO_TLS,
-            "TLS shutdown delayed; pending data cannot be processed until read window opens.",
-        )
+            LS_IO_TLS,string("TLS shutdown delayed; pending data cannot be processed until read window opens.", " ", ))
     end
     handler.read_state = TlsHandlerReadState.SHUTTING_DOWN
     handler.delay_shutdown_error_code = error_code
@@ -801,9 +781,7 @@ function handler_process_read_message(
         else
             logf(
                 LogLevel.ERROR,
-                LS_IO_TLS,
-                "SecureTransport SSLRead failed with OSStatus $status",
-            )
+                LS_IO_TLS,string("SecureTransport SSLRead failed with OSStatus $status", " ", ))
             shutdown_error_code = ERROR_IO_TLS_ERROR_READ_FAILURE
             break
         end
@@ -1080,9 +1058,7 @@ function _secure_transport_handler_new(
     if !st_ctx.verify_peer && protocol_side == _kSSLClientSide
         logf(
             LogLevel.WARN,
-            LS_IO_TLS,
-            "x.509 validation has been disabled. This is unsafe outside of test environments.",
-        )
+            LS_IO_TLS,string("x.509 validation has been disabled. This is unsafe outside of test environments.", " ", ))
         _ = ccall((:SSLSetSessionOption, _SECURITY_LIB), OSStatus, (SSLContextRef, Cint, UInt8), handler.ctx, _kSSLSessionOptionBreakOnServerAuth, 1)
     end
 

--- a/src/sockets/io/unused/dispatch_queue_event_loop.jl
+++ b/src/sockets/io/unused/dispatch_queue_event_loop.jl
@@ -161,10 +161,7 @@
             _dispatch_after(dispatch_loop.dispatch_queue, when, entry_ptr, run_ptr)
             logf(
                 LogLevel.TRACE,
-                LS_IO_EVENT_LOOP,
-                "dispatch queue scheduling future iteration in %d ns",
-                delta,
-            )
+                LS_IO_EVENT_LOOP,string("dispatch queue scheduling future iteration in %d ns", " ", string(delta), " ", ))
         end
 
         return nothing
@@ -311,7 +308,7 @@
         dispatch_loop.dispatch_queue = queue
         _dispatch_suspend(queue)
 
-        logf(LogLevel.INFO, LS_IO_EVENT_LOOP, "dispatch queue created with id: %s", queue_id)
+        logf(LogLevel.INFO, LS_IO_EVENT_LOOP,string("dispatch queue created with id: %s", " ", string(queue_id)))
 
         return event_loop
     end
@@ -439,7 +436,7 @@
 
     function event_loop_cancel_task!(event_loop::DispatchQueueEventLoop, task::ScheduledTask)
         dispatch_loop = event_loop.impl_data
-        logf(LogLevel.TRACE, LS_IO_EVENT_LOOP, "dispatch queue cancelling %s task", task.type_tag)
+        logf(LogLevel.TRACE, LS_IO_EVENT_LOOP,string("dispatch queue cancelling %s task", " ", string(task.type_tag)))
 
         if !task.scheduled
             return nothing
@@ -492,9 +489,7 @@
         _ = user_data
         logf(
             LogLevel.ERROR,
-            LS_IO_EVENT_LOOP,
-            "subscribe_to_io_events not supported for dispatch queue event loops",
-        )
+            LS_IO_EVENT_LOOP,string("subscribe_to_io_events not supported for dispatch queue event loops", " ", ))
         return ErrorResult(raise_error(ERROR_PLATFORM_NOT_SUPPORTED))
     end
 
@@ -505,9 +500,7 @@
         _ = handle
         logf(
             LogLevel.ERROR,
-            LS_IO_EVENT_LOOP,
-            "unsubscribe_from_io_events not supported for dispatch queue event loops",
-        )
+            LS_IO_EVENT_LOOP,string("unsubscribe_from_io_events not supported for dispatch queue event loops", " ", ))
         return ErrorResult(raise_error(ERROR_PLATFORM_NOT_SUPPORTED))
     end
 

--- a/src/sockets/io/winsock_init.jl
+++ b/src/sockets/io/winsock_init.jl
@@ -65,14 +65,14 @@
             wsa_data = Ref(WSADATA(0x0, 0x0, ntuple(_ -> UInt8(0), 257), ntuple(_ -> UInt8(0), 129), 0x0, 0x0, C_NULL))
             rc = ccall((:WSAStartup, _WS2_32), Cint, (UInt16, Ptr{WSADATA}), requested_version, wsa_data)
             if rc != 0
-                logf(LogLevel.ERROR, LS_IO_SOCKET, "static: WinSock initialization failed with error %d", rc)
+                logf(LogLevel.ERROR, LS_IO_SOCKET,string("static: WinSock initialization failed with error %d", " ", string(rc)))
                 throw_error(ERROR_SYS_CALL_FAILURE)
             end
 
             dummy = ccall((:socket, _WS2_32), UInt, (Cint, Cint, Cint), AF_INET, SOCK_STREAM, Cint(0))
             if dummy == INVALID_SOCKET
                 err = _wsa_get_last_error()
-                logf(LogLevel.ERROR, LS_IO_SOCKET, "static: dummy socket() failed with WSAError %d", err)
+                logf(LogLevel.ERROR, LS_IO_SOCKET,string("static: dummy socket() failed with WSAError %d", " ", string(err)))
                 throw_error(ERROR_SYS_CALL_FAILURE)
             end
 
@@ -97,7 +97,7 @@
                 )
                 if rc != 0 || connectex_ref[] == C_NULL
                     err = _wsa_get_last_error()
-                    logf(LogLevel.ERROR, LS_IO_SOCKET, "static: failed to load WSAID_CONNECTEX with WSAError %d", err)
+                    logf(LogLevel.ERROR, LS_IO_SOCKET,string("static: failed to load WSAID_CONNECTEX with WSAError %d", " ", string(err)))
                     throw_error(ERROR_SYS_CALL_FAILURE)
                 end
                 _connectex_fn[] = connectex_ref[]
@@ -122,7 +122,7 @@
                 )
                 if rc != 0 || acceptex_ref[] == C_NULL
                     err = _wsa_get_last_error()
-                    logf(LogLevel.ERROR, LS_IO_SOCKET, "static: failed to load WSAID_ACCEPTEX with WSAError %d", err)
+                    logf(LogLevel.ERROR, LS_IO_SOCKET,string("static: failed to load WSAID_ACCEPTEX with WSAError %d", " ", string(err)))
                     throw_error(ERROR_SYS_CALL_FAILURE)
                 end
                 _acceptex_fn[] = acceptex_ref[]

--- a/src/sockets/io/winsock_socket.jl
+++ b/src/sockets/io/winsock_socket.jl
@@ -306,7 +306,7 @@
         if handle == UInt(typemax(UInt))
             wsa_err = _wsa_get_last_error()
             aws_err = _winsock_determine_socket_error(wsa_err)
-            logf(LogLevel.ERROR, LS_IO_SOCKET, "socket() failed with WSAError %d", wsa_err)
+            logf(LogLevel.ERROR, LS_IO_SOCKET,string("socket() failed with WSAError %d", " ", wsa_err))
             throw_error(aws_err)
         end
 
@@ -315,7 +315,7 @@
         if ccall((:ioctlsocket, _WS2_32), Cint, (UInt, UInt32, Ptr{UInt32}), handle, FIONBIO, non_blocking) != 0
             wsa_err = _wsa_get_last_error()
             aws_err = _winsock_determine_socket_error(wsa_err)
-            logf(LogLevel.ERROR, LS_IO_SOCKET, "ioctlsocket(FIONBIO) failed with WSAError %d", wsa_err)
+            logf(LogLevel.ERROR, LS_IO_SOCKET,string("ioctlsocket(FIONBIO) failed with WSAError %d", " ", wsa_err))
             _ = ccall((:closesocket, _WS2_32), Cint, (UInt,), handle)
             throw_error(aws_err)
         end

--- a/src/task_scheduler.jl
+++ b/src/task_scheduler.jl
@@ -478,12 +478,7 @@ end
 function task_run!(task::ScheduledTask, status::TaskStatus.T)
     logf(
         LogLevel.TRACE,
-        LS_COMMON_TASK_SCHEDULER,
-        "id=%s: Running %s task with %s status",
-        string(objectid(task)),
-        task.type_tag,
-        task_status_to_string(status),
-    )
+        LS_COMMON_TASK_SCHEDULER,string("id=%s: Running %s task with %s status", " ", string(objectid(task)), " ", task.type_tag, " ", task_status_to_string(status), " ", ))
     task.scheduled = false
     task.fn(UInt8(status))
     return nothing
@@ -503,11 +498,7 @@ end
 function task_scheduler_schedule_now!(scheduler::TaskScheduler, task::ScheduledTask)
     logf(
         LogLevel.TRACE,
-        LS_COMMON_TASK_SCHEDULER,
-        "id=%s: Scheduling %s task for immediate execution",
-        string(objectid(task)),
-        task.type_tag,
-    )
+        LS_COMMON_TASK_SCHEDULER,string("id=%s: Scheduling %s task for immediate execution", " ", string(objectid(task)), " ", task.type_tag, " ", ))
     task.timestamp = UInt64(0)
     task.scheduled = true
     push!(scheduler.asap, task)
@@ -517,12 +508,7 @@ end
 function task_scheduler_schedule_future!(scheduler::TaskScheduler, task::ScheduledTask, time_to_run::UInt64)
     logf(
         LogLevel.TRACE,
-        LS_COMMON_TASK_SCHEDULER,
-        "id=%s: Scheduling %s task for future execution at time %d",
-        string(objectid(task)),
-        task.type_tag,
-        time_to_run,
-    )
+        LS_COMMON_TASK_SCHEDULER,string("id=%s: Scheduling %s task for future execution at time %d", " ", string(objectid(task)), " ", task.type_tag, " ", time_to_run, " ", ))
     task.timestamp = time_to_run
     task.scheduled = true
     push!(scheduler.timed, task)


### PR DESCRIPTION
## Summary
- simplify logging internals to strict single-message logging (`logf(level, subject, msg)`)
- remove variadic formatting from logging machinery and `@LOGF*` macros
- migrate Reseau downstream `logf` callsites to build messages at callsites
- refresh `trim/current_state.md` notes after trim experiments

## Validation
- `JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'` (Reseau)
- `JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'` (AwsHTTP)
- `JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'` (HTTP)

## Notes
- downstream repos were updated locally to match the new single-message `logf` call pattern.
