### PR TITLE
refactor(channel): remove AbstractChannelHandler and slot.handler

### DIFF
--- a/src/eventloops/io.jl
+++ b/src/eventloops/io.jl
@@ -228,9 +228,6 @@ end
 
 io_handle_is_valid(handle::IoHandle) = handle.fd >= 0 || handle.handle != C_NULL
 
-# Forward declarations for types defined in other io files
-abstract type AbstractChannelHandler end
-
 # IO Message - data unit flowing through channel pipeline
 mutable struct IoMessage
     message_data::ByteBuffer

--- a/src/foreign_threads.jl
+++ b/src/foreign_threads.jl
@@ -140,14 +140,8 @@ macro wrap_thread_fn(fndef)
             try
                 _ = thread_id
                 $(esc(body))
-            catch e
-                bt = catch_backtrace()
-                Core.print("foreign thread ($thread_id) errored: ")
-                Base.showerror(Core.stdout, e, bt)
-                Core.println()
-                if bt !== nothing
-                    Base.show_backtrace(Core.stdout, bt)
-                end
+            catch
+                Core.println("foreign thread ($thread_id) errored")
             end
             return C_NULL
         end

--- a/src/sockets/io/alpn_handler.jl
+++ b/src/sockets/io/alpn_handler.jl
@@ -1,7 +1,7 @@
 # AWS IO Library - ALPN Handler
 # Port of aws-c-io/source/alpn_handler.c
 
-mutable struct AlpnHandler <: AbstractChannelHandler
+mutable struct AlpnHandler
     slot::Union{ChannelSlot, Nothing}
     on_protocol_negotiated::Union{ProtocolNegotiatedCallable, Nothing}
 end

--- a/src/sockets/io/apple_nw_socket_impl.jl
+++ b/src/sockets/io/apple_nw_socket_impl.jl
@@ -1659,7 +1659,6 @@
             copy(options),
             IoHandle(),
             nothing,
-            nothing,
             SocketState.INIT,
             nothing,
             nothing,

--- a/src/sockets/io/channel_bootstrap.jl
+++ b/src/sockets/io/channel_bootstrap.jl
@@ -618,7 +618,7 @@ function _initiate_socket_connect(request::R, address::HostAddress) where {R <: 
 end
 
 # Callback when socket connect completes
-function _on_socket_connect_complete(socket::Socket, error_code::Int, attempt::SocketConnectionAttempt)
+function _on_socket_connect_complete(socket::Socket, error_code::Int, attempt::SocketConnectionAttempt)::Nothing
     request = attempt.request
 
     if error_code != AWS_OP_SUCCESS
@@ -658,7 +658,7 @@ function _on_socket_connect_complete(socket::Socket, error_code::Int, attempt::S
     request.socket = socket
 
     # Create channel for this connection
-    _setup_client_channel(request)
+    _setup_client_channel(request)::Nothing
 
     return nothing
 end

--- a/src/sockets/io/posix_socket_impl.jl
+++ b/src/sockets/io/posix_socket_impl.jl
@@ -401,7 +401,6 @@ function socket_init_posix(
         copy(options),
         io_handle,
         nothing,  # event_loop
-        nothing,  # handler
         SocketState.INIT,
         nothing,  # readable_fn
         nothing,  # connection_result_fn

--- a/src/sockets/io/socket.jl
+++ b/src/sockets/io/socket.jl
@@ -242,7 +242,6 @@ mutable struct Socket
     options::SocketOptions
     io_handle::IoHandle
     event_loop::Union{EventLoop, Nothing}
-    handler::Any
     state::SocketState.T
     readable_fn::Union{EventCallable, Nothing}
     connection_result_fn::Union{EventCallable, Nothing}

--- a/src/sockets/io/socket.jl
+++ b/src/sockets/io/socket.jl
@@ -242,7 +242,7 @@ mutable struct Socket
     options::SocketOptions
     io_handle::IoHandle
     event_loop::Union{EventLoop, Nothing}
-    handler::Union{AbstractChannelHandler, Nothing}
+    handler::Any
     state::SocketState.T
     readable_fn::Union{EventCallable, Nothing}
     connection_result_fn::Union{EventCallable, Nothing}

--- a/src/sockets/io/tls_channel_handler.jl
+++ b/src/sockets/io/tls_channel_handler.jl
@@ -142,9 +142,9 @@ function _tls_byo_new_handler(
         setup::TlsByoCryptoSetupOptions,
         options,
         slot::ChannelSlot,
-    )::AbstractChannelHandler
+    )
     handler = setup.new_handler_fn(options, slot, setup.user_data)
-    if !(handler isa AbstractChannelHandler)
+    if handler === nothing
         throw_error(ERROR_INVALID_STATE)
     end
     channel_slot_set_handler!(slot, handler)
@@ -153,7 +153,7 @@ end
 
 function _tls_byo_start_negotiation(
         setup::TlsByoCryptoSetupOptions,
-        handler::AbstractChannelHandler,
+        handler,
     )::Nothing
     if setup.start_negotiation_fn === nothing
         throw_error(ERROR_INVALID_STATE)
@@ -1486,7 +1486,7 @@ struct TlsNegotiatedProtocolMessage
 end
 
 # TLS handler base type
-abstract type TlsChannelHandler <: AbstractChannelHandler end
+abstract type TlsChannelHandler end
 
 function _tls_timeout_task(handler, status::TaskStatus.T)
     status == TaskStatus.RUN_READY || return nothing
@@ -1604,7 +1604,7 @@ end
 function tls_client_handler_new(
         options::TlsConnectionOptions,
         slot::ChannelSlot,
-    )::AbstractChannelHandler
+    )
     if options.ctx.options.is_server
         throw_error(ERROR_INVALID_ARGUMENT)
     end
@@ -1625,7 +1625,7 @@ end
 function tls_server_handler_new(
         options::TlsConnectionOptions,
         slot::ChannelSlot,
-    )::AbstractChannelHandler
+    )
     if !options.ctx.options.is_server
         throw_error(ERROR_INVALID_ARGUMENT)
     end
@@ -1643,7 +1643,7 @@ function tls_server_handler_new(
     end
 end
 
-function tls_client_handler_start_negotiation(handler::AbstractChannelHandler)::Nothing
+function tls_client_handler_start_negotiation(handler)::Nothing
     if _tls_byo_client_setup[] !== nothing
         _tls_byo_start_negotiation(_tls_byo_client_setup[], handler)
         return nothing
@@ -1699,7 +1699,7 @@ end
 function tls_channel_handler_new!(
         channel::Channel,
         options::TlsConnectionOptions,
-    )::AbstractChannelHandler
+    )
     channel.last === nothing && throw_error(ERROR_INVALID_STATE)
 
     tls_slot = ChannelSlot()
@@ -1718,7 +1718,7 @@ end
 function channel_setup_client_tls(
         right_of_slot::ChannelSlot,
         options::TlsConnectionOptions,
-    )::AbstractChannelHandler
+    )
     channel = right_of_slot.channel
     channel === nothing && throw_error(ERROR_INVALID_STATE)
 

--- a/src/sockets/io/winsock_socket.jl
+++ b/src/sockets/io/winsock_socket.jl
@@ -341,7 +341,6 @@
             copy(options),
             IoHandle(),
             nothing,
-            nothing,
             SocketState.INIT,
             nothing,
             nothing,

--- a/src/sockets/tcp.jl
+++ b/src/sockets/tcp.jl
@@ -13,7 +13,7 @@ mutable struct TCPSocket <: IO
     channel::Union{Channel, Nothing}
     slot::Union{ChannelSlot{Union{Channel, Nothing}}, Nothing}
     socket::Union{Socket, Nothing}
-    handler::Union{AbstractChannelHandler, Nothing}
+    handler::Any
     host::String
     port::Int
     is_local::Bool
@@ -37,7 +37,7 @@ mutable struct TCPSocket <: IO
     connect_error::Int
 end
 
-mutable struct _TCPSocketHandler <: AbstractChannelHandler
+mutable struct _TCPSocketHandler
     slot::Union{ChannelSlot{Union{Channel, Nothing}}, Nothing}
     io::TCPSocket
 end
@@ -134,10 +134,7 @@ function _install_handler!(io::TCPSocket, channel::Channel)::Nothing
     io.channel = channel
     io.slot = slot
     io.handler = handler
-    first_slot = channel_first_slot(channel)
-    if first_slot !== nothing && first_slot.handler isa SocketChannelHandler
-        io.socket = socket_channel_handler_get_socket(first_slot.handler)
-    end
+    io.socket = channel.socket
     channel.channel_state == ChannelState.ACTIVE && channel_trigger_read(channel)
     return nothing
 end

--- a/src/sockets/tcp.jl
+++ b/src/sockets/tcp.jl
@@ -13,7 +13,6 @@ mutable struct TCPSocket <: IO
     channel::Union{Channel, Nothing}
     slot::Union{ChannelSlot{Union{Channel, Nothing}}, Nothing}
     socket::Union{Socket, Nothing}
-    handler::Any
     host::String
     port::Int
     is_local::Bool
@@ -89,7 +88,6 @@ function _new_unconnected_socket(;
         nothing,
         nothing,
         nothing,
-        nothing,
         "",
         0,
         false,
@@ -133,7 +131,6 @@ function _install_handler!(io::TCPSocket, channel::Channel)::Nothing
     channel_slot_set_handler!(slot, handler)
     io.channel = channel
     io.slot = slot
-    io.handler = handler
     io.socket = channel.socket
     channel.channel_state == ChannelState.ACTIVE && channel_trigger_read(channel)
     return nothing

--- a/test/io_testing_channel_tests.jl
+++ b/test/io_testing_channel_tests.jl
@@ -1,7 +1,7 @@
 using Test
 using Reseau
 
-mutable struct TestingChannelHandler{SlotRef <: Union{Sockets.ChannelSlot, Nothing}} <: Sockets.AbstractChannelHandler
+mutable struct TestingChannelHandler{SlotRef <: Union{Sockets.ChannelSlot, Nothing}}
     slot::SlotRef
     messages::Vector{EventLoops.IoMessage}
     latest_window_update::Csize_t

--- a/test/read_write_test_handler.jl
+++ b/test/read_write_test_handler.jl
@@ -1,6 +1,6 @@
 using Reseau
 
-mutable struct ReadWriteTestHandler{FRead, FWrite, SlotRef <: Union{Sockets.ChannelSlot, Nothing}} <: Sockets.AbstractChannelHandler
+mutable struct ReadWriteTestHandler{FRead, FWrite, SlotRef <: Union{Sockets.ChannelSlot, Nothing}}
     slot::SlotRef
     on_read::FRead
     on_write::FWrite

--- a/test/socket_handler_tests.jl
+++ b/test/socket_handler_tests.jl
@@ -403,7 +403,6 @@ end
     end
     if accepted_socket[] isa Sockets.Socket
         @test socket_handler.socket === accepted_socket[]
-        @test socket_handler.socket.handler === socket_handler
     end
 
     send_done = Ref(false)

--- a/test/socket_handler_tests.jl
+++ b/test/socket_handler_tests.jl
@@ -13,7 +13,7 @@ function wait_for(predicate; timeout_s::Float64 = 5.0)
     return false
 end
 
-mutable struct TestReadHandler <: Sockets.AbstractChannelHandler
+mutable struct TestReadHandler
     slot::Union{Sockets.ChannelSlot, Nothing}
     received::Vector{UInt8}
     lock::ReentrantLock

--- a/test/statistics_tests.jl
+++ b/test/statistics_tests.jl
@@ -10,7 +10,7 @@ function _wait_ready_stats(ch::Channel; timeout_ns::Integer = 5_000_000_000)
     return isready(ch)
 end
 
-mutable struct TestStatsChannelHandler <: Sockets.AbstractChannelHandler
+mutable struct TestStatsChannelHandler
     stats::Sockets.SocketHandlerStatistics
 end
 

--- a/test/tls_tests_impl.jl
+++ b/test/tls_tests_impl.jl
@@ -818,7 +818,7 @@ end
     EventLoops.event_loop_group_destroy!(elg)
 end
 
-mutable struct EchoHandler <: Sockets.AbstractChannelHandler
+mutable struct EchoHandler
     slot::Union{Sockets.ChannelSlot, Nothing}
     saw_ping::Base.RefValue{Bool}
 end
@@ -991,7 +991,7 @@ end
 
     tls_opts = Sockets.TlsConnectionOptions(ctx; server_name = "example.com")
     handler = Sockets.channel_setup_client_tls(left_slot, tls_opts)
-    @test handler isa Sockets.AbstractChannelHandler
+    @test handler !== nothing
     @test new_called[]
     @test start_called[]
     @test seen_slot[] === left_slot.adj_right
@@ -1015,7 +1015,7 @@ end
                 Sockets.TlsConnectionOptions(server_ctx),
                 server_slot,
             )
-            @test server_handler isa Sockets.AbstractChannelHandler
+            @test server_handler !== nothing
             @test server_new_called[]
             @test server_seen_slot[] === server_slot
             @test server_seen_ud[] == 99
@@ -2648,7 +2648,7 @@ end
         return isready(ch)
     end
 
-    mutable struct FakeSocketStatsHandler <: Sockets.AbstractChannelHandler
+    mutable struct FakeSocketStatsHandler
         stats::Sockets.SocketHandlerStatistics
     end
 

--- a/trim/current_state.md
+++ b/trim/current_state.md
@@ -1,81 +1,92 @@
 # Current Trim State
 
+## Date
+
+2026-02-15
+
 ## Goal
 
-Build a fully compiled executable for a simple local TCP echo flow using only `Reseau` constructs, with:
+Compile `trim/echo_trim_safe.jl` as a trim-safe executable via `JuliaC.jl`.
 
-- `@main` entrypoint
-- `--experimental`
-- `--trim=safe`
-- `~/julia/contrib/juliac/juliac.jl`
+## Commands Used
 
-Echo flow in `trim/echo_trim_safe.jl`:
-
-1. Start `TCPServer` via `listenany(0)`.
-2. Connect a `TCPSocket` client.
-3. Client sends `"hello"`.
-4. Server reads and replies `"hello"`.
-5. Client verifies response.
-
-## Compile Command
+Compile + verifier capture:
 
 ```sh
-JULIA_NUM_THREADS=1 julia --startup-file=no --history-file=no \
-  ~/julia/contrib/juliac/juliac.jl \
-  --output-exe trim/echo_trim_safe \
+JULIA_NUM_THREADS=1 julia --startup-file=no --history-file=no --project -e 'using JuliaC; JuliaC.main(ARGS)' -- \
+  --output-exe echo_trim_safe \
   --project=. \
   --experimental --trim=safe \
-  trim/echo_trim_safe.jl
+  trim/echo_trim_safe.jl 2>&1 | tee /tmp/reseau_trim_verify_latest.log
 ```
 
-## Current Result (2026-02-12)
-
-- Compile still fails under trim verifier.
-- Current verifier set: `19` errors + `2` warnings.
-- Latest log: `/tmp/reseau_trim_verify_latest.log`.
-- Net from this pass: improved from `27` to `19` hard errors.
-- Kqueue event-loop verifier cluster is no longer present in current output.
-
-## Item-by-Item Status
-
-1. External JLL init (`aws_c_common_jll` / `JLLWrappers` sort/unique calls, verifier #1-#6)
-- Status: `PASS (for now)`
-- Reason: external package init path, not in Reseau-owned code.
-
-2. Kqueue event-loop paths (`kqueue_event_loop_thread`, `kqueue_* task callbacks`)
-- Status: `RESOLVED (for now)`
-- Result: no kqueue-specific verifier failures in `/tmp/reseau_trim_verify_latest.log`.
-
-3. `_ClientChannelOnSetup` callback invocation still unresolved under trim (verifier #7)
-- Status: `PASS (for now)`
-- Work attempted: moved setup logic into direct callable method body on `_ClientChannelOnSetup`.
-- Result: unresolved invoke remains.
-
-4. Host resolver callback/impl path (`_dispatch_resolve_callback`, `_invoke_resolver_impl`, `impl_data::Any`, verifier #8-#9)
-- Status: `PASS (for now)`
-- Work attempted: explored stronger callback typing; reverted because it introduced additional unresolved `@cfunction` verifier failures.
-- Result: unresolved dynamic path remains and appears structural (callback + `impl_data` representation).
-
-5. Channel handler vtable dispatch wrappers (`handler_process_*`, `handler_shutdown`, `handler_increment_read_window`, verifier #10-#12 and #17/#19 + warnings #1/#2)
-- Status: `PASS (for now)`
-- Work attempted: multiple callable-wrapper rewrites; best stable state still yields unresolved `f::Any` handler field access under trim.
-- Result: unresolved dynamic handler dispatch remains.
-
-6. Socket handler trigger-read path (`_socket_handler_trigger_read`, verifier #13-#16 and #18)
-- Status: `PASS (for now)`
-- Work attempted: tightened return types and removed `slot.channel::Any` usage in trigger path.
-- Result: unresolved invoke remains at callback callsites.
-
-## Changes Kept From This Iteration
-
-1. Re-ran trim verifier echo compile and refreshed `/tmp/reseau_trim_verify_latest.log`.
-2. Current branch still includes EventLoopGroup constructor cleanup (`event_loop_group_new` removal, keyword constructor usage).
-3. Updated kqueue handle typing to `KqueueHandleData{KqueueEventLoop}` with a concrete `handle_registry`, which removed the prior kqueue verifier cluster.
-
-## Validation Run
-
-Default Reseau tests were run and passed:
+Runtime script sanity:
 
 ```sh
-JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'
+JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no trim/echo_trim_safe.jl
 ```
+
+## Current Result
+
+- Compile status: `FAIL` (trim verifier blocks codegen)
+- Verifier totals: `16` errors, `2` warnings
+- Latest verifier log: `/tmp/reseau_trim_verify_latest.log`
+- Runtime script mode: `PASS`
+
+## What Improved This Iteration
+
+1. **Foreign-thread verifier explosion resolved**
+- Change: simplified exception handling in `src/foreign_threads.jl` to avoid `showerror/show_backtrace` in thread trampolines.
+- Impact: reduced verifier output from `124 errors + 2 warnings` to `16 errors + 2 warnings`.
+
+## Remaining Verifier Buckets
+
+1. **Socket connect impl dispatch in bootstrap attempts**
+- Symptoms: unresolved invokes for `socket_connect_impl(... NWSocket ...)` and `socket_connect_impl(... PosixSocket ...)`.
+- Call path: `socket_connect` -> `_initiate_socket_connect` in `src/sockets/io/channel_bootstrap.jl`.
+- Status: `OPEN`.
+- Notes: manual dispatch rewrite was attempted and reverted (it increased total verifier errors).
+
+2. **Client channel setup invocation**
+- Symptoms: unresolved invoke on `_setup_client_channel(...)` from `_on_socket_connect_complete(...)`.
+- Call path: `src/sockets/io/channel_bootstrap.jl`.
+- Status: `OPEN`.
+- Notes: return typing cleanup (`::Nothing`) did not resolve the verifier invoke.
+
+3. **Host resolver callback/impl indirection**
+- Symptoms:
+  - unresolved call `_dispatch_resolve_callback(...)`
+  - unresolved call `_invoke_resolver_impl(..., impl_data::Any)`
+- Call path: `src/sockets/io/host_resolver.jl`.
+- Status: `OPEN`.
+- Notes: likely requires redesign of callback/impl data typing; not a trivial local patch.
+
+4. **Channel handler callback wrappers (`_TCPSocketHandler`)**
+- Symptoms: unresolved calls for `handler_shutdown`, `handler_increment_read_window`, `handler_process_{read,write}` via `_ChannelSlot*CallWrapper`.
+- Call path: `src/sockets/io/channel.jl`.
+- Status: `OPEN`.
+- Notes: attempted callable-ref typing refactor increased verifier set and was reverted.
+
+5. **Socket handler read trigger callback chain**
+- Symptoms: unresolved invoke of `_socket_handler_trigger_read(...)` from readable/setup callback closures and handler dispatch wrappers.
+- Call path: `src/sockets/io/socket_channel_handler.jl`.
+- Status: `OPEN`.
+- Notes: appears coupled with channel handler dispatch/callback representation.
+
+## Attempted But Reverted (Regressed Verifier State)
+
+1. Typed `ChannelHandler*Callable` refactor in `src/sockets/io/channel.jl` (grew to `27 errors`).
+2. Manual `socket_connect` impl branch dispatch in `src/sockets/io/socket.jl` (grew to `18 errors`).
+
+Both were reverted in favor of the lower stable baseline (`16 errors, 2 warnings`).
+
+## Files Changed In This Iteration
+
+1. `src/foreign_threads.jl`
+2. `src/sockets/io/channel_bootstrap.jl`
+3. `trim/AGENTS.md`
+4. `trim/current_state.md`
+
+## Assessment
+
+The easy/high-impact trim win in this pass was eliminating backtrace-rendering from foreign thread wrappers. Remaining failures are concentrated in channel-handler callback indirection and bootstrap/host-resolver generic dispatch; resolving those appears to require broader architecture changes rather than single-line fixes.


### PR DESCRIPTION
## Summary
- remove `AbstractChannelHandler`
- remove `ChannelSlot.handler` object storage and rely on callable refs
- add callable storage for stats/reset paths on `ChannelSlot`
- keep socket access on `Channel` via `channel.socket`
- remove `Channel.tls_handler`/`Channel.pipeline_handler` field dependencies
- update handler/test types and assertions for the new model

## Validation
- `JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'` (Reseau)
- downstream validated locally in `AwsHTTP` and `HTTP` after corresponding refactors
