### PR TITLE
refactor(io): remove aws prefixes and tighten types

### DIFF
--- a/src/sockets/io/apple_nw_socket_impl.jl
+++ b/src/sockets/io/apple_nw_socket_impl.jl
@@ -684,13 +684,13 @@
             )
         end
 
-        if g_aws_channel_max_fragment_size[] < KB_16
+        if g_channel_max_fragment_size[] < KB_16
             ccall(
                 (:nw_tcp_options_set_maximum_segment_size, _NW_NETWORK_LIB),
                 Cvoid,
                 (nw_protocol_options_t, UInt32),
                 tcp_options,
-                UInt32(g_aws_channel_max_fragment_size[]),
+                UInt32(g_channel_max_fragment_size[]),
             )
         end
         return nothing

--- a/src/sockets/io/byte_helpers.jl
+++ b/src/sockets/io/byte_helpers.jl
@@ -1,20 +1,20 @@
 # AWS IO Library - AWS byte buffer helpers (LibAwsCommon-backed)
 
-@inline function _aws_byte_cursor_from_vec(vec::AbstractVector{UInt8})
+@inline function _byte_cursor_from_vec(vec::AbstractVector{UInt8})
     if isempty(vec)
         return LibAwsCommon.aws_byte_cursor(Csize_t(0), Ptr{UInt8}(C_NULL))
     end
     return LibAwsCommon.aws_byte_cursor(Csize_t(length(vec)), pointer(vec))
 end
 
-@inline function _aws_byte_cursor_from_buf(buf::ByteBuffer)
+@inline function _byte_cursor_from_buf(buf::ByteBuffer)
     if buf.len == 0
         return LibAwsCommon.aws_byte_cursor(Csize_t(0), Ptr{UInt8}(C_NULL))
     end
     return LibAwsCommon.aws_byte_cursor(buf.len, pointer(buf.mem))
 end
 
-@inline function _aws_byte_buf_from_vec(vec::AbstractVector{UInt8})
+@inline function _byte_buf_from_vec(vec::AbstractVector{UInt8})
     return LibAwsCommon.aws_byte_buf(
         Csize_t(0),
         pointer(vec),

--- a/src/sockets/io/crypto_primitives.jl
+++ b/src/sockets/io/crypto_primitives.jl
@@ -62,8 +62,8 @@ end
     return LibAwsCal.AWS_CAL_RSA_SIGNATURE_PSS_SHA256
 end
 
-@inline _aws_byte_cursor_from_key(key::AbstractVector{UInt8}) = _aws_byte_cursor_from_vec(key)
-@inline _aws_byte_cursor_from_key(key::ByteBuffer) = _aws_byte_cursor_from_buf(key)
+@inline _byte_cursor_from_key(key::AbstractVector{UInt8}) = _byte_cursor_from_vec(key)
+@inline _byte_cursor_from_key(key::ByteBuffer) = _byte_cursor_from_buf(key)
 
 function hkdf_derive(
         hmac_type::HkdfHmacType.T,
@@ -78,11 +78,11 @@ function hkdf_derive(
     end
     allocator = LibAwsCommon.default_aws_allocator()
 
-    ikm_cur = _aws_byte_cursor_from_vec(ikm)
-    salt_cur = _aws_byte_cursor_from_vec(salt)
-    info_cur = _aws_byte_cursor_from_vec(info)
+    ikm_cur = _byte_cursor_from_vec(ikm)
+    salt_cur = _byte_cursor_from_vec(salt)
+    info_cur = _byte_cursor_from_vec(info)
     out = ByteBuffer(length)
-    out_buf_ref = Ref(_aws_byte_buf_from_vec(out.mem))
+    out_buf_ref = Ref(_byte_buf_from_vec(out.mem))
 
     cal_hmac = LibAwsCal.HKDF_HMAC_SHA512
     GC.@preserve ikm salt info out begin
@@ -121,8 +121,8 @@ function ecc_sign(
     _cal_init()
     sig_len = LibAwsCal.aws_ecc_key_pair_signature_length(pair.handle)
     sig = Memory{UInt8}(undef, Int(sig_len))
-    sig_buf_ref = Ref(_aws_byte_buf_from_vec(sig))
-    msg_cur = _aws_byte_cursor_from_vec(message)
+    sig_buf_ref = Ref(_byte_buf_from_vec(sig))
+    msg_cur = _byte_cursor_from_vec(message)
 
     GC.@preserve message sig begin
         if LibAwsCal.aws_ecc_key_pair_sign_message(pair.handle, Ref(msg_cur), sig_buf_ref) != 0
@@ -140,8 +140,8 @@ function ecc_verify(
         signature::ByteBuffer,
     )::Bool
     _cal_init()
-    msg_cur = _aws_byte_cursor_from_vec(message)
-    sig_cur = _aws_byte_cursor_from_buf(signature)
+    msg_cur = _byte_cursor_from_vec(message)
+    sig_cur = _byte_cursor_from_buf(signature)
     GC.@preserve message signature begin
         rv = LibAwsCal.aws_ecc_key_pair_verify_signature(pair.handle, Ref(msg_cur), Ref(sig_cur))
         rv == 0 && return true
@@ -154,7 +154,7 @@ function rsa_key_pair_new_from_public_key_pkcs1(
     )::RsaKeyPair
     _cal_init()
     allocator = LibAwsCommon.default_aws_allocator()
-    key_cur = _aws_byte_cursor_from_key(key)
+    key_cur = _byte_cursor_from_key(key)
     handle = LibAwsCal.aws_rsa_key_pair_new_from_public_key_pkcs1(allocator, key_cur)
     handle == C_NULL && return _crypto_last_error()
     pair = RsaKeyPair(handle)
@@ -169,7 +169,7 @@ function rsa_key_pair_new_from_private_key_pkcs1(
     )::RsaKeyPair
     _cal_init()
     allocator = LibAwsCommon.default_aws_allocator()
-    key_cur = _aws_byte_cursor_from_key(key)
+    key_cur = _byte_cursor_from_key(key)
     handle = LibAwsCal.aws_rsa_key_pair_new_from_private_key_pkcs1(allocator, key_cur)
     handle == C_NULL && return _crypto_last_error()
     pair = RsaKeyPair(handle)
@@ -184,7 +184,7 @@ function rsa_key_pair_new_from_private_key_pkcs8(
     )::RsaKeyPair
     _cal_init()
     allocator = LibAwsCommon.default_aws_allocator()
-    key_cur = _aws_byte_cursor_from_key(key)
+    key_cur = _byte_cursor_from_key(key)
     handle = LibAwsCal.aws_rsa_key_pair_new_from_private_key_pkcs8(allocator, key_cur)
     handle == C_NULL && return _crypto_last_error()
     pair = RsaKeyPair(handle)
@@ -276,8 +276,8 @@ function rsa_key_pair_encrypt(
     )::ByteBuffer
     _cal_init()
     out = ByteBuffer(Int(rsa_key_pair_block_length(pair)))
-    out_buf_ref = Ref(_aws_byte_buf_from_vec(out.mem))
-    pt_cur = _aws_byte_cursor_from_vec(plaintext)
+    out_buf_ref = Ref(_byte_buf_from_vec(out.mem))
+    pt_cur = _byte_cursor_from_vec(plaintext)
     rv = LibAwsCal.aws_rsa_key_pair_encrypt(pair.handle, _rsa_encryption_native(algorithm), pt_cur, out_buf_ref)
     rv == 0 || return _crypto_last_error()
     out_buf = out_buf_ref[]
@@ -291,8 +291,8 @@ function rsa_key_pair_decrypt(
     )::ByteBuffer
     _cal_init()
     out = ByteBuffer(Int(rsa_key_pair_block_length(pair)))
-    out_buf_ref = Ref(_aws_byte_buf_from_vec(out.mem))
-    ct_cur = _aws_byte_cursor_from_vec(ciphertext)
+    out_buf_ref = Ref(_byte_buf_from_vec(out.mem))
+    ct_cur = _byte_cursor_from_vec(ciphertext)
     rv = LibAwsCal.aws_rsa_key_pair_decrypt(pair.handle, _rsa_encryption_native(algorithm), ct_cur, out_buf_ref)
     rv == 0 || return _crypto_last_error()
     out_buf = out_buf_ref[]
@@ -306,8 +306,8 @@ function rsa_key_pair_sign_message(
     )::ByteBuffer
     _cal_init()
     out = ByteBuffer(Int(rsa_key_pair_signature_length(pair)))
-    out_buf_ref = Ref(_aws_byte_buf_from_vec(out.mem))
-    dig_cur = _aws_byte_cursor_from_vec(digest)
+    out_buf_ref = Ref(_byte_buf_from_vec(out.mem))
+    dig_cur = _byte_cursor_from_vec(digest)
     rv = LibAwsCal.aws_rsa_key_pair_sign_message(pair.handle, _rsa_signature_native(algorithm), dig_cur, out_buf_ref)
     rv == 0 || return _crypto_last_error()
     out_buf = out_buf_ref[]
@@ -321,8 +321,8 @@ function rsa_key_pair_verify_signature(
         signature::AbstractVector{UInt8},
     )::Bool
     _cal_init()
-    dig_cur = _aws_byte_cursor_from_vec(digest)
-    sig_cur = _aws_byte_cursor_from_vec(signature)
+    dig_cur = _byte_cursor_from_vec(digest)
+    sig_cur = _byte_cursor_from_vec(signature)
     rv = LibAwsCal.aws_rsa_key_pair_verify_signature(pair.handle, _rsa_signature_native(algorithm), dig_cur, sig_cur)
     rv == 0 && return true
     _crypto_last_error()
@@ -336,15 +336,15 @@ function aes_gcm_256_encrypt(
     )::NamedTuple{(:ciphertext, :tag), Tuple{ByteBuffer, ByteBuffer}}
     _cal_init()
     allocator = LibAwsCommon.default_aws_allocator()
-    key_cur = _aws_byte_cursor_from_vec(key)
-    iv_cur = _aws_byte_cursor_from_vec(iv)
-    aad_cur = _aws_byte_cursor_from_vec(aad)
+    key_cur = _byte_cursor_from_vec(key)
+    iv_cur = _byte_cursor_from_vec(iv)
+    aad_cur = _byte_cursor_from_vec(aad)
     cipher = LibAwsCal.aws_aes_gcm_256_new(allocator, Ref(key_cur), Ref(iv_cur), Ref(aad_cur))
     cipher == C_NULL && return _crypto_last_error()
 
     out = ByteBuffer(length(plaintext) + 16)
-    out_buf_ref = Ref(_aws_byte_buf_from_vec(out.mem))
-    plain_cur = _aws_byte_cursor_from_vec(plaintext)
+    out_buf_ref = Ref(_byte_buf_from_vec(out.mem))
+    plain_cur = _byte_cursor_from_vec(plaintext)
     tag_buf = ByteBuffer(16)
 
     try
@@ -384,16 +384,16 @@ function aes_gcm_256_decrypt(
     )::ByteBuffer
     _cal_init()
     allocator = LibAwsCommon.default_aws_allocator()
-    key_cur = _aws_byte_cursor_from_vec(key)
-    iv_cur = _aws_byte_cursor_from_vec(iv)
-    aad_cur = _aws_byte_cursor_from_vec(aad)
+    key_cur = _byte_cursor_from_vec(key)
+    iv_cur = _byte_cursor_from_vec(iv)
+    aad_cur = _byte_cursor_from_vec(aad)
     cipher = LibAwsCal.aws_aes_gcm_256_new(allocator, Ref(key_cur), Ref(iv_cur), Ref(aad_cur))
     cipher == C_NULL && return _crypto_last_error()
 
     out = ByteBuffer(length(ciphertext) + 16)
-    out_buf_ref = Ref(_aws_byte_buf_from_vec(out.mem))
-    ct_cur = _aws_byte_cursor_from_vec(ciphertext)
-    tag_cur = _aws_byte_cursor_from_vec(tag)
+    out_buf_ref = Ref(_byte_buf_from_vec(out.mem))
+    ct_cur = _byte_cursor_from_vec(ciphertext)
+    tag_cur = _byte_cursor_from_vec(tag)
 
     try
         GC.@preserve key iv aad ciphertext out tag begin

--- a/src/sockets/io/iocp_pipe.jl
+++ b/src/sockets/io/iocp_pipe.jl
@@ -94,13 +94,13 @@
 
     function _iocp_pipe_raise_last_error()
         win_err = _iocp_pipe_get_last_error()
-        aws_err = _iocp_pipe_translate_windows_error(win_err)
-        throw_error(aws_err)
+        socket_err = _iocp_pipe_translate_windows_error(win_err)
+        throw_error(socket_err)
     end
 
     function _iocp_pipe_unique_name()::String
         uuid_str = string(UUIDs.uuid4())
-        return "\\\\.\\pipe\\aws_pipe_$(uuid_str)"
+        return "\\\\.\\pipe\\reseau_pipe_$(uuid_str)"
     end
 
     function pipe_create_iocp()::Tuple{PipeReadEnd, PipeWriteEnd}

--- a/src/sockets/io/pkcs11.jl
+++ b/src/sockets/io/pkcs11.jl
@@ -61,8 +61,8 @@ const TLS_HASH_SHA512 = UInt8(5)
 const TLS_SIGNATURE_RSA = UInt8(1)
 const TLS_SIGNATURE_ECDSA = UInt8(2)
 
-const AWS_SUPPORTED_CRYPTOKI_VERSION_MAJOR = UInt8(2)
-const AWS_MIN_SUPPORTED_CRYPTOKI_VERSION_MINOR = UInt8(20)
+const SUPPORTED_CRYPTOKI_VERSION_MAJOR = UInt8(2)
+const MIN_SUPPORTED_CRYPTOKI_VERSION_MINOR = UInt8(20)
 
 struct CK_VERSION
     major::UInt8
@@ -192,7 +192,7 @@ struct CK_FUNCTION_LIST
 end
 
 function _pkcs11_function_list_stub(;
-        version = CK_VERSION(AWS_SUPPORTED_CRYPTOKI_VERSION_MAJOR, AWS_MIN_SUPPORTED_CRYPTOKI_VERSION_MINOR),
+        version = CK_VERSION(SUPPORTED_CRYPTOKI_VERSION_MAJOR, MIN_SUPPORTED_CRYPTOKI_VERSION_MINOR),
         C_Initialize::Ptr{Cvoid} = C_NULL,
         C_Finalize::Ptr{Cvoid} = C_NULL,
         C_GetInfo::Ptr{Cvoid} = C_NULL,
@@ -489,8 +489,8 @@ function _pkcs11_init_with_function_list!(lib::Pkcs11Lib)::Nothing
 
     fl = unsafe_load(Ptr{CK_FUNCTION_LIST}(lib.function_list))
     version = fl.version
-    if version.major != AWS_SUPPORTED_CRYPTOKI_VERSION_MAJOR ||
-        version.minor < AWS_MIN_SUPPORTED_CRYPTOKI_VERSION_MINOR
+    if version.major != SUPPORTED_CRYPTOKI_VERSION_MAJOR ||
+        version.minor < MIN_SUPPORTED_CRYPTOKI_VERSION_MINOR
         throw_error(ERROR_IO_PKCS11_VERSION_UNSUPPORTED)
     end
 

--- a/src/sockets/io/retry_strategy.jl
+++ b/src/sockets/io/retry_strategy.jl
@@ -108,14 +108,14 @@ end
 # =============================================================================
 
 # Exponential backoff configuration (matches aws-c-io options)
-struct ExponentialBackoffConfig
+struct ExponentialBackoffConfig{UD}
     backoff_scale_factor_ms::UInt64
     max_backoff_secs::UInt64
     max_retries::UInt32
     jitter_mode::Symbol  # :default, :none, :full, :decorrelated
     generate_random::Union{Nothing, Function}
     generate_random_impl::Union{Nothing, Function}
-    generate_random_user_data::Any
+    generate_random_user_data::UD
 end
 
 function _default_generate_random(_user_data)

--- a/src/sockets/io/tls_channel_handler.jl
+++ b/src/sockets/io/tls_channel_handler.jl
@@ -38,10 +38,10 @@ function _tls_text_is_ascii_or_utf8_bom(cursor::ByteCursor)::Bool
     return true
 end
 
-mutable struct TlsByoCryptoSetupOptions
+mutable struct TlsByoCryptoSetupOptions{UD}
     new_handler_fn::Union{Function, Nothing}
     start_negotiation_fn::Union{Function, Nothing}
-    user_data::Any
+    user_data::UD
 end
 
 function TlsByoCryptoSetupOptions(;
@@ -715,7 +715,7 @@ function tls_ctx_options_init_default_client(;
         alpn_list::Union{String, Nothing} = nothing,
         minimum_tls_version::TlsVersion.T = TlsVersion.TLS_VER_SYS_DEFAULTS,
         cipher_pref::TlsCipherPref.T = TlsCipherPref.TLS_CIPHER_PREF_SYSTEM_DEFAULT,
-        max_fragment_size::Integer = g_aws_channel_max_fragment_size[],
+        max_fragment_size::Integer = g_channel_max_fragment_size[],
     )
     @static if Sys.isapple()
         _tls_set_use_secitem_from_env()
@@ -1132,7 +1132,7 @@ function tls_context_new_client(;
         alpn_list::Union{String, Nothing} = nothing,
         minimum_tls_version::TlsVersion.T = TlsVersion.TLS_VER_SYS_DEFAULTS,
         cipher_pref::TlsCipherPref.T = TlsCipherPref.TLS_CIPHER_PREF_SYSTEM_DEFAULT,
-        max_fragment_size::Integer = g_aws_channel_max_fragment_size[],
+        max_fragment_size::Integer = g_channel_max_fragment_size[],
     )
     opts = tls_ctx_options_init_default_client(;
         verify_peer = verify_peer,
@@ -1153,7 +1153,7 @@ function tls_context_new_server(;
         alpn_list::Union{String, Nothing} = nothing,
         minimum_tls_version::TlsVersion.T = TlsVersion.TLS_VER_SYS_DEFAULTS,
         cipher_pref::TlsCipherPref.T = TlsCipherPref.TLS_CIPHER_PREF_SYSTEM_DEFAULT,
-        max_fragment_size::Integer = g_aws_channel_max_fragment_size[],
+        max_fragment_size::Integer = g_channel_max_fragment_size[],
     )
     opts = tls_ctx_options_init_default_server(
         certificate,

--- a/src/sockets/io/tls_types.jl
+++ b/src/sockets/io/tls_types.jl
@@ -138,7 +138,7 @@ function TlsContextOptions(;
         pkcs12_password_set::Union{Bool, Nothing} = nothing,
         secitem_options::Union{SecItemOptions, Nothing} = nothing,
         keychain_path::Union{String, Nothing} = nothing,
-        max_fragment_size::Integer = g_aws_channel_max_fragment_size[],
+        max_fragment_size::Integer = g_channel_max_fragment_size[],
         verify_peer::Union{Bool, Nothing} = nothing,
         ctx_options_extension = nothing,
         custom_key_op_handler = nothing,

--- a/src/sockets/sockets.jl
+++ b/src/sockets/sockets.jl
@@ -111,7 +111,7 @@ include("io/iocp_pipe.jl")
 include("io/channel_bootstrap.jl")
 
 # Previously included directly from src/Reseau.jl
-include("io/aws_byte_helpers.jl")
+include("io/byte_helpers.jl")
 include("io/crypto_primitives.jl")
 include("io/tls_channel_handler.jl")
 include("io/alpn_handler.jl")

--- a/test/alpn_tests.jl
+++ b/test/alpn_tests.jl
@@ -16,7 +16,7 @@ end
 
 mutable struct AlpnNegotiationArgs
     new_slot::Union{Sockets.ChannelSlot, Nothing}
-    new_handler::Any
+    new_handler::Union{Sockets.PassthroughHandler, Nothing}
     protocol::Union{Reseau.ByteBuffer, Nothing}
 end
 

--- a/test/crypto_tests.jl
+++ b/test/crypto_tests.jl
@@ -22,11 +22,11 @@ end
 
 mutable struct ByoCryptoTestArgs
     lock::ReentrantLock
-    channel::Any
+    channel::Union{Sockets.Channel, Nothing}
     rw_handler::ReadWriteTestHandler
     tls_ctx::Sockets.TlsContext
     tls_options::Sockets.TlsConnectionOptions
-    negotiation_result_fn::Any
+    negotiation_result_fn::Union{Sockets.TlsNegotiationResultCallback, Nothing}
     error_code::Int
     shutdown_invoked::Bool
     listener_destroyed::Bool

--- a/test/pipe_tests.jl
+++ b/test/pipe_tests.jl
@@ -58,7 +58,7 @@ mutable struct PipeState
     results::PipeResults
     buffers::PipeBuffers
     readable_events::PipeReadableEvents
-    test_data::Any
+    test_data::Union{Base.RefValue{Int}, Nothing}
 end
 
 function PipeState(loop_setup::PipeLoopSetup, buffer_size::Integer)

--- a/test/read_write_test_handler.jl
+++ b/test/read_write_test_handler.jl
@@ -1,6 +1,6 @@
 using Reseau
 
-mutable struct ReadWriteTestHandler{FRead, FWrite, SlotRef <: Union{Sockets.ChannelSlot, Nothing}}
+mutable struct ReadWriteTestHandler{FRead, FWrite, SlotRef <: Union{Sockets.ChannelSlot, Nothing}, Ctx}
     slot::SlotRef
     on_read::FRead
     on_write::FWrite
@@ -13,7 +13,7 @@ mutable struct ReadWriteTestHandler{FRead, FWrite, SlotRef <: Union{Sockets.Chan
     increment_read_window_called::Bool
     destroy_called::Union{Base.RefValue{Bool}, Nothing}
     destroy_condition::Union{Base.Threads.Condition, Nothing}
-    ctx::Any
+    ctx::Ctx
 end
 
 function ReadWriteTestHandler(
@@ -23,7 +23,7 @@ function ReadWriteTestHandler(
         window::Integer = 0,
         ctx = nothing,
     )
-    return ReadWriteTestHandler{typeof(on_read), typeof(on_write), Union{Sockets.ChannelSlot, Nothing}}(
+    return ReadWriteTestHandler{typeof(on_read), typeof(on_write), Union{Sockets.ChannelSlot, Nothing}, typeof(ctx)}(
         nothing,
         on_read,
         on_write,
@@ -180,7 +180,7 @@ mutable struct RwWriteTaskArgs
     handler::ReadWriteTestHandler
     slot::Sockets.ChannelSlot
     buffer::Reseau.ByteBuffer
-    on_completion::Any
+    on_completion::Union{Reseau.EventCallable, Nothing}
     user_data::Any
 end
 

--- a/test/tls_tests_impl.jl
+++ b/test/tls_tests_impl.jl
@@ -2202,8 +2202,8 @@ end
     ctx = _test_client_ctx()
     @test ctx isa Sockets.TlsContext
 
-    prev_max = Sockets.g_aws_channel_max_fragment_size[]
-    Sockets.g_aws_channel_max_fragment_size[] = Csize_t(4096)
+    prev_max = Sockets.g_channel_max_fragment_size[]
+    Sockets.g_channel_max_fragment_size[] = Csize_t(4096)
 
     channel = Sockets.Channel(event_loop, nothing)
     tls_slot = Sockets.channel_slot_new!(channel)
@@ -2232,7 +2232,7 @@ end
     EventLoops.schedule_task_now!(event_loop, task)
 
     cap = take!(results)
-    expected = Int(Sockets.g_aws_channel_max_fragment_size[] - Csize_t(Sockets.TLS_EST_RECORD_OVERHEAD))
+    expected = Int(Sockets.g_channel_max_fragment_size[] - Csize_t(Sockets.TLS_EST_RECORD_OVERHEAD))
     @test cap == expected
 
     if handler isa Sockets.TlsChannelHandler
@@ -2240,7 +2240,7 @@ end
         @test Sockets.handler_initial_window_size(handler) == Csize_t(Sockets.TLS_EST_HANDSHAKE_SIZE)
     end
 
-    Sockets.g_aws_channel_max_fragment_size[] = prev_max
+    Sockets.g_channel_max_fragment_size[] = prev_max
     close(elg)
 end
 
@@ -2250,8 +2250,8 @@ end
         return
     end
 
-    prev_max = Sockets.g_aws_channel_max_fragment_size[]
-    Sockets.g_aws_channel_max_fragment_size[] = 4096
+    prev_max = Sockets.g_channel_max_fragment_size[]
+    Sockets.g_channel_max_fragment_size[] = 4096
 
     elg = EventLoops.EventLoopGroup(; loop_count = 1)
     resolver = Sockets.HostResolver()
@@ -2390,7 +2390,7 @@ end
     Sockets.server_bootstrap_shutdown!(server_bootstrap)
     Sockets.close(resolver)
     close(elg)
-    Sockets.g_aws_channel_max_fragment_size[] = prev_max
+    Sockets.g_channel_max_fragment_size[] = prev_max
 end
 
 @testset "TLS shutdown with cached data" begin
@@ -2400,8 +2400,8 @@ end
     end
 
     for window_update_after_shutdown in (false, true)
-        prev_max = Sockets.g_aws_channel_max_fragment_size[]
-        Sockets.g_aws_channel_max_fragment_size[] = 4096
+        prev_max = Sockets.g_channel_max_fragment_size[]
+        Sockets.g_channel_max_fragment_size[] = 4096
 
         elg = EventLoops.EventLoopGroup(; loop_count = 1)
         resolver = Sockets.HostResolver()
@@ -2413,7 +2413,7 @@ end
         if !(server_ctx isa Sockets.TlsContext) || !(client_ctx isa Sockets.TlsContext)
             Sockets.close(resolver)
             close(elg)
-            Sockets.g_aws_channel_max_fragment_size[] = prev_max
+            Sockets.g_channel_max_fragment_size[] = prev_max
             continue
         end
 
@@ -2556,7 +2556,7 @@ end
         Sockets.server_bootstrap_shutdown!(server_bootstrap)
         Sockets.close(resolver)
         close(elg)
-        Sockets.g_aws_channel_max_fragment_size[] = prev_max
+        Sockets.g_channel_max_fragment_size[] = prev_max
     end
 end
 


### PR DESCRIPTION
## Summary
- remove lingering internal aws/AWS-prefixed identifiers where safely possible
- rename `aws_byte_helpers.jl` to `byte_helpers.jl` and update includes/callsites
- tighten straightforward `::Any` fields in IO/test helper structs
- keep parity/external/dependency AWS identifiers intact where required

## Validation
- JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'
- RESEAU_RUN_TLS_TESTS=1 JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'
