### PR TITLE
fix(io): align socket and bootstrap behavior

### DIFF
--- a/src/sockets/io/apple_nw_socket_impl.jl
+++ b/src/sockets/io/apple_nw_socket_impl.jl
@@ -151,15 +151,6 @@
         return nothing
     end
 
-    function _nw_set_event_loop!(
-        socket::Socket,
-        event_loop::EventLoop,
-        event_loop_group::Union{EventLoopGroup,Nothing},
-    )::Nothing
-        _ = event_loop_group
-        return _nw_set_event_loop!(socket, event_loop)
-    end
-
     function _nw_release_event_loop!(nw_socket::NWSocket)
         if nw_socket.event_loop !== nothing
             event_loop = nw_socket.event_loop
@@ -1873,7 +1864,7 @@
 
         event_loop === nothing && throw_error(ERROR_IO_SOCKET_MISSING_EVENT_LOOP)
 
-        _nw_set_event_loop!(socket, event_loop, event_loop_group)
+        _nw_set_event_loop!(socket, event_loop)
 
         _nw_setup_socket_params!(nw_socket, socket.options)
 
@@ -2077,7 +2068,7 @@
             nw_socket.on_accept_started = on_accept_start
             socket.accept_result_fn = on_accept_result
 
-            _nw_set_event_loop!(socket, accept_loop, event_loop_group)
+            _nw_set_event_loop!(socket, accept_loop)
 
             connect_to_io_completion_port(accept_loop, socket.io_handle)
 

--- a/src/sockets/io/channel_bootstrap.jl
+++ b/src/sockets/io/channel_bootstrap.jl
@@ -50,9 +50,7 @@ function ClientBootstrap(;
         on_protocol_negotiated_cb,
         false,
     )
-
     logf(LogLevel.DEBUG, LS_IO_CHANNEL_BOOTSTRAP, "ClientBootstrap: created")
-
     return bootstrap
 end
 
@@ -127,21 +125,18 @@ function client_bootstrap_connect!(
     if @atomic bootstrap.shutdown
         throw(ReseauError(ERROR_IO_EVENT_LOOP_SHUTDOWN))
     end
-
     host_str = String(host)
     logf(
         LogLevel.DEBUG,
         LS_IO_CHANNEL_BOOTSTRAP,
         "ClientBootstrap: initiating connection to $host_str:$port",
     )
-
     event_loop_group = EventLoops.get_event_loop_group()
     host_resolver = get_host_resolver()
     request_resolution_config = _normalize_resolution_config(
         host_resolver,
         host_resolution_config,
     )
-
     request = SocketConnectionRequest(
         bootstrap,
         host_str,
@@ -162,14 +157,15 @@ function client_bootstrap_connect!(
         false,
         Future{Socket}(),
     )
-
     try
         addresses = host_resolver_resolve!(
             request.host_resolver,
             request.host,
             request.host_resolution_config,
         )
-        socket = _start_connection_attempts(request, addresses)
+        event_loop = _get_connection_event_loop(request)
+        event_loop === nothing && throw(ReseauError(ERROR_IO_SOCKET_MISSING_EVENT_LOOP))
+        socket = wait(_schedule_connection_attempts(request, addresses, event_loop))
         return _setup_client_channel(request, socket)
     catch
         _cancel_connection_attempts(request)
@@ -294,32 +290,12 @@ function _start_connection_attempt(
         return nothing
     end
     push!(request.connection_attempt_tasks, task)
-
     if run_at_timestamp == 0
         schedule_task_now!(event_loop, task)
     else
         schedule_task_future!(event_loop, task, run_at_timestamp)
     end
     return nothing
-end
-
-function _start_connection_attempts(
-        request::SocketConnectionRequest,
-        addresses::Vector{HostAddress},
-    )::Socket
-    event_loop = _get_connection_event_loop(request)
-    if event_loop === nothing
-        throw(ReseauError(ERROR_IO_SOCKET_MISSING_EVENT_LOOP))
-    end
-    return _start_connection_attempts(request, addresses, event_loop)
-end
-
-function _start_connection_attempts(
-        request::SocketConnectionRequest,
-        addresses::Vector{HostAddress},
-        event_loop::EventLoop,
-    )::Socket
-    return wait(_schedule_connection_attempts(request, addresses, event_loop))
 end
 
 function _schedule_connection_attempts(
@@ -340,7 +316,6 @@ function _schedule_connection_attempts(
         _notify_future_error!(request.connect_future, ReseauError(ERROR_IO_DNS_NO_ADDRESS_FOR_HOST))
         return request.connect_future
     end
-
     now = clock_now_ns()
     for (idx, address) in enumerate(addresses)
         run_at_timestamp = _attempt_schedule_run_at(request, now, idx - 1)
@@ -351,7 +326,6 @@ function _schedule_connection_attempts(
         )
         _start_connection_attempt(request, address, run_at_timestamp, event_loop)
     end
-
     return request.connect_future
 end
 
@@ -385,12 +359,10 @@ end
 
 function _initiate_socket_connect(request::SocketConnectionRequest, address::HostAddress)
     event_loop = request.event_loop
-
     options = copy(request.socket_options)
     if options.domain != SocketDomain.LOCAL && options.domain != SocketDomain.VSOCK
         options.domain = address.address_type == HostAddressType.AAAA ? SocketDomain.IPV6 : SocketDomain.IPV4
     end
-
     local socket
     try
         socket = socket_init(options)
@@ -399,23 +371,20 @@ function _initiate_socket_connect(request::SocketConnectionRequest, address::Hos
         _note_connection_attempt_failure(request, e isa ReseauError ? e.code : ERROR_UNKNOWN)
         return nothing
     end
-
     remote_endpoint = SocketEndpoint()
     set_address!(remote_endpoint, address.address)
     remote_endpoint.port = request.port
-
     if event_loop === nothing
         logf(LogLevel.ERROR, LS_IO_CHANNEL_BOOTSTRAP, "ClientBootstrap: no event loop available")
         socket_close(socket)
         _notify_future_error!(request.connect_future, ReseauError(ERROR_IO_SOCKET_MISSING_EVENT_LOOP))
         return nothing
     end
-
     try
         socket_connect(
-            socket,
-            remote_endpoint;
-            event_loop = event_loop,
+            socket;
+            remote_endpoint,
+            event_loop,
             event_loop_group = request.event_loop_group,
             on_connection_result = EventCallable(err -> _on_socket_connect_complete(socket, err, request, address)),
             tls_connection_options = request.tls_connection_options,
@@ -427,7 +396,6 @@ function _initiate_socket_connect(request::SocketConnectionRequest, address::Hos
         _note_connection_attempt_failure(request, e isa ReseauError ? e.code : ERROR_UNKNOWN)
         return nothing
     end
-
     return nothing
 end
 
@@ -460,12 +428,10 @@ function _on_socket_connect_complete(
         _note_connection_attempt_failure(request, error_code)
         return nothing
     end
-
     if request.connection_chosen
         socket_close(socket)
         return nothing
     end
-
     logf(
         LogLevel.DEBUG,
         LS_IO_CHANNEL_BOOTSTRAP,
@@ -813,9 +779,9 @@ function ServerBootstrap(options::ServerBootstrapOptions)
         local_endpoint.port = options.port
 
         if _socket_uses_network_framework_tls(listener, options.tls_connection_options)
-            socket_bind(listener, local_endpoint; tls_connection_options = options.tls_connection_options)
+            socket_bind(listener; local_endpoint, tls_connection_options = options.tls_connection_options)
         else
-            socket_bind(listener, local_endpoint)
+            socket_bind(listener; local_endpoint)
         end
 
         # Start listening
@@ -1198,7 +1164,7 @@ function _setup_incoming_channel(bootstrap::ServerBootstrap, socket::Socket)::No
     end
 
     try
-        socket_assign_to_event_loop(socket, event_loop, bootstrap.event_loop_group)
+        socket_assign_to_event_loop(socket, event_loop)
     catch e
         logf(
             LogLevel.ERROR,

--- a/src/sockets/io/socket_channel_handler.jl
+++ b/src/sockets/io/socket_channel_handler.jl
@@ -385,7 +385,7 @@ function _socket_handler_do_read(handler::SocketChannelHandler)
 
         local bytes_read
         try
-            _, bytes_read = socket_read(socket, message.message_data)
+            bytes_read = socket_read(socket, message.message_data)
         catch e
             if e isa ReseauError
                 last_error = e.code

--- a/src/sockets/io/winsock_socket.jl
+++ b/src/sockets/io/winsock_socket.jl
@@ -1675,7 +1675,7 @@
         throw_error(ERROR_IO_READ_WOULD_BLOCK)
     end
 
-    function socket_read_impl(::WinsockSocket, sock::Socket, buffer::ByteBuffer)::Tuple{Nothing, Csize_t}
+    function socket_read_impl(::WinsockSocket, sock::Socket, buffer::ByteBuffer)::Csize_t
         if sock.event_loop !== nothing && !event_loop_thread_is_callers_thread(sock.event_loop)
             throw_error(ERROR_IO_EVENT_LOOP_THREAD_ONLY)
         end
@@ -1684,7 +1684,7 @@
         end
 
         remaining = buffer.capacity - buffer.len
-        remaining == 0 && return (nothing, Csize_t(0))
+        remaining == 0 && return Csize_t(0)
 
         if sock.options.domain == SocketDomain.LOCAL
             # Port of aws-c-io s_local_read(): PeekNamedPipe() then synchronous ReadFile(),
@@ -1766,7 +1766,7 @@
 
             amount = Csize_t(bytes_read[])
             setfield!(buffer, :len, buffer.len + amount)
-            return (nothing, amount)
+            return amount
         end
 
         bytes_to_read = remaining
@@ -1810,7 +1810,7 @@
         if read_val > 0
             amount = Csize_t(read_val)
             setfield!(buffer, :len, buffer.len + amount)
-            return (nothing, amount)
+            return amount
         end
 
         if read_val == 0


### PR DESCRIPTION
## Summary
- make `socket_read` return only `Csize_t` and update all platform implementations/callers
- migrate `SocketOptions.network_interface_name` to `String` with `@kwdef` defaults and validation-at-use
- restore expected VSOCK connect/bind port validation semantics
- restore Apple NW event-loop compatibility overload and requested-event-loop mismatch handling

## Validation
- Reseau default tests
- Reseau with `RESEAU_RUN_NETWORK_TESTS=1`
- Reseau with `RESEAU_RUN_TLS_TESTS=1`
- Reseau with `RESEAU_RUN_TLS_TESTS=1 RESEAU_RUN_NETWORK_TESTS=1`
- AwsHTTP test suite
- HTTP test suite