### PR TITLE
refactor(retry): inline retry strategy config structs

### DIFF
--- a/src/sockets/io/retry_strategy.jl
+++ b/src/sockets/io/retry_strategy.jl
@@ -373,7 +373,7 @@ function _exponential_backoff_retry_task(
 
     logf(
         LogLevel.TRACE, LS_IO_EXPONENTIAL_BACKOFF_RETRY_STRATEGY,
-        "Exponential backoff: retry task executing, status=$status"
+        "Exponential backoff: retry task executing"
     )
 
     if status == TaskStatus.CANCELED

--- a/test/echo_trim_safe.jl
+++ b/test/echo_trim_safe.jl
@@ -1,6 +1,7 @@
 using Reseau
 
 const RS = Reseau.Sockets
+const EL = Reseau.EventLoops
 
 function run_echo()::Nothing
     server::Union{RS.TCPServer, Nothing} = nothing
@@ -39,9 +40,106 @@ function run_echo()::Nothing
     return nothing
 end
 
+@inline function _expect_success(code::Int, what::AbstractString)::Nothing
+    code == Reseau.OP_SUCCESS || error("$what failed with error code $code")
+    return nothing
+end
+
+function _wait_retry_future!(f::EL.Future{Int}, what::AbstractString)::Nothing
+    _expect_success(wait(f), what)
+    return nothing
+end
+
+function run_retry_samples()::Nothing
+    RS.io_library_init()
+
+    event_loop_group = EL.EventLoopGroup(; loop_count = 1)
+    try
+        exp_strategy = RS.ExponentialBackoffRetryStrategy(
+            event_loop_group,
+            ;
+            backoff_scale_factor_ms = 1,
+            max_backoff_secs = 1,
+            max_retries = 1,
+            jitter_mode = :none,
+        )
+        exp_acquired = EL.Future{Int}()
+        exp_ready = EL.Future{Int}()
+        try
+            on_ready = function (token, code)
+                notify(exp_ready, code)
+                if code == Reseau.OP_SUCCESS
+                    RS.retry_token_record_success(token)
+                end
+                RS.retry_token_release!(token)
+                return nothing
+            end
+
+            on_acquired = function (token, code)
+                notify(exp_acquired, code)
+                if code != Reseau.OP_SUCCESS || token === nothing
+                    notify(exp_ready, code)
+                    return nothing
+                end
+                RS.retry_token_schedule_retry(token, RS.RetryErrorType.TRANSIENT, on_ready)
+                return nothing
+            end
+
+            RS.retry_strategy_acquire_token!(exp_strategy, on_acquired)
+            _wait_retry_future!(exp_acquired, "trim exponential retry token acquire")
+            _wait_retry_future!(exp_ready, "trim exponential retry ready")
+        finally
+            RS.retry_strategy_shutdown!(exp_strategy)
+        end
+
+        std_strategy = RS.StandardRetryStrategy(
+            event_loop_group,
+            ;
+            initial_bucket_capacity = 10,
+            backoff_scale_factor_ms = 1,
+            max_backoff_secs = 1,
+            max_retries = 1,
+            jitter_mode = :none,
+        )
+        std_acquired = EL.Future{Int}()
+        std_ready = EL.Future{Int}()
+        try
+            on_ready = function (token, code)
+                notify(std_ready, code)
+                if code == Reseau.OP_SUCCESS
+                    RS.retry_token_record_success(token)
+                end
+                RS.retry_token_release!(token)
+                return nothing
+            end
+
+            on_acquired = function (token, code)
+                notify(std_acquired, code)
+                if code != Reseau.OP_SUCCESS || token === nothing
+                    notify(std_ready, code)
+                    return nothing
+                end
+                RS.retry_token_schedule_retry(token, RS.RetryErrorType.SERVER_ERROR, on_ready)
+                return nothing
+            end
+
+            RS.retry_strategy_acquire_token!(std_strategy, "trim", on_acquired, 0)
+            _wait_retry_future!(std_acquired, "trim standard retry token acquire")
+            _wait_retry_future!(std_ready, "trim standard retry ready")
+        finally
+            RS.retry_strategy_shutdown!(std_strategy)
+        end
+    finally
+        close(event_loop_group)
+    end
+
+    return nothing
+end
+
 function @main(args::Vector{String})::Cint
     _ = args
     run_echo()
+    run_retry_samples()
     return 0
 end
 

--- a/test/retry_strategy_tests.jl
+++ b/test/retry_strategy_tests.jl
@@ -37,13 +37,13 @@ end
 
                 elg = EventLoops.EventLoopGroup(; loop_count = 1)
 
-                config = Sockets.ExponentialBackoffConfig(;
+                config = (;
                     backoff_scale_factor_ms = 1,
                     max_backoff_secs = 1,
                     max_retries = 3,
                     jitter_mode = jitter_mode,
                 )
-                strategy = Sockets.ExponentialBackoffRetryStrategy(elg, config)
+                strategy = Sockets.ExponentialBackoffRetryStrategy(elg; config...)
 
                 mtx = ReentrantLock()
                 retry_count = Ref(0)
@@ -107,13 +107,13 @@ end
 
         elg = EventLoops.EventLoopGroup(; loop_count = 1)
 
-        config = Sockets.ExponentialBackoffConfig(;
+        config = (;
             backoff_scale_factor_ms = 1,
             max_backoff_secs = 1,
             max_retries = 3,
             jitter_mode = :none,
         )
-        strategy = Sockets.ExponentialBackoffRetryStrategy(elg, config)
+        strategy = Sockets.ExponentialBackoffRetryStrategy(elg; config...)
 
         mtx = ReentrantLock()
         retry_count = Ref(0)
@@ -183,13 +183,13 @@ end
 
         elg = EventLoops.EventLoopGroup(; loop_count = 1)
 
-        config = Sockets.ExponentialBackoffConfig(;
+        config = (;
             backoff_scale_factor_ms = 5,
             max_backoff_secs = 10,
             max_retries = 3,
             jitter_mode = :none,
         )
-        strategy = Sockets.ExponentialBackoffRetryStrategy(elg, config)
+        strategy = Sockets.ExponentialBackoffRetryStrategy(elg; config...)
 
         mtx = ReentrantLock()
         retry_count = Ref(0)
@@ -261,13 +261,13 @@ end
 
         elg = EventLoops.EventLoopGroup(; loop_count = 1)
 
-        config = Sockets.ExponentialBackoffConfig(;
+        config = (;
             backoff_scale_factor_ms = 400,
             max_backoff_secs = 1,
             max_retries = 3,
             jitter_mode = :none,
         )
-        strategy = Sockets.ExponentialBackoffRetryStrategy(elg, config)
+        strategy = Sockets.ExponentialBackoffRetryStrategy(elg; config...)
 
         mtx = ReentrantLock()
         retry_count = Ref(0)
@@ -340,11 +340,11 @@ end
 
     elg = EventLoops.EventLoopGroup(; loop_count = 1)
 
-    config = Sockets.ExponentialBackoffConfig(;
+    config = (;
         max_retries = 64,
     )
     err = try
-        Sockets.ExponentialBackoffRetryStrategy(elg, config)
+        Sockets.ExponentialBackoffRetryStrategy(elg; config...)
         nothing
     catch e
         e
@@ -364,17 +364,14 @@ end
 
         elg = EventLoops.EventLoopGroup(; loop_count = 1)
 
-        backoff_config = Sockets.ExponentialBackoffConfig(;
+        config = (;
+            initial_bucket_capacity = 15,
             backoff_scale_factor_ms = 1,
             max_backoff_secs = 1,
             max_retries = 3,
             jitter_mode = :none,
         )
-        config = Sockets.StandardRetryConfig(;
-            initial_bucket_capacity = 15,
-            backoff_config = backoff_config,
-        )
-        strategy = Sockets.StandardRetryStrategy(elg, config)
+        strategy = Sockets.StandardRetryStrategy(elg; config...)
 
         partition = "us-east-1:super-badly-named-aws-service"
 
@@ -468,17 +465,14 @@ end
 
         elg = EventLoops.EventLoopGroup(; loop_count = 1)
 
-        backoff_config = Sockets.ExponentialBackoffConfig(;
+        config = (;
+            initial_bucket_capacity = 15,
             backoff_scale_factor_ms = 1,
             max_backoff_secs = 1,
             max_retries = 3,
             jitter_mode = :none,
         )
-        config = Sockets.StandardRetryConfig(;
-            initial_bucket_capacity = 15,
-            backoff_config = backoff_config,
-        )
-        strategy = Sockets.StandardRetryStrategy(elg, config)
+        strategy = Sockets.StandardRetryStrategy(elg; config...)
 
         partition = "us-west-2:elastic-something-something-manager-manager"
 

--- a/trim/echo_trim_safe.jl
+++ b/trim/echo_trim_safe.jl
@@ -1,6 +1,7 @@
 using Reseau
 
 const RS = Reseau.Sockets
+const EL = Reseau.EventLoops
 
 function run_echo()::Nothing
     server::Union{RS.TCPServer, Nothing} = nothing
@@ -39,9 +40,106 @@ function run_echo()::Nothing
     return nothing
 end
 
+@inline function _expect_success(code::Int, what::AbstractString)::Nothing
+    code == Reseau.OP_SUCCESS || error("$what failed with error code $code")
+    return nothing
+end
+
+function _wait_retry_future!(f::EL.Future{Int}, what::AbstractString)::Nothing
+    _expect_success(wait(f), what)
+    return nothing
+end
+
+function run_retry_samples()::Nothing
+    RS.io_library_init()
+
+    event_loop_group = EL.EventLoopGroup(; loop_count = 1)
+    try
+        exp_strategy = RS.ExponentialBackoffRetryStrategy(
+            event_loop_group,
+            ;
+            backoff_scale_factor_ms = 1,
+            max_backoff_secs = 1,
+            max_retries = 1,
+            jitter_mode = :none,
+        )
+        exp_acquired = EL.Future{Int}()
+        exp_ready = EL.Future{Int}()
+        try
+            on_ready = function (token, code)
+                notify(exp_ready, code)
+                if code == Reseau.OP_SUCCESS
+                    RS.retry_token_record_success(token)
+                end
+                RS.retry_token_release!(token)
+                return nothing
+            end
+
+            on_acquired = function (token, code)
+                notify(exp_acquired, code)
+                if code != Reseau.OP_SUCCESS || token === nothing
+                    notify(exp_ready, code)
+                    return nothing
+                end
+                RS.retry_token_schedule_retry(token, RS.RetryErrorType.TRANSIENT, on_ready)
+                return nothing
+            end
+
+            RS.retry_strategy_acquire_token!(exp_strategy, on_acquired)
+            _wait_retry_future!(exp_acquired, "trim exponential retry token acquire")
+            _wait_retry_future!(exp_ready, "trim exponential retry ready")
+        finally
+            RS.retry_strategy_shutdown!(exp_strategy)
+        end
+
+        std_strategy = RS.StandardRetryStrategy(
+            event_loop_group,
+            ;
+            initial_bucket_capacity = 10,
+            backoff_scale_factor_ms = 1,
+            max_backoff_secs = 1,
+            max_retries = 1,
+            jitter_mode = :none,
+        )
+        std_acquired = EL.Future{Int}()
+        std_ready = EL.Future{Int}()
+        try
+            on_ready = function (token, code)
+                notify(std_ready, code)
+                if code == Reseau.OP_SUCCESS
+                    RS.retry_token_record_success(token)
+                end
+                RS.retry_token_release!(token)
+                return nothing
+            end
+
+            on_acquired = function (token, code)
+                notify(std_acquired, code)
+                if code != Reseau.OP_SUCCESS || token === nothing
+                    notify(std_ready, code)
+                    return nothing
+                end
+                RS.retry_token_schedule_retry(token, RS.RetryErrorType.SERVER_ERROR, on_ready)
+                return nothing
+            end
+
+            RS.retry_strategy_acquire_token!(std_strategy, "trim", on_acquired, 0)
+            _wait_retry_future!(std_acquired, "trim standard retry token acquire")
+            _wait_retry_future!(std_ready, "trim standard retry ready")
+        finally
+            RS.retry_strategy_shutdown!(std_strategy)
+        end
+    finally
+        close(event_loop_group)
+    end
+
+    return nothing
+end
+
 function @main(args::Vector{String})::Cint
     _ = args
     run_echo()
+    run_retry_samples()
     return 0
 end
 


### PR DESCRIPTION
## Summary
- remove `ExponentialBackoffConfig` and inline its fields on `ExponentialBackoffRetryStrategy`
- remove `StandardRetryConfig` and inline its fields on `StandardRetryStrategy`
- tighten exponential token typing to `RetryToken{ExponentialBackoffRetryStrategy}` in standard retry token state
- keep jitter RNG non-configurable via direct `rand(UInt64)`
- update retry precompile + trim workloads and retry tests to use the new keyword constructors

## Validation
- `JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'include("test/retry_strategy_tests.jl")'`
- `JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'`
- `JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'` in `AwsHTTP`
- `JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.test(; coverage=false)'` in `HTTP`
