### PR TITLE
fix(winsock): harden io correctness, cleanup, and perf paths

### DIFF
--- a/src/eventloops/iocp_event_loop.jl
+++ b/src/eventloops/iocp_event_loop.jl
@@ -95,12 +95,14 @@
         storage::Base.RefValue{AwsOverlappedHeader}
         on_completion::Union{Nothing, IocpOnCompletionFn}
         user_data::Any
+        user_data_aux::Any
         active::Bool
     end
 
     function IocpOverlapped()
         op = IocpOverlapped(
             Ref(AwsOverlappedHeader(_ZERO_OVERLAPPED, C_NULL)),
+            nothing,
             nothing,
             nothing,
             false,
@@ -116,6 +118,21 @@
         )::IocpOverlapped
         op.on_completion = on_completion
         op.user_data = user_data
+        op.user_data_aux = nothing
+        op.active = false
+        op.storage[] = AwsOverlappedHeader(_ZERO_OVERLAPPED, pointer_from_objref(op))
+        return op
+    end
+
+    function iocp_overlapped_init!(
+            op::IocpOverlapped,
+            on_completion::IocpOnCompletionFn,
+            user_data,
+            user_data_aux,
+        )::IocpOverlapped
+        op.on_completion = on_completion
+        op.user_data = user_data
+        op.user_data_aux = user_data_aux
         op.active = false
         op.storage[] = AwsOverlappedHeader(_ZERO_OVERLAPPED, pointer_from_objref(op))
         return op

--- a/src/sockets/io/winsock_socket.jl
+++ b/src/sockets/io/winsock_socket.jl
@@ -1465,7 +1465,10 @@
         end
 
         if impl.connect_args !== nothing
-            timeout_task = impl.connect_args.timeout_task
+            connect_args = impl.connect_args
+            connect_args.socket = nothing
+            timeout_task = connect_args.timeout_task
+            connect_args.timeout_task = nothing
             if timeout_task !== nothing && sock.event_loop !== nothing
                 try
                     cancel_task!(sock.event_loop, timeout_task)
@@ -1473,8 +1476,6 @@
                     e isa ReseauError || rethrow()
                 end
             end
-            impl.connect_args.timeout_task = nothing
-            impl.connect_args.socket = nothing
             impl.connect_args = nothing
         end
 

--- a/src/sockets/io/winsock_socket.jl
+++ b/src/sockets/io/winsock_socket.jl
@@ -350,7 +350,7 @@
     function socket_init_winsock(options::SocketOptions)::Socket
         winsock_check_and_init!()
 
-        impl = WinsockSocket{Socket}()
+        impl = WinsockSocket()
         sock = Socket(
             SocketEndpoint(),
             SocketEndpoint(),

--- a/src/sockets/io/winsock_socket_types.jl
+++ b/src/sockets/io/winsock_socket_types.jl
@@ -3,27 +3,27 @@
 
 @static if Sys.iswindows()
     # Track the one-in-flight overlapped operation used for connect/accept/readable monitoring.
-    mutable struct WinsockIoOperationData
-        socket::Any # Socket or nothing (Socket not defined yet at include time)
+    mutable struct WinsockIoOperationData{S}
+        socket::Union{Nothing, S}
         signal::IocpOverlapped
         in_use::Bool
         sequential_task::Union{Nothing, ScheduledTask}
     end
 
-    function WinsockIoOperationData()
-        return WinsockIoOperationData(nothing, IocpOverlapped(), false, nothing)
+    function WinsockIoOperationData{S}() where {S}
+        return WinsockIoOperationData{S}(nothing, IocpOverlapped(), false, nothing)
     end
 
     # Connection args for stream connect timeout bookkeeping.
-    mutable struct WinsockSocketConnectArgs
-        socket::Any # Socket or nothing
+    mutable struct WinsockSocketConnectArgs{S}
+        socket::Union{Nothing, S}
         timeout_task::Union{Nothing, ScheduledTask}
-        io_data::WinsockIoOperationData
+        io_data::WinsockIoOperationData{S}
     end
 
     # Pending write request (WriteFile() overlapped).
-    mutable struct WinsockSocketWriteRequest
-        socket::Any # Socket or nothing
+    mutable struct WinsockSocketWriteRequest{S}
+        socket::Union{Nothing, S}
         detached::Bool
         cursor::ByteCursor
         original_len::Csize_t
@@ -32,12 +32,13 @@
     end
 
     # Windows socket implementation state (Port of aws-c-io's iocp_socket)
-    mutable struct WinsockSocket
-        read_io_data::WinsockIoOperationData
-        incoming_socket::Any  # Socket or nothing
+    mutable struct WinsockSocket{S}
+        read_io_data::WinsockIoOperationData{S}
+        incoming_socket::Union{Nothing, S}
         accept_buffer::Memory{UInt8}
-        connect_args::Union{WinsockSocketConnectArgs, Nothing}
-        pending_writes::Vector{WinsockSocketWriteRequest}
+        connect_args::Union{WinsockSocketConnectArgs{S}, Nothing}
+        pending_writes::Vector{WinsockSocketWriteRequest{S}}
+        pending_write_indices::IdDict{WinsockSocketWriteRequest{S}, Int}
         stop_accept::Bool
         waiting_on_readable::Bool
         on_close_complete::Union{TaskFn, Nothing}
@@ -45,14 +46,15 @@
         cleaned_up::Bool
     end
 
-    function WinsockSocket()
+    function WinsockSocket{S}() where {S}
         buf = Memory{UInt8}(undef, 288) # 2 * (sizeof(sockaddr_storage)+16) in aws-c-io
-        return WinsockSocket(
-            WinsockIoOperationData(),
+        return WinsockSocket{S}(
+            WinsockIoOperationData{S}(),
             nothing,
             buf,
             nothing,
-            WinsockSocketWriteRequest[],
+            WinsockSocketWriteRequest{S}[],
+            IdDict{WinsockSocketWriteRequest{S}, Int}(),
             false,
             false,
             nothing,
@@ -60,6 +62,9 @@
             false,
         )
     end
+
+    WinsockIoOperationData() = WinsockIoOperationData{Any}()
+    WinsockSocket() = WinsockSocket{Any}()
 else
     # Non-Windows builds keep a stub type so dispatch compiles.
     struct WinsockSocket end

--- a/src/sockets/io/winsock_socket_types.jl
+++ b/src/sockets/io/winsock_socket_types.jl
@@ -2,28 +2,8 @@
 # Extracted for include-order: types must exist before Socket struct is defined.
 
 @static if Sys.iswindows()
-    # Track the one-in-flight overlapped operation used for connect/accept/readable monitoring.
-    mutable struct WinsockIoOperationData{S}
-        socket::Union{Nothing, S}
-        signal::IocpOverlapped
-        in_use::Bool
-        sequential_task::Union{Nothing, ScheduledTask}
-    end
-
-    function WinsockIoOperationData{S}() where {S}
-        return WinsockIoOperationData{S}(nothing, IocpOverlapped(), false, nothing)
-    end
-
-    # Connection args for stream connect timeout bookkeeping.
-    mutable struct WinsockSocketConnectArgs{S}
-        socket::Union{Nothing, S}
-        timeout_task::Union{Nothing, ScheduledTask}
-        io_data::WinsockIoOperationData{S}
-    end
-
     # Pending write request (WriteFile() overlapped).
-    mutable struct WinsockSocketWriteRequest{S}
-        socket::Union{Nothing, S}
+    mutable struct WinsockSocketWriteRequest
         detached::Bool
         cursor::ByteCursor
         original_len::Csize_t
@@ -32,13 +12,17 @@
     end
 
     # Windows socket implementation state (Port of aws-c-io's iocp_socket)
-    mutable struct WinsockSocket{S}
-        read_io_data::WinsockIoOperationData{S}
-        incoming_socket::Union{Nothing, S}
+    mutable struct WinsockSocket
+        read_signal::IocpOverlapped
+        read_in_use::Bool
+        read_sequential_task::Union{Nothing, ScheduledTask}
+        connect_timeout_task::Union{Nothing, ScheduledTask}
+        connect_generation::UInt64
+        connect_active::Bool
+        incoming_accept_handle::Ptr{Cvoid}
         accept_buffer::Memory{UInt8}
-        connect_args::Union{WinsockSocketConnectArgs{S}, Nothing}
-        pending_writes::Vector{WinsockSocketWriteRequest{S}}
-        pending_write_indices::IdDict{WinsockSocketWriteRequest{S}, Int}
+        pending_writes::Vector{WinsockSocketWriteRequest}
+        pending_write_indices::IdDict{WinsockSocketWriteRequest, Int}
         stop_accept::Bool
         waiting_on_readable::Bool
         on_close_complete::Union{TaskFn, Nothing}
@@ -46,15 +30,19 @@
         cleaned_up::Bool
     end
 
-    function WinsockSocket{S}() where {S}
+    function WinsockSocket()
         buf = Memory{UInt8}(undef, 288) # 2 * (sizeof(sockaddr_storage)+16) in aws-c-io
-        return WinsockSocket{S}(
-            WinsockIoOperationData{S}(),
+        return WinsockSocket(
+            IocpOverlapped(),
+            false,
             nothing,
+            nothing,
+            UInt64(0),
+            false,
+            C_NULL,
             buf,
-            nothing,
-            WinsockSocketWriteRequest{S}[],
-            IdDict{WinsockSocketWriteRequest{S}, Int}(),
+            WinsockSocketWriteRequest[],
+            IdDict{WinsockSocketWriteRequest, Int}(),
             false,
             false,
             nothing,
@@ -62,9 +50,6 @@
             false,
         )
     end
-
-    WinsockIoOperationData() = WinsockIoOperationData{Any}()
-    WinsockSocket() = WinsockSocket{Any}()
 else
     # Non-Windows builds keep a stub type so dispatch compiles.
     struct WinsockSocket end


### PR DESCRIPTION
## Summary
This PR hardens  for production-grade correctness and robustness.

### Correctness and error semantics
- Use  (not ) for  failures.
- Treat accept re-arm failures as fatal unless , then transition socket state and trigger cleanup.
- Marshal  onto the event-loop thread when called cross-thread, matching intended semantics.
- Update socket state on write completion errors ( vs ).

### Resource cleanup / leak prevention
- Cancel and clear connect-timeout tasks on connect completion and socket close.
- Clear timeout task ownership before close in timeout path to avoid close-time deadlock.

### Socket options parity
- Apply  on Windows via  best-effort .

### Performance
- Replace O(n) pending-write removal (/) with O(1) swap-pop + index map.
- Reduce dynamic dispatch pressure by parameterizing winsock socket operation structs and removing  socket fields.

## Validation
- Ran full Reseau test suite repeatedly while applying fixes in order:
  - 
