### PR TITLE
fix: harden IOCP event loop lifecycle and cleanup

### DIFF
--- a/src/eventloops/iocp_event_loop_types.jl
+++ b/src/eventloops/iocp_event_loop_types.jl
@@ -14,6 +14,7 @@
         mutex::ReentrantLock
         thread_signaled::Bool
         tasks_to_schedule::Vector{ScheduledTask}
+        tasks_to_schedule_spare::Vector{ScheduledTask}
         state::IocpEventThreadState.T
     end
 
@@ -21,6 +22,7 @@
         return IocpSyncedData(
             ReentrantLock(),
             false,
+            ScheduledTask[],
             ScheduledTask[],
             IocpEventThreadState.READY_TO_RUN,
         )


### PR DESCRIPTION
## Summary
- harden IOCP thread startup/teardown signaling and startup failure rollback paths
- make cross-thread wake signaling rollback-safe when PostQueuedCompletionStatus fails
- make IOCP destroy path exception-safe while still cleaning scheduler/tasks/handle
- normalize IOCP completion status handling and explicit non-timeout wait error handling
- clear stale stop state for reliable reruns and improve queue-drain performance
- fix OVERLAPPED_ENTRY ABI assumptions to be portable across pointer widths
- add Windows-only IOCP tests for rerun/stop state reset, wake latch rollback, and layout checks

## Validation
- Ran full Reseau suite after each item fix (`Pkg.test`)
- Ran full Reseau suite again after the final test additions (`Pkg.test`)
- Ran full AwsHTTP suite (`Pkg.test`)
- Ran full HTTP suite (`Pkg.test`)
