### PR TITLE
fix(nw-socket): harden lifecycle and optimize read path

### DIFF
--- a/src/sockets/io/apple_nw_socket_types.jl
+++ b/src/sockets/io/apple_nw_socket_types.jl
@@ -70,6 +70,7 @@
         parameters_context::Union{NWParametersContext, Nothing}
         mode::NWSocketMode.T
         read_queue::Vector{ReadQueueNode}
+        read_queue_head::Int
         on_readable::Union{EventCallable, Nothing}
         on_connection_result::Union{EventCallable, Nothing}
         on_accept_started::Union{EventCallable, Nothing}
@@ -79,6 +80,7 @@
         event_loop::Union{EventLoop, Nothing}
         connection_setup::Bool
         timeout_task::Union{ScheduledTask, Nothing}
+        listener_port_poll_task::Union{ScheduledTask, Nothing}
         host_name::Union{String, Nothing}
         alpn_list::Union{String, Nothing}
         tls_ctx::Union{TlsContext, Nothing}
@@ -101,6 +103,7 @@
             nothing,
             NWSocketMode.CONNECTION,
             ReadQueueNode[],
+            1,
             nothing,
             nothing,
             nothing,
@@ -109,6 +112,7 @@
             false,
             nothing,
             false,
+            nothing,
             nothing,
             nothing,
             nothing,


### PR DESCRIPTION
## Summary
- harden Apple Network socket lifecycle paths to avoid leaks when sockets are closed before event-loop assignment
- make state/accept callback paths lock-safe and callback-failure-safe so cleanup still runs deterministically
- prevent listener accept-start races by tracking/canceling port-poll tasks on fail/cancel transitions
- make callback/global one-time initialization thread-safe
- enforce readable-subscription state validation for NW sockets
- improve NW read-path performance by using bulk copy, increasing receive max length, and avoiding `popfirst!` queue churn

## Validation
- full `Pkg.test` run in `Reseau` after each of the 7 fix items
- `AwsHTTP` test suite pass
- `HTTP` test suite pass
