### PR TITLE
Epoll linux CI fix sweep from jq-epoll-event-loop

### DIFF
--- a/src/eventloops/epoll_event_loop.jl
+++ b/src/eventloops/epoll_event_loop.jl
@@ -5,6 +5,21 @@
 @static if Sys.islinux()
     using LibAwsCal
 
+    const _LIBC_EWOULDBLOCK = isdefined(Base.Libc, :EWOULDBLOCK) ? Base.Libc.EWOULDBLOCK : Base.Libc.EAGAIN
+    @inline function _epoll_handle_data_key(handle_data::EpollEventHandleData)::UInt64
+        return UInt64(objectid(handle_data))
+    end
+
+    @inline function _epoll_handle_data_key(handle::IoHandle)::UInt64
+        if handle.additional_ref === nothing
+            return UInt64(0)
+        end
+        if !(handle.additional_ref isa EpollEventHandleData)
+            throw_error(ERROR_INVALID_STATE)
+        end
+        return _epoll_handle_data_key(handle.additional_ref)
+    end
+
     # Channel-based rendezvous for passing EventLoop to the thread function.
     const _EPOLL_THREAD_STARTUP = Channel{Any}(1)
 
@@ -13,7 +28,9 @@
         try
             epoll_event_loop_thread(event_loop)
         catch e
-            Core.println("epoll event loop thread errored")
+            Core.print("epoll event loop thread errored: ")
+            Base.showerror(Core.stdout, e, catch_backtrace())
+            Core.println()
         finally
             impl = event_loop.impl_data
             notify(impl.completion_event)
@@ -147,14 +164,20 @@
     # Run the event loop
     function event_loop_run!(event_loop::EventLoop)::Nothing
         impl = event_loop.impl_data
+        event_loop_running = @atomic event_loop.running
+        thread_ready = impl.thread_state == EpollEventThreadState.READY_TO_RUN
 
-        if @atomic event_loop.running
+        if event_loop_running || !thread_ready
             throw_error(ERROR_INVALID_STATE)
         end
 
         logf(LogLevel.INFO, LS_IO_EVENT_LOOP, "Starting event-loop thread")
 
         impl.should_continue = true
+        impl.thread_state = EpollEventThreadState.RUNNING
+        impl.should_process_task_pre_queue = false
+        @atomic impl.stop_task_scheduled = false
+        impl.stop_task = nothing
 
         # Thread startup synchronization (avoid libuv-backed `sleep`/`time_ns` polling).
         impl.startup_event = Base.Threads.Event()
@@ -170,6 +193,9 @@
             take!(_EPOLL_THREAD_STARTUP)  # drain on failure
             logf(LogLevel.FATAL, LS_IO_EVENT_LOOP, "thread creation failed")
             impl.should_continue = false
+            impl.thread_state = EpollEventThreadState.READY_TO_RUN
+            @atomic impl.stop_task_scheduled = false
+            impl.should_process_task_pre_queue = false
             throw_error(ERROR_THREAD_NO_SUCH_THREAD_ID)
         end
 
@@ -179,6 +205,11 @@
         wait(impl.startup_event)
         startup_error = @atomic impl.startup_error
         if startup_error != 0 || (@atomic impl.running_thread_id) == 0
+            @atomic event_loop.running = false
+            impl.thread_state = EpollEventThreadState.READY_TO_RUN
+            impl.should_continue = false
+            impl.should_process_task_pre_queue = false
+            @atomic impl.stop_task_scheduled = false
             throw_error(startup_error != 0 ? startup_error : ERROR_IO_EVENT_LOOP_SHUTDOWN)
         end
 
@@ -188,6 +219,22 @@
     # Stop the event loop
     function event_loop_stop!(event_loop::EventLoop)::Nothing
         impl = event_loop.impl_data
+
+        if !@atomic event_loop.running
+            return nothing
+        end
+
+        if impl.thread_state == EpollEventThreadState.STOPPING
+            return nothing
+        end
+
+        impl.thread_state = EpollEventThreadState.STOPPING
+        @atomic event_loop.should_stop = true
+
+        if event_loop_thread_is_callers_thread(event_loop)
+            impl.should_continue = false
+            return nothing
+        end
 
         # Use atomic CAS to ensure stop task is only scheduled once
         expected = false
@@ -222,6 +269,12 @@
         if impl.thread_created_on !== nothing
             wait(impl.completion_event)
         end
+        impl.thread_state = EpollEventThreadState.READY_TO_RUN
+        impl.should_continue = false
+        impl.stop_task = nothing
+        impl.should_process_task_pre_queue = false
+        @atomic impl.stop_task_scheduled = false
+        @atomic event_loop.should_stop = false
 
         @atomic event_loop.running = false
 
@@ -232,37 +285,104 @@
     function schedule_task_cross_thread(event_loop::EventLoop, task::ScheduledTask, run_at_nanos::UInt64)
         impl = event_loop.impl_data
 
-        logf(
-            LogLevel.TRACE,
-            LS_IO_EVENT_LOOP,string("Scheduling %s task cross-thread for timestamp %d", " ", task.type_tag, " ", run_at_nanos, " ", ))
-
-        task.timestamp = run_at_nanos
-        task.scheduled = true
-
+        should_signal = false
         lock(impl.task_pre_queue_mutex)
         try
-            is_first_task = isempty(impl.task_pre_queue)
-            push!(impl.task_pre_queue, task)
-
-            # If the list was not empty, we already have a pending read on the pipe/eventfd
-            if is_first_task
-                logf(LogLevel.TRACE, LS_IO_EVENT_LOOP, "Waking up event-loop thread")
-                # Write to signal the event thread
-                counter = Ref(UInt64(1))
-                while true
-                    written = @ccall gc_safe = true write(
-                        impl.write_task_handle.fd::Cint,
-                        counter::Ptr{UInt64},
-                        sizeof(UInt64)::Csize_t,
-                    )::Cssize_t
-                    if written == -1 && Base.Libc.errno() == Libc.EINTR
-                        continue
-                    end
-                    break
-                end
+            if task.scheduled
+                logf(
+                    LogLevel.TRACE,
+                    LS_IO_EVENT_LOOP,
+                    string(
+                        "skipping cross-thread schedule for %s because it is already scheduled",
+                        " ",
+                        task.type_tag,
+                        " ",
+                    ),
+                )
+                return nothing
             end
+
+            if findfirst(x -> x === task, impl.task_pre_queue) !== nothing
+                logf(
+                    LogLevel.TRACE,
+                    LS_IO_EVENT_LOOP,
+                    string(
+                        "skipping duplicate cross-thread schedule for %s currently queued",
+                        " ",
+                        task.type_tag,
+                        " ",
+                    ),
+                )
+                return nothing
+            end
+
+            logf(
+                LogLevel.TRACE,
+                LS_IO_EVENT_LOOP,
+                string(
+                    "Scheduling %s task cross-thread for timestamp %d",
+                    " ",
+                    task.type_tag,
+                    " ",
+                    run_at_nanos,
+                    " ",
+                ),
+            )
+
+            task.timestamp = run_at_nanos
+            task.scheduled = true
+
+            is_first_task = isempty(impl.task_pre_queue)
+            should_signal = !impl.should_process_task_pre_queue
+            push!(impl.task_pre_queue, task)
+            should_signal = is_first_task || should_signal
         finally
             unlock(impl.task_pre_queue_mutex)
+        end
+
+        if should_signal
+            logf(LogLevel.TRACE, LS_IO_EVENT_LOOP, "Waking up event-loop thread")
+            # Write to signal the event thread
+            counter = Ref(UInt64(1))
+            write_ptr = Ptr{UInt8}(Base.unsafe_convert(Ptr{UInt64}, counter))
+            remaining = Csize_t(sizeof(UInt64))
+            retries = 0
+            while remaining > 0
+                written = @ccall gc_safe = true write(
+                    impl.write_task_handle.fd::Cint,
+                    write_ptr::Ptr{UInt8},
+                    remaining::Csize_t,
+                )::Cssize_t
+                if written == -1
+                    errno = Base.Libc.errno()
+                    if errno == Libc.EINTR
+                        retries += 1
+                        if retries > EWOULDBLOCK_RETRY_LIMIT
+                            logf(
+                                LogLevel.ERROR,
+                                LS_IO_EVENT_LOOP,
+                                "aborting cross-thread wakeup write after repeated EINTR",
+                            )
+                            break
+                        end
+                        continue
+                    end
+                    if errno in (Libc.EAGAIN, _LIBC_EWOULDBLOCK)
+                        logf(
+                            LogLevel.TRACE,
+                            LS_IO_EVENT_LOOP,
+                            "Ignoring cross-thread wakeup write backpressure when scheduling task queue",
+                        )
+                        break
+                    end
+                    throw_error(ERROR_SYS_CALL_FAILURE)
+                end
+                if written <= 0
+                    break
+                end
+                remaining -= Csize_t(written)
+                write_ptr += Int(written)
+            end
         end
 
         return nothing
@@ -277,11 +397,32 @@
             logf(
                 LogLevel.TRACE,
                 LS_IO_EVENT_LOOP,string("scheduling %s task in-thread for timestamp %d", " ", task.type_tag, " ", run_at_nanos, " ", ))
-            if run_at_nanos == 0
-                task_scheduler_schedule_now!(impl.scheduler, task)
-            else
-                task_scheduler_schedule_future!(impl.scheduler, task, run_at_nanos)
+
+            lock(impl.task_pre_queue_mutex)
+            try
+                if task.scheduled
+                    logf(
+                        LogLevel.TRACE,
+                        LS_IO_EVENT_LOOP,
+                        string(
+                            "skipping task %s schedule because it is already scheduled",
+                            " ",
+                            task.type_tag,
+                            " ",
+                        ),
+                    )
+                    return nothing
+                end
+
+                if run_at_nanos == 0
+                    task_scheduler_schedule_now!(impl.scheduler, task)
+                else
+                    task_scheduler_schedule_future!(impl.scheduler, task, run_at_nanos)
+                end
+            finally
+                unlock(impl.task_pre_queue_mutex)
             end
+
             return nothing
         end
 
@@ -310,13 +451,13 @@
         debug_assert(event_loop_thread_is_callers_thread(event_loop))
         impl = event_loop.impl_data
         logf(LogLevel.TRACE, LS_IO_EVENT_LOOP,string("cancelling %s task", " ", task.type_tag))
-        if !task.scheduled
-            return nothing
-        end
-
         removed = false
         lock(impl.task_pre_queue_mutex)
         try
+            if !task.scheduled
+                return nothing
+            end
+
             if !isempty(impl.task_pre_queue)
                 idx = findfirst(x -> x === task, impl.task_pre_queue)
                 if idx !== nothing
@@ -350,15 +491,25 @@
             events::Int,
             on_event::EventCallable,
         )::Nothing
+        if handle.fd < 0
+            throw_error(ERROR_INVALID_ARGUMENT)
+        end
         logf(LogLevel.TRACE, LS_IO_EVENT_LOOP,string("subscribing to events on fd %d", " ", handle.fd))
+        if handle.additional_data != C_NULL
+            throw_error(ERROR_IO_ALREADY_SUBSCRIBED)
+        end
 
         epoll_event_data = EpollEventHandleData(handle, on_event)
+        handle_data_key = _epoll_handle_data_key(epoll_event_data)
 
         # Store handle data reference
-        handle.additional_data = pointer_from_objref(epoll_event_data)
-        handle.additional_ref = epoll_event_data
+        epoll_store_handle_data!(handle, epoll_event_data)
 
         impl = event_loop.impl_data
+        if impl.epoll_fd < 0
+            epoll_release_handle_data!(handle)
+            throw_error(ERROR_IO_EVENT_LOOP_SHUTDOWN)
+        end
 
         # Build event mask - everyone is always registered for edge-triggered, hang up, remote hang up, errors
         event_mask = EPOLLET | EPOLLHUP | EPOLLRDHUP | EPOLLERR
@@ -371,8 +522,17 @@
             event_mask |= EPOLLOUT
         end
 
+        # Keep the map entry until callback processing finishes to guarantee
+        # stable lifetime during epoll dispatch.
+        lock(impl.subscribed_handle_data_mutex)
+        try
+            impl.subscribed_handle_data[handle_data_key] = epoll_event_data
+        finally
+            unlock(impl.subscribed_handle_data_mutex)
+        end
+
         # Create epoll_event struct
-        epoll_ev = EpollEvent(event_mask, handle.additional_data)
+        epoll_ev = EpollEvent(event_mask, Ptr{Cvoid}(handle_data_key))
         epoll_ev_ref = Ref(epoll_ev)
 
         ret = @ccall epoll_ctl(
@@ -384,11 +544,15 @@
 
         if ret != 0
             logf(LogLevel.ERROR, LS_IO_EVENT_LOOP,string("failed to subscribe to events on fd %d", " ", handle.fd))
-            handle.additional_data = C_NULL
-            handle.additional_ref = nothing
+            lock(impl.subscribed_handle_data_mutex)
+            try
+                delete!(impl.subscribed_handle_data, handle_data_key)
+            finally
+                unlock(impl.subscribed_handle_data_mutex)
+            end
+            epoll_release_handle_data!(handle)
             throw_error(ERROR_SYS_CALL_FAILURE)
         end
-
         return nothing
     end
 
@@ -398,7 +562,26 @@
     end
 
     # Cleanup task callback
-    function epoll_unsubscribe_cleanup_task_callback(event_data::EpollEventHandleData, status::TaskStatus.T)
+    function epoll_unsubscribe_cleanup_task_callback(
+            event_loop::EventLoop,
+            handle_data_key::UInt64,
+            event_data::EpollEventHandleData,
+            status::TaskStatus.T,
+        )
+        event_data.cleanup_task = nothing
+
+        impl = event_loop.impl_data
+        status == TaskStatus.CANCELED && return nothing
+
+        lock(impl.subscribed_handle_data_mutex)
+        try
+            stored_data = get(impl.subscribed_handle_data, handle_data_key, nothing)
+            if stored_data === event_data
+                delete!(impl.subscribed_handle_data, handle_data_key)
+            end
+        finally
+            unlock(impl.subscribed_handle_data_mutex)
+        end
         return nothing
     end
 
@@ -407,18 +590,27 @@
             event_loop::EventLoop,
             handle::IoHandle,
         )::Nothing
+        if handle.fd < 0
+            throw_error(ERROR_INVALID_ARGUMENT)
+        end
         if (@atomic event_loop.running) && !event_loop_thread_is_callers_thread(event_loop)
             throw_error(ERROR_IO_EVENT_LOOP_THREAD_ONLY)
         end
         logf(LogLevel.TRACE, LS_IO_EVENT_LOOP,string("un-subscribing from events on fd %d", " ", handle.fd))
 
         impl = event_loop.impl_data
+        if impl.epoll_fd < 0
+            throw_error(ERROR_IO_EVENT_LOOP_SHUTDOWN)
+        end
 
         if handle.additional_data == C_NULL
             throw_error(ERROR_IO_NOT_SUBSCRIBED)
         end
-
-        event_data = unsafe_pointer_to_objref(handle.additional_data)::EpollEventHandleData
+        event_data = epoll_get_handle_data(handle)
+        handle_data_key = _epoll_handle_data_key(handle)
+        if handle_data_key == UInt64(0)
+            throw_error(ERROR_IO_NOT_SUBSCRIBED)
+        end
 
         # Remove from epoll - use a dummy event (required by older kernels)
         dummy_event = EpollEvent(UInt32(0), C_NULL)
@@ -438,11 +630,22 @@
 
         # Mark as unsubscribed and schedule cleanup task
         event_data.is_subscribed = false
+        lock(impl.subscribed_handle_data_mutex)
+        try
+            delete!(impl.subscribed_handle_data, handle_data_key)
+        finally
+            unlock(impl.subscribed_handle_data_mutex)
+        end
 
         event_data.cleanup_task = ScheduledTask(
             TaskFn(function(status)
                 try
-                    epoll_unsubscribe_cleanup_task_callback(event_data, _coerce_task_status(status))
+                    epoll_unsubscribe_cleanup_task_callback(
+                        event_loop,
+                        handle_data_key,
+                        event_data,
+                        _coerce_task_status(status),
+                    )
                 catch e
                     Core.println("epoll_cleanup task errored")
                 end
@@ -450,10 +653,19 @@
             end);
             type_tag = "epoll_event_loop_unsubscribe_cleanup",
         )
-        event_loop_schedule_task_now!(event_loop, event_data.cleanup_task)
 
-        handle.additional_data = C_NULL
-        handle.additional_ref = nothing
+        if (@atomic event_loop.running)
+            event_loop_schedule_task_now!(event_loop, event_data.cleanup_task)
+        else
+            epoll_unsubscribe_cleanup_task_callback(
+                event_loop,
+                handle_data_key,
+                event_data,
+                TaskStatus.T(TaskStatus.CANCELED),
+            )
+        end
+
+        epoll_release_handle_data!(handle)
 
         return nothing
     end
@@ -463,8 +675,22 @@
         logf(LogLevel.TRACE, LS_IO_EVENT_LOOP, "notified of cross-thread tasks to schedule")
         impl = event_loop.impl_data
 
-        if (events & Int(IoEventType.READABLE)) != 0
+        if (events & Int(IoEventType.READABLE)) == 0
+            if events != 0
+                logf(
+                    LogLevel.DEBUG,
+                    LS_IO_EVENT_LOOP,
+                    "ignoring non-readable task-notification event mask on epoll read fd $events",
+                )
+            end
+            return nothing
+        end
+
+        lock(impl.task_pre_queue_mutex)
+        try
             impl.should_process_task_pre_queue = true
+        finally
+            unlock(impl.task_pre_queue_mutex)
         end
 
         return nothing
@@ -473,10 +699,6 @@
     # Process cross-thread task queue
     function process_task_pre_queue(event_loop::EventLoop)
         impl = event_loop.impl_data
-
-        if !impl.should_process_task_pre_queue
-            return nothing
-        end
 
         logf(LogLevel.TRACE, LS_IO_EVENT_LOOP, "processing cross-thread tasks")
 
@@ -487,24 +709,49 @@
 
         lock(impl.task_pre_queue_mutex)
         try
-            if !impl.should_process_task_pre_queue
+            if !impl.should_process_task_pre_queue && isempty(impl.task_pre_queue)
                 return nothing
             end
 
             impl.should_process_task_pre_queue = false
 
             # Drain the eventfd/pipe
+            retries = 0
             while true
                 read_bytes = @ccall read(
                     impl.read_task_handle.fd::Cint,
                     count_ignore::Ptr{UInt64},
                     sizeof(UInt64)::Csize_t,
                 )::Cssize_t
-                read_bytes < 0 && break
+                if read_bytes == -1
+                    errno = Base.Libc.errno()
+                    if errno == Libc.EINTR
+                        retries += 1
+                        if retries > EWOULDBLOCK_RETRY_LIMIT
+                            logf(
+                                LogLevel.ERROR,
+                                LS_IO_EVENT_LOOP,
+                                "aborting cross-thread wakeup read after repeated EINTR",
+                            )
+                            break
+                        end
+                        continue
+                    end
+                    if errno in (Libc.EAGAIN, _LIBC_EWOULDBLOCK)
+                        break
+                    end
+                    logf(LogLevel.ERROR, LS_IO_EVENT_LOOP, "cross-thread wakeup read failed with errno $errno")
+                    break
+                end
+                if read_bytes == 0
+                    break
+                end
             end
 
-            tasks_to_schedule, impl.task_pre_queue = impl.task_pre_queue, tasks_to_schedule
-            impl.task_pre_queue_spare = tasks_to_schedule
+            empty!(tasks_to_schedule)
+            append!(tasks_to_schedule, impl.task_pre_queue)
+            empty!(impl.task_pre_queue)
+
         finally
             unlock(impl.task_pre_queue_mutex)
         end
@@ -513,9 +760,25 @@
         while !isempty(tasks_to_schedule)
             task = popfirst!(tasks_to_schedule)
             task === nothing && break
+            if !task.scheduled
+                logf(
+                    LogLevel.TRACE,
+                    LS_IO_EVENT_LOOP,
+                    string(
+                        "skipping queued task %s because it is not currently scheduled",
+                        " ",
+                        task.type_tag,
+                        " ",
+                    ),
+                )
+                continue
+            end
+
             logf(
                 LogLevel.TRACE,
-                LS_IO_EVENT_LOOP,string("task %s pulled to event-loop, scheduling now", " ", task.type_tag, " ", ))
+                LS_IO_EVENT_LOOP,
+                string("task %s pulled to event-loop, scheduling now", " ", task.type_tag, " ", ),
+            )
             if task.timestamp == 0
                 task_scheduler_schedule_now!(impl.scheduler, task)
             else
@@ -530,182 +793,253 @@
     function epoll_event_loop_thread(event_loop::EventLoop)
         logf(LogLevel.INFO, LS_IO_EVENT_LOOP, "main loop started")
         impl = event_loop.impl_data
+        subscribed_for_task_notifications = false
 
         # Set running thread ID
         @atomic impl.running_thread_id = UInt64(Base.Threads.threadid())
 
-        # Subscribe to events on the read task handle for cross-thread notifications.
-        # Signal `startup_event` once subscription is complete.
         try
-            event_loop_subscribe_to_io_events!(
-                event_loop,
-                impl.read_task_handle,
-                Int(IoEventType.READABLE),
-                EventCallable(events -> on_tasks_to_schedule(event_loop, events)),
-            )
-        catch
-            logf(LogLevel.ERROR, LS_IO_EVENT_LOOP, "failed to subscribe to task notification events")
-            @atomic impl.startup_error = ERROR_SYS_CALL_FAILURE
-            notify(impl.startup_event)
-            @atomic impl.running_thread_id = UInt64(0)
-            return nothing
-        end
-        notify(impl.startup_event)
-
-        # Cal cleanup is handled in the thread entry finally block
-
-        timeout = DEFAULT_TIMEOUT_MS
-        events = Memory{EpollEvent}(undef, MAX_EVENTS)
-
-        logf(
-            LogLevel.INFO,
-            LS_IO_EVENT_LOOP,string("default timeout %d ms, and max events to process per tick %d", " ", timeout, " ", MAX_EVENTS, " ", ))
-
-        while impl.should_continue
-            logf(LogLevel.TRACE, LS_IO_EVENT_LOOP,string("waiting for a maximum of %d ms", " ", timeout))
-
-            # Call epoll_wait
-            event_count = @ccall gc_safe = true epoll_wait(
-                impl.epoll_fd::Cint,
-                events::Ptr{EpollEvent},
-                MAX_EVENTS::Cint,
-                timeout::Cint,
-            )::Cint
-
-            event_loop_register_tick_start!(event_loop)
-
-            logf(LogLevel.TRACE, LS_IO_EVENT_LOOP,string("wake up with %d events to process", " ", event_count))
-
-            # Process events
-            if event_count > 0
-                tracing_task_begin(tracing_event_loop_events)
+            # Subscribe to events on the read task handle for cross-thread notifications.
+            # Signal `startup_event` once subscription is complete.
+            try
+                event_loop_subscribe_to_io_events!(
+                    event_loop,
+                    impl.read_task_handle,
+                    Int(IoEventType.READABLE),
+                    EventCallable(events -> on_tasks_to_schedule(event_loop, events)),
+                )
+                subscribed_for_task_notifications = true
+            catch
+                logf(LogLevel.ERROR, LS_IO_EVENT_LOOP, "failed to subscribe to task notification events")
+                @atomic impl.startup_error = ERROR_SYS_CALL_FAILURE
+                notify(impl.startup_event)
+                @atomic impl.running_thread_id = UInt64(0)
+                return nothing
             end
-            for i in 1:event_count
-                tracing_task_begin(tracing_event_loop_event)
-                try
-                    ev = events[i]
-                    event_data_ptr = _epoll_event_data_ptr(ev)
+            notify(impl.startup_event)
 
-                    if event_data_ptr == C_NULL
-                        continue
-                    end
+            timeout = DEFAULT_TIMEOUT_MS
+            event_wait_capacity = impl.event_wait_capacity
+            events = Memory{EpollEvent}(undef, event_wait_capacity)
 
-                    event_data = unsafe_pointer_to_objref(event_data_ptr)::EpollEventHandleData
+            logf(
+                LogLevel.INFO,
+                LS_IO_EVENT_LOOP,
+                "default timeout $timeout ms, and max events to process per tick $event_wait_capacity",
+            )
 
-                    # Convert epoll events to our event mask
-                    event_mask = 0
+            while impl.should_continue
+                logf(LogLevel.TRACE, LS_IO_EVENT_LOOP,string("waiting for a maximum of %d ms", " ", timeout))
 
-                    if (ev.events & EPOLLIN) != 0
-                        event_mask |= Int(IoEventType.READABLE)
-                    end
-
-                    if (ev.events & EPOLLOUT) != 0
-                        event_mask |= Int(IoEventType.WRITABLE)
-                    end
-
-                    if (ev.events & EPOLLRDHUP) != 0
-                        event_mask |= Int(IoEventType.REMOTE_HANG_UP)
-                    end
-
-                    if (ev.events & EPOLLHUP) != 0
-                        event_mask |= Int(IoEventType.CLOSED)
-                    end
-
-                    if (ev.events & EPOLLERR) != 0
-                        event_mask |= Int(IoEventType.ERROR)
-                    end
-
-                    if event_data.is_subscribed
+                # Call epoll_wait
+                event_count = @ccall gc_safe = true epoll_wait(
+                    impl.epoll_fd::Cint,
+                    events::Ptr{EpollEvent},
+                    event_wait_capacity::Cint,
+                    timeout::Cint,
+                )::Cint
+                if event_count == -1
+                    err = Base.Libc.errno()
+                    if err == Libc.EINTR
+                        event_count = 0
+                    else
                         logf(
-                            LogLevel.TRACE,
-                            LS_IO_EVENT_LOOP,string("activity on fd %d, invoking handler", " ", event_data.handle.fd, " ", ))
+                            LogLevel.ERROR,
+                            LS_IO_EVENT_LOOP,
+                            "epoll_wait failed while waiting for events: errno $err",
+                        )
+                        event_count = 0
+                    end
+                end
+
+                if event_count == event_wait_capacity && event_wait_capacity < MAX_EVENTS
+                    event_wait_capacity = min(event_wait_capacity << 1, MAX_EVENTS)
+                    impl.event_wait_capacity = event_wait_capacity
+                    events = Memory{EpollEvent}(undef, event_wait_capacity)
+                    logf(LogLevel.TRACE, LS_IO_EVENT_LOOP, "expanded epoll event wait capacity to $event_wait_capacity")
+                end
+
+                event_loop_register_tick_start!(event_loop)
+
+                logf(LogLevel.TRACE, LS_IO_EVENT_LOOP,string("wake up with %d events to process", " ", event_count))
+
+                # Process events
+                if event_count > 0
+                    tracing_task_begin(tracing_event_loop_events)
+                end
+                for i in 1:event_count
+                    tracing_task_begin(tracing_event_loop_event)
+                    try
+                        ev = events[i]
+                        event_data_key = UInt64(UInt(_epoll_event_data_ptr(ev)))
+                        event_data = nothing
+
+                        if event_data_key == 0
+                            continue
+                        end
+                        lock(impl.subscribed_handle_data_mutex)
                         try
-                            event_data.on_event(event_mask)
-                        catch e
-                            if e isa ReseauError &&
+                            event_data = get(impl.subscribed_handle_data, event_data_key, nothing)
+                        finally
+                            unlock(impl.subscribed_handle_data_mutex)
+                        end
+                        if event_data === nothing
+                            logf(
+                                LogLevel.TRACE,
+                                LS_IO_EVENT_LOOP,
+                                "skipping event for stale or unknown handle id $event_data_key",
+                            )
+                            continue
+                        end
+
+                        # Convert epoll events to our event mask
+                        event_mask = 0
+
+                        if (ev.events & EPOLLIN) != 0
+                            event_mask |= Int(IoEventType.READABLE)
+                        end
+
+                        if (ev.events & EPOLLOUT) != 0
+                            event_mask |= Int(IoEventType.WRITABLE)
+                        end
+
+                        if (ev.events & EPOLLRDHUP) != 0
+                            event_mask |= Int(IoEventType.REMOTE_HANG_UP)
+                        end
+
+                        if (ev.events & EPOLLHUP) != 0
+                            event_mask |= Int(IoEventType.CLOSED)
+                        end
+
+                        if (ev.events & EPOLLERR) != 0
+                            event_mask |= Int(IoEventType.ERROR)
+                        end
+
+                        if event_data.is_subscribed
+                            logf(
+                                LogLevel.TRACE,
+                                LS_IO_EVENT_LOOP,
+                                "activity on fd $(event_data.handle.fd) invoking handler",
+                            )
+                            try
+                                event_data.on_event(event_mask)
+                            catch e
+                                if e isa ReseauError &&
                                     (e.code == ERROR_IO_SOCKET_CLOSED ||
-                                     e.code == ERROR_IO_SOCKET_NOT_CONNECTED ||
-                                     e.code == ERROR_IO_READ_WOULD_BLOCK)
-                                logf(
-                                    LogLevel.DEBUG,
-                                    LS_IO_EVENT_LOOP,string("ignoring non-fatal IO callback error on fd %d: %d", " ", event_data.handle.fd, " ", e.code, " ", ))
-                            else
-                                rethrow()
+                                    e.code == ERROR_IO_SOCKET_NOT_CONNECTED ||
+                                    e.code == ERROR_IO_READ_WOULD_BLOCK)
+                                    logf(
+                                        LogLevel.DEBUG,
+                                        LS_IO_EVENT_LOOP,
+                                        "ignoring non-fatal IO callback error during event dispatch: $(e.code)",
+                                    )
+                                else
+                                    logf(LogLevel.ERROR, LS_IO_EVENT_LOOP, "unhandled IO callback exception during event dispatch: $e")
+                                end
                             end
                         end
+                    finally
+                        tracing_task_end(tracing_event_loop_event)
                     end
+                end
+                if event_count > 0
+                    tracing_task_end(tracing_event_loop_events)
+                end
+
+                # Process cross-thread tasks
+                process_task_pre_queue(event_loop)
+
+                # Run scheduled tasks
+                now_ns = try
+                    clock_now_ns(event_loop.clock)
+                catch
+                    UInt64(0)
+                end
+
+                logf(LogLevel.TRACE, LS_IO_EVENT_LOOP, "running scheduled tasks")
+                tracing_task_begin(tracing_event_loop_run_tasks)
+                try
+                    lock(impl.task_pre_queue_mutex)
+                    try
+                        task_scheduler_run_all!(impl.scheduler, now_ns)
+                    finally
+                        unlock(impl.task_pre_queue_mutex)
+                    end
+                catch e
+                    logf(LogLevel.ERROR, LS_IO_EVENT_LOOP, "unhandled scheduled-task exception in main loop: $e")
                 finally
-                    tracing_task_end(tracing_event_loop_event)
-                end
-            end
-            if event_count > 0
-                tracing_task_end(tracing_event_loop_events)
-            end
-
-            # Process cross-thread tasks
-            process_task_pre_queue(event_loop)
-
-            # Run scheduled tasks
-            now_ns = try
-                clock_now_ns(event_loop.clock)
-            catch
-                UInt64(0)
-            end
-
-            logf(LogLevel.TRACE, LS_IO_EVENT_LOOP, "running scheduled tasks")
-            tracing_task_begin(tracing_event_loop_run_tasks)
-            try
-                task_scheduler_run_all!(impl.scheduler, now_ns)
-            finally
-                tracing_task_end(tracing_event_loop_run_tasks)
-            end
-
-            # Calculate next timeout
-            use_default_timeout = false
-
-            try
-                now_ns = clock_now_ns(event_loop.clock)
-            catch
-                use_default_timeout = true
-            end
-
-            has_tasks, next_run_time = task_scheduler_has_tasks(impl.scheduler)
-            if !has_tasks
-                use_default_timeout = true
-            end
-
-            if use_default_timeout
-                logf(LogLevel.TRACE, LS_IO_EVENT_LOOP, "no more scheduled tasks using default timeout")
-                timeout = DEFAULT_TIMEOUT_MS
-            else
-                # Translate timestamp (in nanoseconds) to timeout (in milliseconds)
-                timeout_ns = next_run_time > now_ns ? next_run_time - now_ns : UInt64(0)
-                timeout_ms = timeout_ns ÷ 1_000_000
-
-                if timeout_ms > typemax(Cint)
-                    timeout_ms = typemax(Cint)
+                    tracing_task_end(tracing_event_loop_run_tasks)
                 end
 
-                logf(
-                    LogLevel.TRACE,
-                    LS_IO_EVENT_LOOP,string("detected more scheduled tasks with the next occurring at %d ns, using timeout of %d ms", " ", timeout_ns, " ", timeout_ms, " ", ))
-                timeout = Cint(timeout_ms)
+                # Calculate next timeout
+                use_default_timeout = false
+
+                try
+                    now_ns = clock_now_ns(event_loop.clock)
+                catch
+                    use_default_timeout = true
+                end
+
+                has_tasks, next_run_time = task_scheduler_has_tasks(impl.scheduler)
+                if !has_tasks
+                    use_default_timeout = true
+                end
+
+                if use_default_timeout
+                    logf(LogLevel.TRACE, LS_IO_EVENT_LOOP, "no more scheduled tasks using default timeout")
+                    timeout = DEFAULT_TIMEOUT_MS
+                else
+                    # Translate timestamp (in nanoseconds) to timeout (in milliseconds)
+                    timeout_ns = next_run_time > now_ns ? next_run_time - now_ns : UInt64(0)
+                    timeout_ms = timeout_ns ÷ 1_000_000
+
+                    if timeout_ms > typemax(Cint)
+                        timeout_ms = typemax(Cint)
+                    end
+
+                    logf(
+                        LogLevel.TRACE,
+                        LS_IO_EVENT_LOOP,
+                        string(
+                            "detected more scheduled tasks with the next occurring at %d ns, using timeout of %d ms",
+                            " ",
+                            timeout_ns,
+                            " ",
+                            timeout_ms,
+                            " ",
+                        ),
+                    )
+                    timeout = Cint(timeout_ms)
+                end
+
+                event_loop_register_tick_end!(event_loop)
             end
 
-            event_loop_register_tick_end!(event_loop)
+            logf(LogLevel.DEBUG, LS_IO_EVENT_LOOP, "exiting main loop")
+        finally
+            if subscribed_for_task_notifications
+                try
+                    event_loop_unsubscribe_from_io_events!(event_loop, impl.read_task_handle)
+                catch e
+                    logf(
+                        LogLevel.ERROR,
+                        LS_IO_EVENT_LOOP,
+                        "failed to unsubscribe task notification fd during epoll thread exit: $e",
+                    )
+                end
+            end
+
+            event_loop_thread_exit_s2n_cleanup!(event_loop)
+            @atomic impl.running_thread_id = UInt64(0)
+            impl.thread_state = EpollEventThreadState.READY_TO_RUN
+            impl.should_continue = false
+            impl.should_process_task_pre_queue = false
+            impl.stop_task = nothing
+            @atomic impl.stop_task_scheduled = false
+            @atomic event_loop.should_stop = false
+
+            LibAwsCal.aws_cal_thread_clean_up()
         end
-
-        logf(LogLevel.DEBUG, LS_IO_EVENT_LOOP, "exiting main loop")
-
-        # Unsubscribe from the task notification events
-        event_loop_unsubscribe_from_io_events!(event_loop, impl.read_task_handle)
-
-        event_loop_thread_exit_s2n_cleanup!(event_loop)
-
-        # Set thread ID back to NULL
-        @atomic impl.running_thread_id = UInt64(0)
-
-        LibAwsCal.aws_cal_thread_clean_up()
         return nothing
     end
 
@@ -713,46 +1047,110 @@
     function event_loop_complete_destroy!(event_loop::EventLoop)
         logf(LogLevel.INFO, LS_IO_EVENT_LOOP, "destroying event_loop")
         impl = event_loop.impl_data
+        destroy_error = nothing
 
-        # Stop and wait
-        event_loop_stop!(event_loop)
-        event_loop_wait_for_stop_completion!(event_loop)
+        try
+            # Stop and wait
+            event_loop_stop!(event_loop)
+            event_loop_wait_for_stop_completion!(event_loop)
 
-        # Set thread ID for cancellation callbacks
-        impl.thread_joined_to = UInt64(Base.Threads.threadid())
-        @atomic impl.running_thread_id = impl.thread_joined_to
+            # Set thread ID for cancellation callbacks
+            impl.thread_joined_to = UInt64(Base.Threads.threadid())
+            @atomic impl.running_thread_id = impl.thread_joined_to
 
-        # Clean up scheduler (cancels remaining tasks)
-        task_scheduler_clean_up!(impl.scheduler)
-
-        # Cancel tasks in pre-queue
-        while true
-            tasks_to_cancel = nothing
-            lock(impl.task_pre_queue_mutex)
+            # Clean up scheduler (cancels remaining tasks)
             try
-                isempty(impl.task_pre_queue) && break
-                tasks_to_cancel = impl.task_pre_queue
-                impl.task_pre_queue = ScheduledTask[]
+                task_scheduler_clean_up!(impl.scheduler)
+            catch e
+                logf(LogLevel.ERROR, LS_IO_EVENT_LOOP, "task scheduler cleanup errored during destroy: $e")
+                destroy_error = destroy_error === nothing ? e : destroy_error
+            end
+
+            # Cancel tasks in pre-queue
+            while true
+                tasks_to_cancel = nothing
+                lock(impl.task_pre_queue_mutex)
+                try
+                    isempty(impl.task_pre_queue) && break
+                    tasks_to_cancel = impl.task_pre_queue
+                    impl.task_pre_queue = ScheduledTask[]
+                finally
+                    unlock(impl.task_pre_queue_mutex)
+                end
+                for task in tasks_to_cancel
+                    try
+                        task_run!(task, TaskStatus.CANCELED)
+                    catch e
+                        logf(LogLevel.ERROR, LS_IO_EVENT_LOOP, "task cancellation callback errored during destroy: $e")
+                        destroy_error = destroy_error === nothing ? e : destroy_error
+                    end
+                end
+            end
+        catch e
+            logf(LogLevel.ERROR, LS_IO_EVENT_LOOP, "epoll event-loop destroy failed: $e")
+            destroy_error = destroy_error === nothing ? e : destroy_error
+        finally
+            # Close file descriptors
+            lock(impl.subscribed_handle_data_mutex)
+            try
+                empty!(impl.subscribed_handle_data)
             finally
-                unlock(impl.task_pre_queue_mutex)
+                unlock(impl.subscribed_handle_data_mutex)
             end
-            for task in tasks_to_cancel
-                task_run!(task, TaskStatus.CANCELED)
+            if impl.use_eventfd
+                read_task_fd = impl.read_task_handle.fd
+                write_task_fd = impl.write_task_handle.fd
+                if read_task_fd != write_task_fd && read_task_fd >= 0
+                    try
+                        @ccall close(read_task_fd::Cint)::Cint
+                    catch e
+                        destroy_error = destroy_error === nothing ? e : destroy_error
+                    end
+                end
+                if write_task_fd >= 0
+                    try
+                        @ccall close(write_task_fd::Cint)::Cint
+                    catch e
+                        destroy_error = destroy_error === nothing ? e : destroy_error
+                    end
+                end
+                impl.read_task_handle = IoHandle()
+                impl.write_task_handle = IoHandle()
+            else
+                read_task_fd = impl.read_task_handle.fd
+                write_task_fd = impl.write_task_handle.fd
+                if read_task_fd >= 0
+                    try
+                        @ccall close(read_task_fd::Cint)::Cint
+                    catch e
+                        destroy_error = destroy_error === nothing ? e : destroy_error
+                    end
+                end
+                if write_task_fd >= 0
+                    try
+                        @ccall close(write_task_fd::Cint)::Cint
+                    catch e
+                        destroy_error = destroy_error === nothing ? e : destroy_error
+                    end
+                end
+                impl.read_task_handle = IoHandle()
+                impl.write_task_handle = IoHandle()
             end
+
+            epoll_fd = impl.epoll_fd
+            if epoll_fd >= 0
+                try
+                    @ccall close(epoll_fd::Cint)::Cint
+                catch e
+                    destroy_error = destroy_error === nothing ? e : destroy_error
+                end
+            end
+            impl.epoll_fd = Int32(-1)
+
+            _event_loop_clean_up_shared_resources!(event_loop)
         end
 
-        # Close file descriptors
-        if impl.use_eventfd
-            @ccall close(impl.write_task_handle.fd::Cint)::Cint
-        else
-            @ccall close(impl.read_task_handle.fd::Cint)::Cint
-            @ccall close(impl.write_task_handle.fd::Cint)::Cint
-        end
-
-        @ccall close(impl.epoll_fd::Cint)::Cint
-
-        _event_loop_clean_up_shared_resources!(event_loop)
-
+        destroy_error === nothing || throw(destroy_error)
         return nothing
     end
 

--- a/src/eventloops/iocp_event_loop.jl
+++ b/src/eventloops/iocp_event_loop.jl
@@ -324,7 +324,19 @@
                     # Note: Internal is an NTSTATUS-style status code (0 on success).
                     status_code = Int(entry.Internal)
                     bytes = Csize_t(entry.dwNumberOfBytesTransferred)
-                    cb(event_loop, op, status_code, bytes)
+                    try
+                        cb(event_loop, op, status_code, bytes)
+                    catch e
+                        logf(
+                            LogLevel.ERROR,
+                            LS_IO_EVENT_LOOP,
+                            "unhandled IOCP completion callback exception on fd ",
+                            Int(impl.iocp_handle),
+                            ": ",
+                            e,
+                            " ",
+                        )
+                    end
                 end
             else
                 # Timeout is a normal condition.

--- a/src/eventloops/kqueue_event_loop.jl
+++ b/src/eventloops/kqueue_event_loop.jl
@@ -870,7 +870,37 @@
                     logf(
                         LogLevel.TRACE,
                         LS_IO_EVENT_LOOP,string("activity on fd %d, invoking handler", " ", handle_data.owner.fd, " ", ))
-                    handle_data.on_event(handle_data.events_this_loop)
+                    try
+                        handle_data.on_event(handle_data.events_this_loop)
+                    catch e
+                        if e isa ReseauError &&
+                            (e.code == ERROR_IO_SOCKET_CLOSED ||
+                            e.code == ERROR_IO_SOCKET_NOT_CONNECTED ||
+                            e.code == ERROR_IO_READ_WOULD_BLOCK)
+                            logf(
+                                LogLevel.DEBUG,
+                                LS_IO_EVENT_LOOP,
+                                string(
+                                    "ignoring non-fatal IO callback error on fd %d: %d",
+                                    " ",
+                                    handle_data.owner.fd,
+                                    " ",
+                                    e.code,
+                                    " ",
+                                ),
+                            )
+                        else
+                            logf(
+                                LogLevel.ERROR,
+                                LS_IO_EVENT_LOOP,
+                                "unhandled IO callback exception on fd ",
+                                handle_data.owner.fd,
+                                ": ",
+                                e,
+                                " ",
+                            )
+                        end
+                    end
                 end
                 handle_data.events_this_loop = 0
             end

--- a/src/foreign_threads.jl
+++ b/src/foreign_threads.jl
@@ -141,7 +141,13 @@ macro wrap_thread_fn(fndef)
                 _ = thread_id
                 $(esc(body))
             catch e
-                Core.println("foreign thread ($thread_id) errored")
+                bt = catch_backtrace()
+                Core.print("foreign thread ($thread_id) errored: ")
+                Base.showerror(Core.stdout, e, bt)
+                Core.println()
+                if bt !== nothing
+                    Base.show_backtrace(Core.stdout, bt)
+                end
             end
             return C_NULL
         end

--- a/src/sockets/io/posix_socket_types.jl
+++ b/src/sockets/io/posix_socket_types.jl
@@ -24,8 +24,10 @@ mutable struct PosixSocket
     written_task::Union{ScheduledTask, Nothing}  # nullable
     connect_args::Union{PosixSocketConnectArgs, Nothing}  # nullable
     written_task_scheduled::Bool
+    has_pending_readable_event::Bool
     currently_subscribed::Bool
     continue_accept::Bool
+    accept_retry_task::Union{ScheduledTask, Nothing}  # nullable
     close_happened::Union{Ref{Bool}, Nothing}  # nullable
     on_close_complete::Union{TaskFn, Nothing}
     on_cleanup_complete::Union{TaskFn, Nothing}
@@ -40,6 +42,8 @@ function PosixSocket()
         false,
         false,
         false,
+        false,
+        nothing,
         nothing,
         nothing,
         nothing,

--- a/src/task_scheduler.jl
+++ b/src/task_scheduler.jl
@@ -528,7 +528,14 @@ function task_scheduler_cancel!(scheduler::TaskScheduler, task::ScheduledTask)
     if !removed
         removed = remove!(scheduler.timed, task; eq = (===))
     end
-    task_run!(task, TaskStatus.CANCELED)
+
+    # Only report cancellation when the task is actually tracked and removed.
+    # This avoids duplicate/invalid status transitions when cancel is called
+    # repeatedly after the task already completed or was never queued.
+    if removed
+        task_run!(task, TaskStatus.CANCELED)
+    end
+
     return nothing
 end
 

--- a/test/common_tests.jl
+++ b/test/common_tests.jl
@@ -59,9 +59,14 @@ end
         end);
         type_tag = "task_cancel",
     )
+    Reseau.task_scheduler_schedule_now!(scheduler, task)
     Reseau.task_scheduler_cancel!(scheduler, task)
     @test Base.timedwait(() -> isready(status_ch), 5.0) == :ok
     @test take!(status_ch) == Reseau.TaskStatus.CANCELED
+
+    # Cancelling again after removal should be idempotent.
+    Reseau.task_scheduler_cancel!(scheduler, task)
+    @test Base.timedwait(() -> isready(status_ch), 0.05) == :timed_out
 end
 
 @testset "TaskScheduler fairness" begin


### PR DESCRIPTION
Cherry-picking jq-epoll-event-loop PR-23 commits one-by-one and validating Linux/Windows/Mac CI at each step.\n\n- Tracks progress in \n- Starts from commit  (first unique commit in PR-23 vs main)\n- Stops at first failing commit for regression fix before continuing