### PR TITLE
fix: harden POSIX socket lifecycle, threading, and write queues

### DIFF
--- a/src/eventloops/epoll_event_loop.jl
+++ b/src/eventloops/epoll_event_loop.jl
@@ -6,6 +6,10 @@
     using LibAwsCal
 
     const _LIBC_EWOULDBLOCK = isdefined(Base.Libc, :EWOULDBLOCK) ? Base.Libc.EWOULDBLOCK : Base.Libc.EAGAIN
+    @inline function event_loop_thread_exit_s2n_cleanup!(::EpollEventLoop)::Nothing
+        return nothing
+    end
+
     @inline function _epoll_handle_data_key(handle_data::EpollEventHandleData)::UInt64
         return UInt64(objectid(handle_data))
     end

--- a/src/eventloops/epoll_event_loop.jl
+++ b/src/eventloops/epoll_event_loop.jl
@@ -6,7 +6,7 @@
     using LibAwsCal
 
     const _LIBC_EWOULDBLOCK = isdefined(Base.Libc, :EWOULDBLOCK) ? Base.Libc.EWOULDBLOCK : Base.Libc.EAGAIN
-    @inline function event_loop_thread_exit_s2n_cleanup!(::EpollEventLoop)::Nothing
+    @inline function event_loop_thread_exit_s2n_cleanup!(::Any)::Nothing
         return nothing
     end
 

--- a/src/sockets/io/posix_socket_impl.jl
+++ b/src/sockets/io/posix_socket_impl.jl
@@ -1629,10 +1629,9 @@ function socket_close_impl(socket_impl::PosixSocket, sock::Socket)::Nothing
         socket_impl.connect_args = nothing
     end
 
-    # Prevent user callbacks from firing after the socket closes.
+    # Prevent readable callbacks from firing after close. Connection/accept
+    # callbacks may still be needed by in-flight error paths before cleanup.
     sock.readable_fn = nothing
-    sock.connection_result_fn = nothing
-    sock.accept_result_fn = nothing
 
     if socket_is_open(sock)
         ccall(:close, Cint, (Cint,), fd)

--- a/src/sockets/io/posix_socket_impl.jl
+++ b/src/sockets/io/posix_socket_impl.jl
@@ -1232,7 +1232,9 @@ function _socket_connect_event(connect_args::PosixSocketConnectArgs{S}, events::
         sock = connect_args.socket::Socket
         socket_impl = _posix_impl(sock)
 
-        if connectable
+        # Match aws-c-io semantics: writable/readable only indicates successful
+        # completion when no error bits are present on the same event.
+        if connectable && !has_error
             _cancel_connect_pending_tasks!(sock, connect_args)
             connect_args.socket = nothing
             socket_impl.connect_args = nothing

--- a/src/sockets/io/posix_socket_impl.jl
+++ b/src/sockets/io/posix_socket_impl.jl
@@ -1260,6 +1260,7 @@ function _socket_connect_event(connect_args::PosixSocketConnectArgs{S}, events::
                     unsubscribe_from_io_events!(sock.event_loop, sock.io_handle)
                 catch e
                 end
+                socket_impl.currently_subscribed = false
             end
             _cancel_connect_pending_tasks!(sock, connect_args)
             connect_args.socket = nothing

--- a/src/sockets/io/tls/s2n_tls_handler.jl
+++ b/src/sockets/io/tls/s2n_tls_handler.jl
@@ -212,7 +212,7 @@ function _s2n_cleanup()
 end
 
 @static if Sys.islinux()
-function EventLoops.event_loop_thread_exit_s2n_cleanup!(::EventLoops.EpollEventLoop)::Nothing
+function EventLoops.event_loop_thread_exit_s2n_cleanup!(::EventLoops.EventLoop)::Nothing
     _s2n_cleanup_thread()
     return nothing
 end

--- a/src/sockets/io/tls/s2n_tls_handler.jl
+++ b/src/sockets/io/tls/s2n_tls_handler.jl
@@ -212,7 +212,7 @@ function _s2n_cleanup()
 end
 
 @static if Sys.islinux()
-function event_loop_thread_exit_s2n_cleanup!(::EpollEventLoop)::Nothing
+function EventLoops.event_loop_thread_exit_s2n_cleanup!(::EventLoops.EpollEventLoop)::Nothing
     _s2n_cleanup_thread()
     return nothing
 end


### PR DESCRIPTION
## Summary
- harden POSIX socket lifecycle handling around close/cleanup and asynchronous callback races
- align connect/accept/read/write errno handling with POSIX/aws-c-io expectations (including EINTR paths)
- cancel pending connect timeout/retry tasks on all completion/error/close paths to avoid retained tasks
- enforce event-loop thread affinity for stop-accept and dispatch  on the accept-loop thread
- replace O(n)   socket write queues with an amortized O(1) queue wrapper and keep callback fairness semantics
- add a regression assertion that  runs on the event-loop thread

## Validation
- 
- 
- 