### PR TITLE
Refactor channel internals and stabilize precompile workload

### DIFF
--- a/Manifest-v1.12.toml
+++ b/Manifest-v1.12.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.3"
 manifest_format = "2.0"
-project_hash = "5161651ccad8168f11dafa414897e86ec255adbd"
+project_hash = "ba135afc97a360bc968a31a17132cd5334ef8a36"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -58,6 +58,12 @@ version = "1.11.0"
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 version = "1.11.0"
 
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "07a921781cab75691315adc645096ed5e370cb77"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.3"
+
 [[deps.Preferences]]
 deps = ["TOML"]
 git-tree-sha1 = "522f093a29b31a93e34eaea17ba055d850edea28"
@@ -75,7 +81,7 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 version = "1.11.0"
 
 [[deps.Reseau]]
-deps = ["Base64", "Dates", "EnumX", "LibAwsCal", "LibAwsCommon", "Libdl", "Printf", "ScopedValues", "UUIDs"]
+deps = ["Base64", "Dates", "EnumX", "LibAwsCal", "LibAwsCommon", "Libdl", "PrecompileTools", "Printf", "ScopedValues", "UUIDs"]
 path = "."
 uuid = "802f3686-a58f-41ce-bb0c-3c43c75bba36"
 version = "1.1.1"

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
 ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 julia = "1.11"
@@ -19,6 +20,7 @@ LibAwsCal = "1.1.12"
 LibAwsCommon = "1.3.1"
 EnumX = "1"
 ScopedValues = "1"
+PrecompileTools = "1"
 
 [weakdeps]
 aws_lc_jll = "97bc56f7-b146-5eb0-9ba6-f74d48471a93"

--- a/src/Reseau.jl
+++ b/src/Reseau.jl
@@ -1,6 +1,7 @@
 module Reseau
 
 using EnumX
+using PrecompileTools: @compile_workload, @setup_workload
 using ScopedValues
 import UUIDs
 
@@ -29,6 +30,7 @@ include("foreign_threads.jl")
 include("task_scheduler.jl")
 include("eventloops/eventloops.jl")
 include("sockets/sockets.jl")
+include("precompile_workload.jl")
 
 function __init__()
     ForeignThreads.__init__()

--- a/src/eventloops/kqueue_event_loop.jl
+++ b/src/eventloops/kqueue_event_loop.jl
@@ -616,7 +616,6 @@
         end
 
         handle_data = unsafe_pointer_to_objref(handle.additional_data)::KqueueHandleData{KqueueEventLoop}
-        impl = event_loop.impl::KqueueEventLoop
 
         if @atomic event_loop.running
             if event_loop_thread_is_callers_thread(event_loop)

--- a/src/precompile_workload.jl
+++ b/src/precompile_workload.jl
@@ -1,93 +1,3 @@
-const _PRECOMPILE_STAGE = let
-    stage_env = get(ENV, "RESEAU_PRECOMPILE_STAGE", "6")
-    parsed = try
-        parse(Int, stage_env)
-    catch
-        6
-    end
-    max(parsed, 0)
-end
-function _pc_debug(msg::AbstractString)::Nothing
-    _ = msg
-    return nothing
-end
-
-@inline function _pc_try(f)::Nothing
-    try
-        f()
-    catch
-    end
-    return nothing
-end
-
-function _pc_init_all!()::Bool
-    _pc_debug("init start")
-    ok = true
-
-    try
-        ForeignThreads.__init__()
-    catch e
-        _pc_debug("ForeignThreads.__init__ failed: $(repr(e))")
-        ok = false
-    end
-
-    try
-        EventLoops.__init__()
-    catch e
-        _pc_debug("EventLoops.__init__ failed: $(repr(e))")
-        ok = false
-    end
-
-    try
-        Sockets.io_library_init()
-    catch e
-        _pc_debug("Sockets.io_library_init failed: $(repr(e))")
-        ok = false
-    end
-
-    _pc_debug(ok ? "init done" : "init partial")
-    return ok
-end
-
-function _pc_close_default_event_loop_group!()::Nothing
-    if !isdefined(EventLoops, :EVENT_LOOP_GROUP)
-        return nothing
-    end
-    once = EventLoops.EVENT_LOOP_GROUP
-    if getfield(once, :state) != 0
-        value = getfield(once, :value)
-        value !== nothing && close(value)
-    end
-    return nothing
-end
-
-function _pc_close_default_host_resolver!()::Nothing
-    if !isdefined(Sockets, :HOST_RESOLVER)
-        return nothing
-    end
-    once = Sockets.HOST_RESOLVER
-    if getfield(once, :state) != 0
-        value = getfield(once, :value)
-        value !== nothing && close(value)
-    end
-    return nothing
-end
-
-function _pc_cleanup_all!()::Nothing
-    _pc_debug("cleanup start")
-
-    _pc_try(_pc_close_default_host_resolver!)
-    _pc_try(_pc_close_default_event_loop_group!)
-    _pc_try(Sockets.io_library_clean_up)
-    _pc_try(EventLoops._cal_cleanup)
-    _pc_try(ForeignThreads.join_all_managed)
-    _pc_try(() -> GC.gc(true))
-    _pc_try(GC.gc)
-
-    _pc_debug("cleanup done")
-    return nothing
-end
-
 const _PC_FOREIGN_THREAD_ENTRY_C = Ref{Ptr{Cvoid}}(C_NULL)
 const _PC_FOREIGN_THREAD_LOCK = ReentrantLock()
 
@@ -99,215 +9,83 @@ ForeignThreads.@wrap_thread_fn function _pc_foreign_thread_entry(started::Base.T
     end
 end
 
-function _pc_init_cfunctions!()::Nothing
+function _pc_init_foreign_thread_entry!()::Nothing
     _PC_FOREIGN_THREAD_ENTRY_C[] != C_NULL && return nothing
     lock(_PC_FOREIGN_THREAD_LOCK)
     try
-        _PC_FOREIGN_THREAD_ENTRY_C[] != C_NULL && return nothing
-        _PC_FOREIGN_THREAD_ENTRY_C[] = @cfunction(_pc_foreign_thread_entry, Ptr{Cvoid}, (Ptr{Cvoid},))
+        _PC_FOREIGN_THREAD_ENTRY_C[] == C_NULL || return nothing
+        _PC_FOREIGN_THREAD_ENTRY_C[] = @cfunction(
+            _pc_foreign_thread_entry,
+            Ptr{Cvoid},
+            (Ptr{Cvoid},),
+        )
     finally
         unlock(_PC_FOREIGN_THREAD_LOCK)
     end
     return nothing
 end
 
-function _pc_stage_1_foreign_thread!()::Nothing
-    _pc_debug("stage 1 start: foreign thread")
-    _pc_init_cfunctions!()
-
-    started = Base.Threads.Event()
-    _ = ForeignThreads.ForeignThread(
-        "ReseauPrecompileStage1",
-        _PC_FOREIGN_THREAD_ENTRY_C,
-        started;
-        join_strategy = ForeignThreads.ThreadJoinStrategy.MANAGED,
-    )
-
-    wait(started)
-    ForeignThreads.join_all_managed()
-    _pc_debug("stage 1 done")
-    return nothing
-end
-
-function _pc_stage_2_event_loop_task!()::Nothing
-    _pc_debug("stage 2 start: event loop group + scheduled task")
-    elg = EventLoops.EventLoopGroup(; loop_count = 1)
-    ran = Base.Threads.Event()
-
-    try
-        loop = elg.event_loops[1]
-        EventLoops.schedule_task_now!(loop; type_tag = "precompile_stage2_task") do _
-            _pc_try(() -> notify(ran))
-            return nothing
-        end
-        wait(ran)
-    finally
-        close(elg)
-        yield()
-    end
-
-    _pc_debug("stage 2 done")
-    return nothing
-end
-
-function _pc_stage_3_host_resolver!()::Nothing
-    _pc_debug("stage 3 start: host resolver")
-    resolver = Sockets.HostResolver()
-
-    try
-        addresses = Sockets.host_resolver_resolve!(resolver, "127.0.0.1")
-        isempty(addresses) && error("host resolver returned no addresses for 127.0.0.1")
-    finally
-        close(resolver)
-        ForeignThreads.join_all_managed()
-    end
-
-    _pc_debug("stage 3 done")
-    return nothing
-end
-
-@inline function _pc_close_socket_safe!(sock)::Nothing
-    _pc_try(() -> Sockets.socket_close(sock))
-    _pc_try(() -> Sockets.socket_cleanup!(sock))
-    return nothing
-end
-
-@inline function _pc_close_server_safe!(server)::Nothing
-    _pc_try(() -> begin
-        lock(server.state.cond)
-        try
-            if !server.state.closed
-                server.state.closed = true
-                server.state.close_error = ERROR_IO_SOCKET_CLOSED
-                notify(server.state.cond)
-            end
-        finally
-            unlock(server.state.cond)
-        end
-        Sockets.server_bootstrap_shutdown!(server.bootstrap)
-    end)
-    return nothing
-end
-
-@inline function _pc_close_pending_server_accepts!(server)::Nothing
-    pending = []
-    lock(server.state.cond)
-    try
-        while !isempty(server.state.accept_queue)
-            push!(pending, popfirst!(server.state.accept_queue))
-        end
-    finally
-        unlock(server.state.cond)
-    end
-    for sock in pending
-        _pc_try(() -> close(sock))
+@inline function _pc_close_default_event_loop_group!()::Nothing
+    isdefined(EventLoops, :EVENT_LOOP_GROUP) || return nothing
+    once = EventLoops.EVENT_LOOP_GROUP
+    if getfield(once, :state) != 0
+        value = getfield(once, :value)
+        value === nothing || close(value)
     end
     return nothing
 end
 
-@inline function _pc_drain_yields!(rounds::Int = 512)::Nothing
+@inline function _pc_close_default_host_resolver!()::Nothing
+    isdefined(Sockets, :HOST_RESOLVER) || return nothing
+    once = Sockets.HOST_RESOLVER
+    if getfield(once, :state) != 0
+        value = getfield(once, :value)
+        value === nothing || close(value)
+    end
+    return nothing
+end
+
+@inline function _pc_yield!(rounds::Int = 128)::Nothing
     for _ in 1:rounds
         yield()
     end
     return nothing
 end
 
-function _pc_stage_4_tcp_listener!()::Nothing
-    elg = EventLoops.EventLoopGroup(; loop_count = 1)
-    server::Union{Sockets.TCPServer, Nothing} = nothing
-    try
-        server = Sockets.listen("127.0.0.1", 0; event_loop_group = elg)
-        close(server)
-        server = nothing
-    finally
-        server !== nothing && _pc_close_server_safe!(server)
-        _pc_drain_yields!()
-        close(elg)
-        _pc_drain_yields!()
-    end
+function _pc_cleanup_runtime!()::Nothing
+    _pc_close_default_host_resolver!()
+    _pc_close_default_event_loop_group!()
+    Sockets.io_library_clean_up()
+    EventLoops._cal_cleanup()
+    ForeignThreads.join_all_managed()
+    GC.gc(true)
+    GC.gc()
     return nothing
 end
 
-function _pc_echo_exchange!(client, peer)::Nothing
-    write(client, "hello")
-    flush(client)
+function _pc_run_echo_workload!()::Nothing
+    _pc_init_foreign_thread_entry!()
 
-    request = String(read(peer, 5))
-    request == "hello" || error("server expected hello, got $(repr(request))")
+    started = Base.Threads.Event()
+    _ = ForeignThreads.ForeignThread(
+        "ReseauPrecompile",
+        _PC_FOREIGN_THREAD_ENTRY_C,
+        started;
+        join_strategy = ForeignThreads.ThreadJoinStrategy.MANAGED,
+    )
+    wait(started)
+    ForeignThreads.join_all_managed()
 
-    write(peer, "hello")
-    flush(peer)
-    close(peer)
+    event_loop_group = EventLoops.EventLoopGroup(; loop_count = 1)
+    host_resolver = Sockets.HostResolver()
 
-    response = String(read(client, 5))
-    response == "hello" || error("client expected hello, got $(repr(response))")
-
-    close(client)
-    return nothing
-end
-
-function _pc_stage_5_tcp_echo!()::Nothing
-    elg = EventLoops.EventLoopGroup(; loop_count = 1)
-    connect_opts = Sockets.SocketOptions(connect_timeout_ms = UInt32(1000))
-    resolve_as_address = Sockets.HostResolutionConfig(resolve_host_as_address = true)
-
-    server::Union{Sockets.TCPServer, Nothing} = nothing
-    client::Union{Sockets.TCPSocket, Nothing} = nothing
-    peer::Union{Sockets.TCPSocket, Nothing} = nothing
+    server::Union{Sockets.TCPServer,Nothing} = nothing
+    client::Union{Sockets.TCPSocket,Nothing} = nothing
+    peer::Union{Sockets.TCPSocket,Nothing} = nothing
 
     try
-        server = Sockets.listen("127.0.0.1", 0; event_loop_group = elg)
-        _, port_u16 = Sockets.getsockname(server)
-
-        client = Sockets.connect(
-            "127.0.0.1",
-            Int(port_u16);
-            event_loop_group = elg,
-            socket_options = connect_opts,
-            host_resolution_config = resolve_as_address,
-        )
-
-        peer = Sockets.accept(server)
-
-        _pc_echo_exchange!(client, peer)
-
-        peer = nothing
-        client = nothing
-
-        _pc_close_server_safe!(server)
-        server = nothing
-    finally
-        peer !== nothing && close(peer)
-        client !== nothing && close(client)
-        if server !== nothing
-            _pc_close_pending_server_accepts!(server)
-            _pc_close_server_safe!(server)
-            _pc_close_pending_server_accepts!(server)
-        end
-
-        _pc_drain_yields!()
-        server !== nothing && _pc_close_pending_server_accepts!(server)
-        close(elg)
-        _pc_drain_yields!()
-    end
-    return nothing
-end
-
-function _pc_stage_6_trim_echo!()::Nothing
-    elg = EventLoops.EventLoopGroup(; loop_count = 1)
-    resolver = Sockets.HostResolver()
-    server::Union{Sockets.TCPServer, Nothing} = nothing
-    client::Union{Sockets.TCPSocket, Nothing} = nothing
-    peer::Union{Sockets.TCPSocket, Nothing} = nothing
-
-    try
-        # Mirror trim/echo_trim_safe.jl to root the exact high-level API path.
-        Sockets.io_library_init()
-
-        port_u16, server = Sockets.listenany(0; event_loop_group = elg)
-
-        client = Sockets.connect(Int(port_u16); event_loop_group = elg, host_resolver = resolver)
-
+        port_u16, server = Sockets.listenany(0; event_loop_group = event_loop_group)
+        client = Sockets.connect(Int(port_u16); event_loop_group = event_loop_group, host_resolver = host_resolver)
         peer = Sockets.accept(server)
 
         write(client, "hello")
@@ -326,55 +104,36 @@ function _pc_stage_6_trim_echo!()::Nothing
 
         close(client)
         client = nothing
-        _pc_close_server_safe!(server)
+
+        close(server)
         server = nothing
     finally
-        peer !== nothing && close(peer)
-        client !== nothing && close(client)
-        if server !== nothing
-            _pc_close_pending_server_accepts!(server)
-            _pc_close_server_safe!(server)
-            _pc_close_pending_server_accepts!(server)
-        end
-        close(resolver)
-        _pc_drain_yields!()
-        server !== nothing && _pc_close_pending_server_accepts!(server)
-        close(elg)
-        _pc_drain_yields!()
+        peer === nothing || close(peer)
+        client === nothing || close(client)
+        server === nothing || close(server)
+        close(host_resolver)
+        _pc_yield!()
+        close(event_loop_group)
+        _pc_yield!()
+        ForeignThreads.join_all_managed()
     end
-    return nothing
-end
-
-function _pc_run_upto_stage!(stage::Int)::Nothing
-    stage <= 0 && return nothing
-
-    stage >= 1 && _pc_stage_1_foreign_thread!()
-    stage >= 2 && _pc_stage_2_event_loop_task!()
-    stage >= 3 && _pc_stage_3_host_resolver!()
-    stage >= 4 && _pc_stage_4_tcp_listener!()
-    stage >= 5 && _pc_stage_5_tcp_echo!()
-    stage >= 6 && _pc_stage_6_trim_echo!()
 
     return nothing
 end
 
 try
     @setup_workload begin
-        init_ok = _pc_init_all!()
         try
+            ForeignThreads.__init__()
+            EventLoops.__init__()
+            Sockets.io_library_init()
             @compile_workload begin
-                if init_ok
-                    _pc_debug("compile workload start (stage=$(_PRECOMPILE_STAGE))")
-                    _pc_run_upto_stage!(_PRECOMPILE_STAGE)
-                    _pc_debug("compile workload done")
-                else
-                    _pc_debug("compile workload skipped (init failed)")
-                end
+                _pc_run_echo_workload!()
             end
         finally
-            _pc_cleanup_all!()
+            _pc_cleanup_runtime!()
         end
     end
 catch e
-    @info "Ignoring error that occurred during precompilation workload" exception = (e, catch_backtrace())
+    @info "Ignoring an error that occurred during the precompilation workload" exception = (e, catch_backtrace())
 end

--- a/src/precompile_workload.jl
+++ b/src/precompile_workload.jl
@@ -1,0 +1,380 @@
+const _PRECOMPILE_STAGE = let
+    stage_env = get(ENV, "RESEAU_PRECOMPILE_STAGE", "6")
+    parsed = try
+        parse(Int, stage_env)
+    catch
+        6
+    end
+    max(parsed, 0)
+end
+function _pc_debug(msg::AbstractString)::Nothing
+    _ = msg
+    return nothing
+end
+
+@inline function _pc_try(f)::Nothing
+    try
+        f()
+    catch
+    end
+    return nothing
+end
+
+function _pc_init_all!()::Bool
+    _pc_debug("init start")
+    ok = true
+
+    try
+        ForeignThreads.__init__()
+    catch e
+        _pc_debug("ForeignThreads.__init__ failed: $(repr(e))")
+        ok = false
+    end
+
+    try
+        EventLoops.__init__()
+    catch e
+        _pc_debug("EventLoops.__init__ failed: $(repr(e))")
+        ok = false
+    end
+
+    try
+        Sockets.io_library_init()
+    catch e
+        _pc_debug("Sockets.io_library_init failed: $(repr(e))")
+        ok = false
+    end
+
+    _pc_debug(ok ? "init done" : "init partial")
+    return ok
+end
+
+function _pc_close_default_event_loop_group!()::Nothing
+    if !isdefined(EventLoops, :EVENT_LOOP_GROUP)
+        return nothing
+    end
+    once = EventLoops.EVENT_LOOP_GROUP
+    if getfield(once, :state) != 0
+        value = getfield(once, :value)
+        value !== nothing && close(value)
+    end
+    return nothing
+end
+
+function _pc_close_default_host_resolver!()::Nothing
+    if !isdefined(Sockets, :HOST_RESOLVER)
+        return nothing
+    end
+    once = Sockets.HOST_RESOLVER
+    if getfield(once, :state) != 0
+        value = getfield(once, :value)
+        value !== nothing && close(value)
+    end
+    return nothing
+end
+
+function _pc_cleanup_all!()::Nothing
+    _pc_debug("cleanup start")
+
+    _pc_try(_pc_close_default_host_resolver!)
+    _pc_try(_pc_close_default_event_loop_group!)
+    _pc_try(Sockets.io_library_clean_up)
+    _pc_try(EventLoops._cal_cleanup)
+    _pc_try(ForeignThreads.join_all_managed)
+    _pc_try(() -> GC.gc(true))
+    _pc_try(GC.gc)
+
+    _pc_debug("cleanup done")
+    return nothing
+end
+
+const _PC_FOREIGN_THREAD_ENTRY_C = Ref{Ptr{Cvoid}}(C_NULL)
+const _PC_FOREIGN_THREAD_LOCK = ReentrantLock()
+
+ForeignThreads.@wrap_thread_fn function _pc_foreign_thread_entry(started::Base.Threads.Event)
+    try
+        notify(started)
+    finally
+        ForeignThreads.managed_thread_finished!()
+    end
+end
+
+function _pc_init_cfunctions!()::Nothing
+    _PC_FOREIGN_THREAD_ENTRY_C[] != C_NULL && return nothing
+    lock(_PC_FOREIGN_THREAD_LOCK)
+    try
+        _PC_FOREIGN_THREAD_ENTRY_C[] != C_NULL && return nothing
+        _PC_FOREIGN_THREAD_ENTRY_C[] = @cfunction(_pc_foreign_thread_entry, Ptr{Cvoid}, (Ptr{Cvoid},))
+    finally
+        unlock(_PC_FOREIGN_THREAD_LOCK)
+    end
+    return nothing
+end
+
+function _pc_stage_1_foreign_thread!()::Nothing
+    _pc_debug("stage 1 start: foreign thread")
+    _pc_init_cfunctions!()
+
+    started = Base.Threads.Event()
+    _ = ForeignThreads.ForeignThread(
+        "ReseauPrecompileStage1",
+        _PC_FOREIGN_THREAD_ENTRY_C,
+        started;
+        join_strategy = ForeignThreads.ThreadJoinStrategy.MANAGED,
+    )
+
+    wait(started)
+    ForeignThreads.join_all_managed()
+    _pc_debug("stage 1 done")
+    return nothing
+end
+
+function _pc_stage_2_event_loop_task!()::Nothing
+    _pc_debug("stage 2 start: event loop group + scheduled task")
+    elg = EventLoops.EventLoopGroup(; loop_count = 1)
+    ran = Base.Threads.Event()
+
+    try
+        loop = elg.event_loops[1]
+        EventLoops.schedule_task_now!(loop; type_tag = "precompile_stage2_task") do _
+            _pc_try(() -> notify(ran))
+            return nothing
+        end
+        wait(ran)
+    finally
+        close(elg)
+        yield()
+    end
+
+    _pc_debug("stage 2 done")
+    return nothing
+end
+
+function _pc_stage_3_host_resolver!()::Nothing
+    _pc_debug("stage 3 start: host resolver")
+    resolver = Sockets.HostResolver()
+
+    try
+        addresses = Sockets.host_resolver_resolve!(resolver, "127.0.0.1")
+        isempty(addresses) && error("host resolver returned no addresses for 127.0.0.1")
+    finally
+        close(resolver)
+        ForeignThreads.join_all_managed()
+    end
+
+    _pc_debug("stage 3 done")
+    return nothing
+end
+
+@inline function _pc_close_socket_safe!(sock)::Nothing
+    _pc_try(() -> Sockets.socket_close(sock))
+    _pc_try(() -> Sockets.socket_cleanup!(sock))
+    return nothing
+end
+
+@inline function _pc_close_server_safe!(server)::Nothing
+    _pc_try(() -> begin
+        lock(server.state.cond)
+        try
+            if !server.state.closed
+                server.state.closed = true
+                server.state.close_error = ERROR_IO_SOCKET_CLOSED
+                notify(server.state.cond)
+            end
+        finally
+            unlock(server.state.cond)
+        end
+        Sockets.server_bootstrap_shutdown!(server.bootstrap)
+    end)
+    return nothing
+end
+
+@inline function _pc_close_pending_server_accepts!(server)::Nothing
+    pending = []
+    lock(server.state.cond)
+    try
+        while !isempty(server.state.accept_queue)
+            push!(pending, popfirst!(server.state.accept_queue))
+        end
+    finally
+        unlock(server.state.cond)
+    end
+    for sock in pending
+        _pc_try(() -> close(sock))
+    end
+    return nothing
+end
+
+@inline function _pc_drain_yields!(rounds::Int = 512)::Nothing
+    for _ in 1:rounds
+        yield()
+    end
+    return nothing
+end
+
+function _pc_stage_4_tcp_listener!()::Nothing
+    elg = EventLoops.EventLoopGroup(; loop_count = 1)
+    server::Union{Sockets.TCPServer, Nothing} = nothing
+    try
+        server = Sockets.listen("127.0.0.1", 0; event_loop_group = elg)
+        close(server)
+        server = nothing
+    finally
+        server !== nothing && _pc_close_server_safe!(server)
+        _pc_drain_yields!()
+        close(elg)
+        _pc_drain_yields!()
+    end
+    return nothing
+end
+
+function _pc_echo_exchange!(client, peer)::Nothing
+    write(client, "hello")
+    flush(client)
+
+    request = String(read(peer, 5))
+    request == "hello" || error("server expected hello, got $(repr(request))")
+
+    write(peer, "hello")
+    flush(peer)
+    close(peer)
+
+    response = String(read(client, 5))
+    response == "hello" || error("client expected hello, got $(repr(response))")
+
+    close(client)
+    return nothing
+end
+
+function _pc_stage_5_tcp_echo!()::Nothing
+    elg = EventLoops.EventLoopGroup(; loop_count = 1)
+    connect_opts = Sockets.SocketOptions(connect_timeout_ms = UInt32(1000))
+    resolve_as_address = Sockets.HostResolutionConfig(resolve_host_as_address = true)
+
+    server::Union{Sockets.TCPServer, Nothing} = nothing
+    client::Union{Sockets.TCPSocket, Nothing} = nothing
+    peer::Union{Sockets.TCPSocket, Nothing} = nothing
+
+    try
+        server = Sockets.listen("127.0.0.1", 0; event_loop_group = elg)
+        _, port_u16 = Sockets.getsockname(server)
+
+        client = Sockets.connect(
+            "127.0.0.1",
+            Int(port_u16);
+            event_loop_group = elg,
+            socket_options = connect_opts,
+            host_resolution_config = resolve_as_address,
+        )
+
+        peer = Sockets.accept(server)
+
+        _pc_echo_exchange!(client, peer)
+
+        peer = nothing
+        client = nothing
+
+        _pc_close_server_safe!(server)
+        server = nothing
+    finally
+        peer !== nothing && close(peer)
+        client !== nothing && close(client)
+        if server !== nothing
+            _pc_close_pending_server_accepts!(server)
+            _pc_close_server_safe!(server)
+            _pc_close_pending_server_accepts!(server)
+        end
+
+        _pc_drain_yields!()
+        server !== nothing && _pc_close_pending_server_accepts!(server)
+        close(elg)
+        _pc_drain_yields!()
+    end
+    return nothing
+end
+
+function _pc_stage_6_trim_echo!()::Nothing
+    elg = EventLoops.EventLoopGroup(; loop_count = 1)
+    resolver = Sockets.HostResolver()
+    server::Union{Sockets.TCPServer, Nothing} = nothing
+    client::Union{Sockets.TCPSocket, Nothing} = nothing
+    peer::Union{Sockets.TCPSocket, Nothing} = nothing
+
+    try
+        # Mirror trim/echo_trim_safe.jl to root the exact high-level API path.
+        Sockets.io_library_init()
+
+        port_u16, server = Sockets.listenany(0; event_loop_group = elg)
+
+        client = Sockets.connect(Int(port_u16); event_loop_group = elg, host_resolver = resolver)
+
+        peer = Sockets.accept(server)
+
+        write(client, "hello")
+        flush(client)
+
+        request = String(read(peer, 5))
+        request == "hello" || error("server expected hello, got $(repr(request))")
+
+        write(peer, "hello")
+        flush(peer)
+        close(peer)
+        peer = nothing
+
+        response = String(read(client, 5))
+        response == "hello" || error("client expected hello, got $(repr(response))")
+
+        close(client)
+        client = nothing
+        _pc_close_server_safe!(server)
+        server = nothing
+    finally
+        peer !== nothing && close(peer)
+        client !== nothing && close(client)
+        if server !== nothing
+            _pc_close_pending_server_accepts!(server)
+            _pc_close_server_safe!(server)
+            _pc_close_pending_server_accepts!(server)
+        end
+        close(resolver)
+        _pc_drain_yields!()
+        server !== nothing && _pc_close_pending_server_accepts!(server)
+        close(elg)
+        _pc_drain_yields!()
+    end
+    return nothing
+end
+
+function _pc_run_upto_stage!(stage::Int)::Nothing
+    stage <= 0 && return nothing
+
+    stage >= 1 && _pc_stage_1_foreign_thread!()
+    stage >= 2 && _pc_stage_2_event_loop_task!()
+    stage >= 3 && _pc_stage_3_host_resolver!()
+    stage >= 4 && _pc_stage_4_tcp_listener!()
+    stage >= 5 && _pc_stage_5_tcp_echo!()
+    stage >= 6 && _pc_stage_6_trim_echo!()
+
+    return nothing
+end
+
+try
+    @setup_workload begin
+        init_ok = _pc_init_all!()
+        try
+            @compile_workload begin
+                if init_ok
+                    _pc_debug("compile workload start (stage=$(_PRECOMPILE_STAGE))")
+                    _pc_run_upto_stage!(_PRECOMPILE_STAGE)
+                    _pc_debug("compile workload done")
+                else
+                    _pc_debug("compile workload skipped (init failed)")
+                end
+            end
+        finally
+            _pc_cleanup_all!()
+        end
+    end
+catch e
+    @info "Ignoring error that occurred during precompilation workload" exception = (e, catch_backtrace())
+end

--- a/src/sockets/io/channel_callables.jl
+++ b/src/sockets/io/channel_callables.jl
@@ -1,0 +1,294 @@
+# Trim-safe handler dispatch wrappers so hot channel send paths can avoid
+# abstract-method dispatch on handler reference types.
+struct _ChannelSlotReadCallWrapper <: Function end
+@inline function (::_ChannelSlotReadCallWrapper)(
+        f::F,
+        slot_ptr::Ptr{Cvoid},
+        message_ptr::Ptr{Cvoid},
+    ) where {F <: Function}
+    slot = _callback_ptr_to_obj(slot_ptr)::ChannelSlot
+    message = _callback_ptr_to_obj(message_ptr)::IoMessage
+    f(slot, message)
+    return nothing
+end
+
+@generated function _channel_slot_read_gen_fptr(::Type{F}) where {F <: Function}
+    quote
+        @cfunction($(_ChannelSlotReadCallWrapper()), Cvoid, (Ref{$F}, Ptr{Cvoid}, Ptr{Cvoid}))
+    end
+end
+
+struct ChannelHandlerReadCallable
+    ptr::Ptr{Cvoid}
+    objptr::Ptr{Cvoid}
+    _root::Any
+end
+
+function ChannelHandlerReadCallable(callable::F) where {F <: Function}
+    ptr = _channel_slot_read_gen_fptr(F)
+    objref = Base.cconvert(Ref{F}, callable)
+    objptr = Ptr{Cvoid}(Base.unsafe_convert(Ref{F}, objref))
+    return ChannelHandlerReadCallable(ptr, objptr, objref)
+end
+
+function ChannelHandlerReadCallable(handler::H) where {H}
+    return ChannelHandlerReadCallable(_ChannelHandlerReadDispatch(handler))
+end
+
+@inline function (f::ChannelHandlerReadCallable)(slot, message)::Nothing
+    slot_ptr, slot_root = _callback_obj_to_ptr_and_root(slot)
+    message_ptr, message_root = _callback_obj_to_ptr_and_root(message)
+    GC.@preserve slot_root message_root begin
+        ccall(f.ptr, Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), f.objptr, slot_ptr, message_ptr)
+    end
+    return nothing
+end
+
+struct _ChannelSlotWriteCallWrapper <: Function end
+@inline function (::_ChannelSlotWriteCallWrapper)(
+        f::F,
+        slot_ptr::Ptr{Cvoid},
+        message_ptr::Ptr{Cvoid},
+    ) where {F <: Function}
+    slot = _callback_ptr_to_obj(slot_ptr)::ChannelSlot
+    message = _callback_ptr_to_obj(message_ptr)::IoMessage
+    f(slot, message)
+    return nothing
+end
+
+@generated function _channel_slot_write_gen_fptr(::Type{F}) where {F <: Function}
+    quote
+        @cfunction($(_ChannelSlotWriteCallWrapper()), Cvoid, (Ref{$F}, Ptr{Cvoid}, Ptr{Cvoid}))
+    end
+end
+
+struct ChannelHandlerWriteCallable
+    ptr::Ptr{Cvoid}
+    objptr::Ptr{Cvoid}
+    _root::Any
+end
+
+function ChannelHandlerWriteCallable(callable::F) where {F <: Function}
+    ptr = _channel_slot_write_gen_fptr(F)
+    objref = Base.cconvert(Ref{F}, callable)
+    objptr = Ptr{Cvoid}(Base.unsafe_convert(Ref{F}, objref))
+    return ChannelHandlerWriteCallable(ptr, objptr, objref)
+end
+
+function ChannelHandlerWriteCallable(handler::H) where {H}
+    return ChannelHandlerWriteCallable(_ChannelHandlerWriteDispatch(handler))
+end
+
+@inline function (f::ChannelHandlerWriteCallable)(slot, message)::Nothing
+    slot_ptr, slot_root = _callback_obj_to_ptr_and_root(slot)
+    message_ptr, message_root = _callback_obj_to_ptr_and_root(message)
+    GC.@preserve slot_root message_root begin
+        ccall(f.ptr, Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), f.objptr, slot_ptr, message_ptr)
+    end
+    return nothing
+end
+
+struct _ChannelSlotIncrementWindowCallWrapper <: Function end
+@inline function (::_ChannelSlotIncrementWindowCallWrapper)(
+        f::F,
+        slot_ptr::Ptr{Cvoid},
+        size::Csize_t,
+    ) where {F <: Function}
+    slot = _callback_ptr_to_obj(slot_ptr)::ChannelSlot
+    f(slot, size)
+    return nothing
+end
+
+@generated function _channel_slot_increment_window_gen_fptr(::Type{F}) where {F <: Function}
+    quote
+        @cfunction($(_ChannelSlotIncrementWindowCallWrapper()), Cvoid, (Ref{$F}, Ptr{Cvoid}, Csize_t))
+    end
+end
+
+struct ChannelHandlerIncrementWindowCallable
+    ptr::Ptr{Cvoid}
+    objptr::Ptr{Cvoid}
+    _root::Any
+end
+
+function ChannelHandlerIncrementWindowCallable(callable::F) where {F <: Function}
+    ptr = _channel_slot_increment_window_gen_fptr(F)
+    objref = Base.cconvert(Ref{F}, callable)
+    objptr = Ptr{Cvoid}(Base.unsafe_convert(Ref{F}, objref))
+    return ChannelHandlerIncrementWindowCallable(ptr, objptr, objref)
+end
+
+function ChannelHandlerIncrementWindowCallable(handler::H) where {H}
+    return ChannelHandlerIncrementWindowCallable(_ChannelHandlerIncrementWindowDispatch(handler))
+end
+
+@inline function (f::ChannelHandlerIncrementWindowCallable)(slot, size::Csize_t)::Nothing
+    slot_ptr, slot_root = _callback_obj_to_ptr_and_root(slot)
+    GC.@preserve slot_root begin
+        ccall(f.ptr, Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t), f.objptr, slot_ptr, size)
+    end
+    return nothing
+end
+
+struct _ChannelSlotShutdownCallWrapper <: Function end
+@inline function (::_ChannelSlotShutdownCallWrapper)(
+        f::F,
+        slot_ptr::Ptr{Cvoid},
+        direction::UInt8,
+        error_code::Int,
+        free_scarce_resources_immediately::Bool,
+    ) where {F <: Function}
+    slot = _callback_ptr_to_obj(slot_ptr)::ChannelSlot
+    f(
+        slot,
+        ChannelDirection.T(direction),
+        error_code,
+        free_scarce_resources_immediately,
+    )
+    return nothing
+end
+
+@generated function _channel_slot_shutdown_gen_fptr(::Type{F}) where {F <: Function}
+    quote
+        @cfunction($(_ChannelSlotShutdownCallWrapper()), Cvoid, (Ref{$F}, Ptr{Cvoid}, UInt8, Int, Bool))
+    end
+end
+
+struct ChannelHandlerShutdownCallable
+    ptr::Ptr{Cvoid}
+    objptr::Ptr{Cvoid}
+    _root::Any
+end
+
+function ChannelHandlerShutdownCallable(callable::F) where {F <: Function}
+    ptr = _channel_slot_shutdown_gen_fptr(F)
+    objref = Base.cconvert(Ref{F}, callable)
+    objptr = Ptr{Cvoid}(Base.unsafe_convert(Ref{F}, objref))
+    return ChannelHandlerShutdownCallable(ptr, objptr, objref)
+end
+
+function ChannelHandlerShutdownCallable(handler::H) where {H}
+    return ChannelHandlerShutdownCallable(_ChannelHandlerShutdownDispatch(handler))
+end
+
+@inline function (f::ChannelHandlerShutdownCallable)(
+        slot,
+        direction::ChannelDirection.T,
+        error_code::Int,
+        free_scarce_resources_immediately::Bool,
+    )::Nothing
+    slot_ptr, slot_root = _callback_obj_to_ptr_and_root(slot)
+    GC.@preserve slot_root begin
+        ccall(
+            f.ptr,
+            Cvoid,
+            (Ptr{Cvoid}, Ptr{Cvoid}, UInt8, Int, Bool),
+            f.objptr,
+            slot_ptr,
+            UInt8(direction),
+            error_code,
+            free_scarce_resources_immediately,
+        )
+    end
+    return nothing
+end
+
+struct _ChannelSlotMessageOverheadCallWrapper <: Function end
+@inline function (::_ChannelSlotMessageOverheadCallWrapper)(f::F)::Csize_t where {F <: Function}
+    return f()
+end
+
+@generated function _channel_slot_message_overhead_gen_fptr(::Type{F}) where {F <: Function}
+    quote
+        @cfunction($(_ChannelSlotMessageOverheadCallWrapper()), Csize_t, (Ref{$F},))
+    end
+end
+
+struct ChannelHandlerMessageOverheadCallable
+    ptr::Ptr{Cvoid}
+    objptr::Ptr{Cvoid}
+    _root::Any
+end
+
+function ChannelHandlerMessageOverheadCallable(callable::F) where {F <: Function}
+    ptr = _channel_slot_message_overhead_gen_fptr(F)
+    objref = Base.cconvert(Ref{F}, callable)
+    objptr = Ptr{Cvoid}(Base.unsafe_convert(Ref{F}, objref))
+    return ChannelHandlerMessageOverheadCallable(ptr, objptr, objref)
+end
+
+function ChannelHandlerMessageOverheadCallable(handler::H) where {H}
+    return ChannelHandlerMessageOverheadCallable(_ChannelHandlerMessageOverheadDispatch(handler))
+end
+
+@inline function (f::ChannelHandlerMessageOverheadCallable)()::Csize_t
+    return ccall(f.ptr, Csize_t, (Ptr{Cvoid},), f.objptr)
+end
+
+struct _ChannelSlotDestroyCallWrapper <: Function end
+@inline function (::_ChannelSlotDestroyCallWrapper)(f::F)::Nothing where {F <: Function}
+    f()
+    return nothing
+end
+
+@generated function _channel_slot_destroy_gen_fptr(::Type{F}) where {F <: Function}
+    quote
+        @cfunction($(_ChannelSlotDestroyCallWrapper()), Cvoid, (Ref{$F},))
+    end
+end
+
+struct ChannelHandlerDestroyCallable
+    ptr::Ptr{Cvoid}
+    objptr::Ptr{Cvoid}
+    _root::Any
+end
+
+function ChannelHandlerDestroyCallable(callable::F) where {F <: Function}
+    ptr = _channel_slot_destroy_gen_fptr(F)
+    objref = Base.cconvert(Ref{F}, callable)
+    objptr = Ptr{Cvoid}(Base.unsafe_convert(Ref{F}, objref))
+    return ChannelHandlerDestroyCallable(ptr, objptr, objref)
+end
+
+function ChannelHandlerDestroyCallable(handler::H) where {H}
+    return ChannelHandlerDestroyCallable(_ChannelHandlerDestroyDispatch(handler))
+end
+
+@inline function (f::ChannelHandlerDestroyCallable)()::Nothing
+    ccall(f.ptr, Cvoid, (Ptr{Cvoid},), f.objptr)
+    return nothing
+end
+
+struct _ChannelSlotTriggerReadCallWrapper <: Function end
+@inline function (::_ChannelSlotTriggerReadCallWrapper)(f::F)::Nothing where {F <: Function}
+    f()
+    return nothing
+end
+
+@generated function _channel_slot_trigger_read_gen_fptr(::Type{F}) where {F <: Function}
+    quote
+        @cfunction($(_ChannelSlotTriggerReadCallWrapper()), Cvoid, (Ref{$F},))
+    end
+end
+
+struct ChannelHandlerTriggerReadCallable
+    ptr::Ptr{Cvoid}
+    objptr::Ptr{Cvoid}
+    _root::Any
+end
+
+function ChannelHandlerTriggerReadCallable(callable::F) where {F <: Function}
+    ptr = _channel_slot_trigger_read_gen_fptr(F)
+    objref = Base.cconvert(Ref{F}, callable)
+    objptr = Ptr{Cvoid}(Base.unsafe_convert(Ref{F}, objref))
+    return ChannelHandlerTriggerReadCallable(ptr, objptr, objref)
+end
+
+function ChannelHandlerTriggerReadCallable(handler::H) where {H}
+    return ChannelHandlerTriggerReadCallable(_ChannelHandlerTriggerReadDispatch(handler))
+end
+
+@inline function (f::ChannelHandlerTriggerReadCallable)()::Nothing
+    ccall(f.ptr, Cvoid, (Ptr{Cvoid},), f.objptr)
+    return nothing
+end

--- a/src/sockets/io/host_resolver.jl
+++ b/src/sockets/io/host_resolver.jl
@@ -652,7 +652,11 @@ function _host_resolver_resolve_async!(
                 )
             catch e
                 delete!(resolver.cache, host)
-                notify(result, e isa Exception ? e : ReseauError(ERROR_UNKNOWN))
+                if e isa Exception
+                    @inline notify_exception!(result, e)
+                else
+                    @inline notify_exception!(result, ReseauError(ERROR_UNKNOWN))
+                end
             end
             return result
         end

--- a/src/sockets/io/posix_socket_impl.jl
+++ b/src/sockets/io/posix_socket_impl.jl
@@ -283,9 +283,9 @@ end
 
 function _cancel_connect_pending_tasks!(
     sock::Socket,
-    connect_args::PosixSocketConnectArgs{S};
+    connect_args::PosixSocketConnectArgs;
     skip_task::Union{ScheduledTask, Nothing} = nothing,
-) where {S}
+)::Nothing
     # Canceling scheduled tasks may invoke callbacks synchronously with
     # `TaskStatus.CANCELED`; clear the shared socket pointer first so canceled
     # timeout/poll callbacks become no-ops instead of racing error paths.
@@ -1604,8 +1604,9 @@ function socket_close_impl(socket_impl::PosixSocket, sock::Socket)::Nothing
 
     connect_args = socket_impl.connect_args
     if connect_args !== nothing
-        _cancel_connect_pending_tasks!(sock, connect_args)
-        (connect_args::PosixSocketConnectArgs{Socket}).socket = nothing
+        connect_args_typed = connect_args::PosixSocketConnectArgs{Socket}
+        _cancel_connect_pending_tasks!(sock, connect_args_typed)
+        connect_args_typed.socket = nothing
         socket_impl.connect_args = nothing
     end
 

--- a/src/sockets/io/tls_types.jl
+++ b/src/sockets/io/tls_types.jl
@@ -243,4 +243,21 @@ function TlsConnectionOptions(
     )
 end
 
+@inline function _tls_connection_options_with_negotiation(
+        options::TlsConnectionOptions,
+        advertise_alpn_message::Bool,
+        on_negotiation_result::Union{TlsNegotiationResultCallback, Nothing},
+    )::TlsConnectionOptions
+    return TlsConnectionOptions(
+        options.ctx,
+        options.server_name,
+        options.alpn_list,
+        options.advertise_alpn_message || advertise_alpn_message,
+        on_negotiation_result,
+        options.on_data_read,
+        options.on_error,
+        options.timeout_ms,
+    )
+end
+
 const MaybeTlsConnectionOptions = Union{TlsConnectionOptions, Nothing}

--- a/test/channel_tests.jl
+++ b/test/channel_tests.jl
@@ -27,13 +27,11 @@ function _setup_channel(; with_shutdown_cb::Bool = false)
             end)
         ) : nothing
 
-    channel_opts = Sockets.ChannelOptions(
+    channel = Sockets.channel_new(
         event_loop = el,
         on_setup_completed = on_setup,
         on_shutdown_completed = on_shutdown,
     )
-
-    channel = Sockets.channel_new(channel_opts)
 
     @test _wait_ready_channel(setup_ch)
     if isready(setup_ch)
@@ -91,13 +89,11 @@ end
                 return nothing
             end)
 
-            channel_opts = Sockets.ChannelOptions(
+            channel = Sockets.channel_new(
                 event_loop = el,
                 on_setup_completed = on_setup,
                 on_shutdown_completed = nothing,
             )
-
-            channel = Sockets.channel_new(channel_opts)
 
             Sockets.channel_destroy!(channel)
             @test EventLoops.run!(el) === nothing

--- a/test/event_loop_tests.jl
+++ b/test/event_loop_tests.jl
@@ -1597,8 +1597,8 @@ end
                 return nothing
             end)
 
-            ch1 = Sockets.channel_new(Sockets.ChannelOptions(; event_loop = el, on_setup_completed = on_setup))
-            ch2 = Sockets.channel_new(Sockets.ChannelOptions(; event_loop = el, on_setup_completed = on_setup))
+            ch1 = Sockets.channel_new(; event_loop = el, on_setup_completed = on_setup)
+            ch2 = Sockets.channel_new(; event_loop = el, on_setup_completed = on_setup)
 
             @test _wait_for_channel(setup_ch)
             @test _wait_for_channel(setup_ch)

--- a/test/io_testing_channel_tests.jl
+++ b/test/io_testing_channel_tests.jl
@@ -115,13 +115,11 @@ function _setup_channel(; enable_read_back_pressure::Bool = false)
         return nothing
     end)
 
-    channel_opts = Sockets.ChannelOptions(
+    channel = Sockets.channel_new(
         event_loop = el,
         on_setup_completed = on_setup,
         enable_read_back_pressure = enable_read_back_pressure,
     )
-
-    channel = Sockets.channel_new(channel_opts)
 
     @test _wait_ready_channel(setup_ch)
     if isready(setup_ch)

--- a/test/read_write_test_handler.jl
+++ b/test/read_write_test_handler.jl
@@ -72,7 +72,7 @@ function Sockets.handler_process_read_message(
     )::Nothing
     next_data = handler.on_read(handler, slot, message.message_data, handler.ctx)
 
-    if slot.channel !== nothing
+    if Sockets.channel_slot_is_attached(slot)
         Sockets.channel_release_message_to_pool!(slot.channel, message)
     end
 
@@ -101,7 +101,7 @@ function Sockets.handler_process_write_message(
     )::Nothing
     next_data = handler.on_write(handler, slot, message.message_data, handler.ctx)
 
-    if slot.channel !== nothing
+    if Sockets.channel_slot_is_attached(slot)
         Sockets.channel_release_message_to_pool!(slot.channel, message)
     end
 

--- a/test/socket_handler_tests.jl
+++ b/test/socket_handler_tests.jl
@@ -36,7 +36,7 @@ function Sockets.handler_process_read_message(handler::TestReadHandler, slot::So
         Sockets.channel_slot_increment_read_window!(slot, message.message_data.len)
     end
 
-    if slot.channel !== nothing
+    if Sockets.channel_slot_is_attached(slot)
         Sockets.channel_release_message_to_pool!(slot.channel, message)
     end
     return nothing

--- a/test/tls_tests_impl.jl
+++ b/test/tls_tests_impl.jl
@@ -884,7 +884,7 @@ function SinkHandler()
 end
 
 function Sockets.handler_process_read_message(handler::SinkHandler, slot::Sockets.ChannelSlot, message::Sockets.IoMessage)
-    if slot.channel !== nothing
+    if Sockets.channel_slot_is_attached(slot)
         Sockets.channel_release_message_to_pool!(slot.channel, message)
     end
     return nothing
@@ -892,7 +892,7 @@ end
 
 function Sockets.handler_process_write_message(handler::SinkHandler, slot::Sockets.ChannelSlot, message::Sockets.IoMessage)
     handler.writes[] += 1
-    if slot.channel !== nothing
+    if Sockets.channel_slot_is_attached(slot)
         Sockets.channel_release_message_to_pool!(slot.channel, message)
     end
     return nothing
@@ -1571,7 +1571,7 @@ end
                 try
                     Sockets.handler_process_write_message(send_args.handler, send_args.slot, send_args.message)
                 catch e
-                    if send_args.slot.channel !== nothing
+                    if Sockets.channel_slot_is_attached(send_args.slot)
                         Sockets.channel_release_message_to_pool!(send_args.slot.channel, send_args.message)
                     end
                 end


### PR DESCRIPTION
## Summary
- remove `ChannelOptions` and inline channel construction parameters into `Channel`/`channel_new`
- simplify `ChannelSlot` ownership typing and add explicit attached/detached state guards
- add staged `PrecompileTools` workload (`src/precompile_workload.jl`) that exercises init, loop, accept/connect, and trim echo paths while ensuring teardown
- tighten socket/eventloop lifecycle handling across NW/posix/channel bootstrap paths to reduce trim verifier issues and precompile hangs
- add trim-safe callable wrappers for channel handlers and clean up related TCP/handler dispatch code

## Validation
- `JULIA_NUM_THREADS=1 julia --startup-file=no --history-file=no --project -e 'using JuliaC; JuliaC.main(ARGS)' -- --output-exe echo_trim_safe --project=. --experimental --trim=safe trim/echo_trim_safe.jl`
  - result: `Trim verify finished with 11 errors, 0 warnings`
- `cd /Users/jacob.quinn/.julia/dev/AwsHTTP && JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'`
- `cd /Users/jacob.quinn/.julia/dev/HTTP && JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'`
