### PR TITLE
Refactor channel slot dispatch and switch trim compile flow to JuliaC

### DIFF
--- a/src/eventloops/io.jl
+++ b/src/eventloops/io.jl
@@ -228,9 +228,6 @@ end
 
 io_handle_is_valid(handle::IoHandle) = handle.fd >= 0 || handle.handle != C_NULL
 
-# Forward declarations for types defined in other io files
-abstract type AbstractChannelHandler end
-
 # IO Message - data unit flowing through channel pipeline
 mutable struct IoMessage
     message_data::ByteBuffer

--- a/src/sockets/io/alpn_handler.jl
+++ b/src/sockets/io/alpn_handler.jl
@@ -1,7 +1,7 @@
 # AWS IO Library - ALPN Handler
 # Port of aws-c-io/source/alpn_handler.c
 
-mutable struct AlpnHandler <: AbstractChannelHandler
+mutable struct AlpnHandler
     slot::Union{ChannelSlot, Nothing}
     on_protocol_negotiated::Union{ProtocolNegotiatedCallable, Nothing}
 end
@@ -42,13 +42,13 @@ function handler_process_read_message(handler::AlpnHandler, slot::ChannelSlot, m
         throw_error(ERROR_IO_MISSING_ALPN_MESSAGE)
     end
     protocol_str = byte_buffer_as_string(protocol)
-    chan = slot.channel
+    chan = slot_channel_or_nothing(slot)
     chan_id = chan === nothing ? -1 : chan.channel_id
     logf(
         LogLevel.DEBUG,
         LS_IO_ALPN,string("ALPN negotiated protocol: %s (channel %d)", " ", string(isempty(protocol_str) ? "<empty>" : protocol_str), " ", string(chan_id), " ", ))
 
-    channel = slot.channel
+    channel = slot_channel_or_nothing(slot)
     if channel === nothing
         throw_error(ERROR_IO_CHANNEL_ERROR_CANT_ACCEPT_INPUT)
     end

--- a/src/sockets/io/apple_nw_socket_impl.jl
+++ b/src/sockets/io/apple_nw_socket_impl.jl
@@ -1664,6 +1664,7 @@
             nothing,
             nothing,
             nothing,
+            nothing,
             nw_socket,
         )
 

--- a/src/sockets/io/posix_socket_impl.jl
+++ b/src/sockets/io/posix_socket_impl.jl
@@ -406,6 +406,7 @@ function socket_init_posix(
         nothing,  # readable_fn
         nothing,  # connection_result_fn
         nothing,  # accept_result_fn
+        nothing,  # read_fn
         socket_impl,
     )
 

--- a/src/sockets/io/socket.jl
+++ b/src/sockets/io/socket.jl
@@ -242,7 +242,7 @@ mutable struct Socket
     options::SocketOptions
     io_handle::IoHandle
     event_loop::Union{EventLoop, Nothing}
-    handler::Union{AbstractChannelHandler, Nothing}
+    handler::Any
     state::SocketState.T
     readable_fn::Union{EventCallable, Nothing}
     connection_result_fn::Union{EventCallable, Nothing}

--- a/src/sockets/io/socket.jl
+++ b/src/sockets/io/socket.jl
@@ -247,6 +247,7 @@ mutable struct Socket
     readable_fn::Union{EventCallable, Nothing}
     connection_result_fn::Union{EventCallable, Nothing}
     accept_result_fn::Union{ChannelCallable, Nothing}
+    read_fn::Any
     impl::Union{PlatformSocketImpl, Nothing}
 end
 

--- a/src/sockets/io/socket_channel_handler.jl
+++ b/src/sockets/io/socket_channel_handler.jl
@@ -475,8 +475,8 @@ function socket_channel_handler_new!(
     # Link handler to the socket
     socket.handler = handler
     channel.socket = socket
-    if channel.downstream_read_handler isa _PipelineDownstreamReadHandler
-        socket.read_fn = channel.downstream_read_handler.read_fn
+    if channel.downstream isa _PipelineDownstreamState
+        socket.read_fn = channel.downstream.handler.read_fn
     end
 
     _socket_handler_wrap_channel_setup!(handler, channel)

--- a/src/sockets/io/socket_channel_handler.jl
+++ b/src/sockets/io/socket_channel_handler.jl
@@ -475,6 +475,9 @@ function socket_channel_handler_new!(
     # Link handler to the socket
     socket.handler = handler
     channel.socket = socket
+    if channel.downstream_read_handler isa _PipelineDownstreamReadHandler
+        socket.read_fn = channel.downstream_read_handler.read_fn
+    end
 
     _socket_handler_wrap_channel_setup!(handler, channel)
 

--- a/src/sockets/io/tls_channel_handler.jl
+++ b/src/sockets/io/tls_channel_handler.jl
@@ -1716,6 +1716,7 @@ function tls_channel_handler_new!(
 
     channel_slot_insert_right!(channel.last, tls_slot)
     channel_slot_set_handler!(tls_slot, handler)
+    channel.tls_handler = handler
 
     return handler
 end
@@ -1734,6 +1735,7 @@ function channel_setup_client_tls(
 
     channel_slot_insert_right!(right_of_slot, tls_slot)
     channel_slot_set_handler!(tls_slot, handler)
+    channel.tls_handler = handler
 
     tls_client_handler_start_negotiation(handler)
 

--- a/src/sockets/io/tls_channel_handler.jl
+++ b/src/sockets/io/tls_channel_handler.jl
@@ -1486,9 +1486,6 @@ struct TlsNegotiatedProtocolMessage
     protocol::ByteBuffer
 end
 
-# TLS handler base type
-abstract type TlsChannelHandler end
-
 function _tls_timeout_task(handler, status::TaskStatus.T)
     status == TaskStatus.RUN_READY || return nothing
     handler isa TlsChannelHandler || return nothing

--- a/src/sockets/io/tls_types.jl
+++ b/src/sockets/io/tls_types.jl
@@ -5,6 +5,7 @@
 
 abstract type AbstractTlsContext end
 abstract type AbstractTlsConnectionOptions end
+abstract type TlsChannelHandler end
 
 const MaybeTlsConnectionOptions = Union{AbstractTlsConnectionOptions, Nothing}
 

--- a/src/sockets/io/winsock_socket.jl
+++ b/src/sockets/io/winsock_socket.jl
@@ -346,6 +346,7 @@
             nothing,
             nothing,
             nothing,
+            nothing,
             impl,
         )
 

--- a/test/channel_tests.jl
+++ b/test/channel_tests.jl
@@ -108,10 +108,10 @@ end
             end
 
             deadline = Base.time_ns() + 1_000_000_000
-            while channel.channel_state != Sockets.ChannelState.SHUT_DOWN && Base.time_ns() < deadline
+            while channel.channel_state != Sockets.ChannelLifecycleState.SHUT_DOWN && Base.time_ns() < deadline
                 yield()
             end
-            @test channel.channel_state == Sockets.ChannelState.SHUT_DOWN
+            @test channel.channel_state == Sockets.ChannelLifecycleState.SHUT_DOWN
 
             EventLoops.event_loop_destroy!(el)
         end

--- a/test/io_testing_channel_tests.jl
+++ b/test/io_testing_channel_tests.jl
@@ -1,7 +1,7 @@
 using Test
 using Reseau
 
-mutable struct TestingChannelHandler{SlotRef <: Union{Sockets.ChannelSlot, Nothing}} <: Sockets.AbstractChannelHandler
+mutable struct TestingChannelHandler{SlotRef <: Union{Sockets.ChannelSlot, Nothing}}
     slot::SlotRef
     messages::Vector{EventLoops.IoMessage}
     latest_window_update::Csize_t
@@ -38,7 +38,13 @@ function Sockets.handler_process_write_message(
     )
     push!(handler.messages, message)
     if handler.complete_write_immediately && message.on_completion !== nothing && slot.adj_left === nothing
-        Base.invokelatest(message.on_completion, slot.channel, message, handler.complete_write_error_code, message.user_data)
+        Base.invokelatest(
+            message.on_completion,
+            Sockets.slot_channel_or_nothing(slot),
+            message,
+            handler.complete_write_error_code,
+            message.user_data,
+        )
         message.on_completion = nothing
     end
     return nothing

--- a/test/socket_handler_tests.jl
+++ b/test/socket_handler_tests.jl
@@ -13,7 +13,7 @@ function wait_for(predicate; timeout_s::Float64 = 5.0)
     return false
 end
 
-mutable struct TestReadHandler <: Sockets.AbstractChannelHandler
+mutable struct TestReadHandler
     slot::Union{Sockets.ChannelSlot, Nothing}
     received::Vector{UInt8}
     lock::ReentrantLock
@@ -36,9 +36,8 @@ function Sockets.handler_process_read_message(handler::TestReadHandler, slot::So
         Sockets.channel_slot_increment_read_window!(slot, message.message_data.len)
     end
 
-    if slot.channel !== nothing
-        Sockets.channel_release_message_to_pool!(slot.channel, message)
-    end
+    channel = Sockets.slot_channel_or_nothing(slot)
+    channel !== nothing && Sockets.channel_release_message_to_pool!(channel, message)
     return nothing
 end
 

--- a/test/statistics_tests.jl
+++ b/test/statistics_tests.jl
@@ -10,7 +10,7 @@ function _wait_ready_stats(ch::Channel; timeout_ns::Integer = 5_000_000_000)
     return isready(ch)
 end
 
-mutable struct TestStatsChannelHandler <: Sockets.AbstractChannelHandler
+mutable struct TestStatsChannelHandler
     stats::Sockets.SocketHandlerStatistics
 end
 

--- a/trim/AGENTS.md
+++ b/trim/AGENTS.md
@@ -1,6 +1,6 @@
 # Trim Echo Goal
 
-This directory is for validating a fully compiled executable using Julia's `juliac` flow with safe trimming.
+This directory validates a fully compiled executable using the official `JuliaC.jl` CLI with safe trimming.
 
 ## Objective
 
@@ -24,12 +24,24 @@ Expected behavior of the script:
 Run from the repository root:
 
 ```sh
-JULIA_NUM_THREADS=1 julia --startup-file=no --history-file=no \
-  ~/julia/contrib/juliac/juliac.jl \
-  --output-exe trim/echo_trim_safe \
-  --project=. \
+trim/compile_echo_trim_safe.sh
+```
+
+The helper script:
+
+- installs `JuliaC` in `@v1.12` if missing
+- runs `julia -m JuliaC` from `trim/`
+- writes verifier output to `/tmp/reseau_trim_verify_latest.log` by default
+
+Direct equivalent command:
+
+```sh
+cd trim
+JULIA_NUM_THREADS=1 julia --startup-file=no --history-file=no --project=@v1.12 -m JuliaC \
+  --output-exe echo_trim_safe \
+  --project=.. \
   --experimental --trim=safe \
-  trim/echo_trim_safe.jl
+  echo_trim_safe.jl
 ```
 
 ## What To Report

--- a/trim/compile_echo_trim_safe.sh
+++ b/trim/compile_echo_trim_safe.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_PATH="${1:-/tmp/reseau_trim_verify_latest.log}"
+JULIA_BIN="${JULIA_BIN:-julia}"
+
+# Install JuliaC once in the default Julia 1.12 environment if needed.
+"$JULIA_BIN" --startup-file=no --history-file=no --project=@v1.12 -e 'using JuliaC' >/dev/null 2>&1 || \
+    "$JULIA_BIN" --startup-file=no --history-file=no --project=@v1.12 -e 'using Pkg; Pkg.add("JuliaC")'
+
+cd "$ROOT_DIR/trim"
+JULIA_NUM_THREADS="${JULIA_NUM_THREADS:-1}" "$JULIA_BIN" \
+    --startup-file=no --history-file=no --project=@v1.12 -m JuliaC \
+    --output-exe echo_trim_safe \
+    --project=.. \
+    --experimental --trim=safe \
+    echo_trim_safe.jl >"$LOG_PATH" 2>&1

--- a/trim/current_state.md
+++ b/trim/current_state.md
@@ -39,7 +39,7 @@ JULIA_NUM_THREADS=1 julia --startup-file=no --history-file=no --project=@v1.12 -
 ## Current Result (2026-02-15)
 
 - Compile still fails under trim verifier.
-- Current verifier set: `130` errors, `0` warnings.
+- Current verifier set: `129` errors, `0` warnings.
 - Latest log: `/tmp/reseau_trim_verify_latest.log`.
 - No executable emitted.
 

--- a/trim/current_state.md
+++ b/trim/current_state.md
@@ -51,17 +51,16 @@ JULIA_NUM_THREADS=1 julia --startup-file=no --history-file=no --project=@v1.12 -
   - `src/eventloops/epoll_event_loop.jl` (`Base.showerror(...)`)
 - These produce a large cluster of Base stacktrace/printing verifier failures (#1 through most of the early set).
 
-2. Channel/socket state still has dynamic `Any` access in trim-reached paths.
-- Representative failures:
-  - `downstream_read_handler::Any` property access (`socket_channel_handler_new!`)
-  - `socket.handler::Any` and nested `stats` property access during write completion
-  - resolver `impl_data::Any` callback invocation path
+2. Remaining trim blockers in I/O paths are now outside `ChannelState`.
+- `ChannelState` no longer carries `downstream_*::Any` or `tls_handler::Any` fields.
+- Representative remaining failures:
+  - `socket.handler::Any` and nested `stats` access during socket write completion
+  - resolver callback plumbing with `impl_data::Any`
 
-3. Remaining unresolved invokes across channel bootstrap and socket handler trigger paths.
+3. Remaining unresolved invokes across channel bootstrap and socket-handler trigger paths.
 - Representative failures:
   - `_setup_client_channel(...)`
   - `_socket_handler_trigger_read(...)`
-  - `channel_slot_increment_read_window!(..., size::Any)`
 
 ## Validation Run Context
 


### PR DESCRIPTION
## Summary
- refactor channel internals to carry shared state in `ChannelState` and remove direct dynamic handler dispatch from `ChannelSlot`
- add pipeline facade compatibility on top of the refactored channel state so downstream `AwsHTTP`/`HTTP` usages keep working
- switch trim echo compilation from `julia/contrib/juliac.jl` to official `JuliaC.jl` (`julia -m JuliaC`), add `trim/compile_echo_trim_safe.sh`, and rewrite `trim/current_state.md`

## Validation
- `JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'` (Reseau)
- `RESEAU_RUN_TLS_TESTS=1 RESEAU_RUN_NETWORK_TESTS=1 JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'` (Reseau)
- `JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'` (AwsHTTP)
- `JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'` (HTTP)
- `trim/compile_echo_trim_safe.sh /tmp/reseau_trim_verify_latest.log` (expected trim verifier failure, documented in `trim/current_state.md`)
