### PR TITLE
feat(netpoll): integrate poller-owned deadlines

### DIFF
--- a/src/1_eventloops.jl
+++ b/src/1_eventloops.jl
@@ -99,14 +99,6 @@ struct PollEvent
     errored::Bool
 end
 
-struct DeadlineEntry{R}
-    deadline_ns::Int64
-    registration::R
-    mode::PollMode.T
-    rseq::UInt64
-    wseq::UInt64
-end
-
 """
     Registration
 
@@ -133,6 +125,14 @@ function Registration(
     return Registration(fd, token, mode, read_waiter, write_waiter, event_err, C_NULL)
 end
 
+struct DeadlineEntry
+    deadline_ns::Int64
+    registration::Registration
+    mode::PollMode.T
+    rseq::UInt64
+    wseq::UInt64
+end
+
 """
     Poller
 
@@ -143,7 +143,7 @@ mutable struct Poller
     lock::ReentrantLock
     registrations::Dict{Cint, Registration}
     registrations_by_token::Dict{UInt64, Registration}
-    deadline_heap::Vector{DeadlineEntry{Registration}}
+    deadline_heap::Vector{DeadlineEntry}
     shutdown_event::Base.Threads.Event
     kq::Cint
     wake_ident::UInt
@@ -159,7 +159,7 @@ function Poller()
         ReentrantLock(),
         Dict{Cint, Registration}(),
         Dict{UInt64, Registration}(),
-        DeadlineEntry{Registration}[],
+        DeadlineEntry[],
         Base.Threads.Event(),
         Cint(-1),
         UInt(1),
@@ -224,7 +224,7 @@ function deadline_fire!(owner, registration::Registration, mode::PollMode.T, rse
     return nothing
 end
 
-@inline function _deadline_less(a::DeadlineEntry{Registration}, b::DeadlineEntry{Registration})::Bool
+@inline function _deadline_less(a::DeadlineEntry, b::DeadlineEntry)::Bool
     if a.deadline_ns != b.deadline_ns
         return a.deadline_ns < b.deadline_ns
     end
@@ -246,12 +246,12 @@ end
     return (i << 1) + 1
 end
 
-function _deadline_swap!(heap::Vector{DeadlineEntry{Registration}}, i::Int, j::Int)
+function _deadline_swap!(heap::Vector{DeadlineEntry}, i::Int, j::Int)
     heap[i], heap[j] = heap[j], heap[i]
     return nothing
 end
 
-function _deadline_sift_up!(heap::Vector{DeadlineEntry{Registration}}, i::Int)
+function _deadline_sift_up!(heap::Vector{DeadlineEntry}, i::Int)
     while i > 1
         parent = _heap_parent_index(i)
         _deadline_less(heap[i], heap[parent]) || break
@@ -261,7 +261,7 @@ function _deadline_sift_up!(heap::Vector{DeadlineEntry{Registration}}, i::Int)
     return nothing
 end
 
-function _deadline_sift_down!(heap::Vector{DeadlineEntry{Registration}}, i::Int)
+function _deadline_sift_down!(heap::Vector{DeadlineEntry}, i::Int)
     len = length(heap)
     while true
         left = _heap_left_index(i)
@@ -278,14 +278,14 @@ function _deadline_sift_down!(heap::Vector{DeadlineEntry{Registration}}, i::Int)
     return nothing
 end
 
-function _deadline_push_locked!(state::Poller, entry::DeadlineEntry{Registration})
+function _deadline_push_locked!(state::Poller, entry::DeadlineEntry)
     heap = state.deadline_heap
     push!(heap, entry)
     _deadline_sift_up!(heap, length(heap))
     return nothing
 end
 
-function _deadline_pop_locked!(state::Poller)::DeadlineEntry{Registration}
+function _deadline_pop_locked!(state::Poller)::DeadlineEntry
     heap = state.deadline_heap
     isempty(heap) && throw(ArgumentError("deadline heap is empty"))
     entry = heap[1]
@@ -323,8 +323,8 @@ function _build_deadline_entries(
         wd_ns::Int64,
         rseq::UInt64,
         wseq::UInt64,
-    )::Vector{DeadlineEntry{Registration}}
-    entries = DeadlineEntry{Registration}[]
+    )::Vector{DeadlineEntry}
+    entries = DeadlineEntry[]
     if rd_ns > 0 && wd_ns > 0 && rd_ns == wd_ns
         push!(entries, DeadlineEntry(rd_ns, registration, PollMode.READWRITE, rseq, wseq))
         return entries
@@ -385,7 +385,7 @@ function _poll_delay_ns(state::Poller)::Int64
 end
 
 function _drain_expired_deadlines!(state::Poller, now_ns::Int64)
-    expired = DeadlineEntry{Registration}[]
+    expired = DeadlineEntry[]
     lock(state.lock)
     try
         while true

--- a/src/1_eventloops.jl
+++ b/src/1_eventloops.jl
@@ -99,6 +99,14 @@ struct PollEvent
     errored::Bool
 end
 
+struct DeadlineEntry{R}
+    deadline_ns::Int64
+    registration::R
+    mode::PollMode.T
+    rseq::UInt64
+    wseq::UInt64
+end
+
 """
     Registration
 
@@ -111,6 +119,18 @@ mutable struct Registration
     read_waiter::PollWaiter
     write_waiter::PollWaiter
     @atomic event_err::Bool
+    deadline_owner::Ptr{Cvoid}
+end
+
+function Registration(
+        fd::Cint,
+        token::UInt64,
+        mode::PollMode.T,
+        read_waiter::PollWaiter,
+        write_waiter::PollWaiter,
+        event_err::Bool,
+    )
+    return Registration(fd, token, mode, read_waiter, write_waiter, event_err, C_NULL)
 end
 
 """
@@ -123,12 +143,14 @@ mutable struct Poller
     lock::ReentrantLock
     registrations::Dict{Cint, Registration}
     registrations_by_token::Dict{UInt64, Registration}
+    deadline_heap::Vector{DeadlineEntry{Registration}}
     shutdown_event::Base.Threads.Event
     kq::Cint
     wake_ident::UInt
     backend_scratch::Any
     @atomic wak_sig::UInt32
     @atomic next_token::UInt64
+    @atomic poll_until_ns::Int64
     @atomic running::Bool
 end
 
@@ -137,12 +159,14 @@ function Poller()
         ReentrantLock(),
         Dict{Cint, Registration}(),
         Dict{UInt64, Registration}(),
+        DeadlineEntry{Registration}[],
         Base.Threads.Event(),
         Cint(-1),
         UInt(1),
         nothing,
         UInt32(0),
         UInt64(0),
+        Int64(0),
         false,
     )
 end
@@ -184,6 +208,201 @@ end
 
 function _new_registration(fd::Cint, token::UInt64, mode::PollMode.T)::Registration
     return Registration(fd, token, mode, PollWaiter(), PollWaiter(), false)
+end
+
+function attach_deadline_owner!(registration::Registration, owner)
+    registration.deadline_owner = owner === nothing ? C_NULL : pointer_from_objref(owner)
+    return registration
+end
+
+function deadline_fire!(owner, registration::Registration, mode::PollMode.T, rseq::UInt64, wseq::UInt64)
+    _ = owner
+    _ = registration
+    _ = mode
+    _ = rseq
+    _ = wseq
+    return nothing
+end
+
+@inline function _deadline_less(a::DeadlineEntry{Registration}, b::DeadlineEntry{Registration})::Bool
+    if a.deadline_ns != b.deadline_ns
+        return a.deadline_ns < b.deadline_ns
+    end
+    if a.registration.token != b.registration.token
+        return a.registration.token < b.registration.token
+    end
+    return UInt8(a.mode) < UInt8(b.mode)
+end
+
+@inline function _heap_parent_index(i::Int)::Int
+    return i >>> 1
+end
+
+@inline function _heap_left_index(i::Int)::Int
+    return i << 1
+end
+
+@inline function _heap_right_index(i::Int)::Int
+    return (i << 1) + 1
+end
+
+function _deadline_swap!(heap::Vector{DeadlineEntry{Registration}}, i::Int, j::Int)
+    heap[i], heap[j] = heap[j], heap[i]
+    return nothing
+end
+
+function _deadline_sift_up!(heap::Vector{DeadlineEntry{Registration}}, i::Int)
+    while i > 1
+        parent = _heap_parent_index(i)
+        _deadline_less(heap[i], heap[parent]) || break
+        _deadline_swap!(heap, i, parent)
+        i = parent
+    end
+    return nothing
+end
+
+function _deadline_sift_down!(heap::Vector{DeadlineEntry{Registration}}, i::Int)
+    len = length(heap)
+    while true
+        left = _heap_left_index(i)
+        left > len && break
+        smallest = left
+        right = _heap_right_index(i)
+        if right <= len && _deadline_less(heap[right], heap[left])
+            smallest = right
+        end
+        _deadline_less(heap[smallest], heap[i]) || break
+        _deadline_swap!(heap, i, smallest)
+        i = smallest
+    end
+    return nothing
+end
+
+function _deadline_push_locked!(state::Poller, entry::DeadlineEntry{Registration})
+    heap = state.deadline_heap
+    push!(heap, entry)
+    _deadline_sift_up!(heap, length(heap))
+    return nothing
+end
+
+function _deadline_pop_locked!(state::Poller)::DeadlineEntry{Registration}
+    heap = state.deadline_heap
+    isempty(heap) && throw(ArgumentError("deadline heap is empty"))
+    entry = heap[1]
+    last = pop!(heap)
+    if !isempty(heap)
+        heap[1] = last
+        _deadline_sift_down!(heap, 1)
+    end
+    return entry
+end
+
+@inline function _registration_active_locked(state::Poller, registration::Registration)::Bool
+    current = get(() -> nothing, state.registrations_by_token, registration.token)
+    return current === registration
+end
+
+function _discard_stale_deadlines_locked!(state::Poller)
+    while !isempty(state.deadline_heap)
+        entry = state.deadline_heap[1]
+        _registration_active_locked(state, entry.registration) && return nothing
+        _ = _deadline_pop_locked!(state)
+    end
+    return nothing
+end
+
+function _deadline_peek_locked(state::Poller)
+    _discard_stale_deadlines_locked!(state)
+    isempty(state.deadline_heap) && return nothing
+    return state.deadline_heap[1]
+end
+
+function _build_deadline_entries(
+        registration::Registration,
+        rd_ns::Int64,
+        wd_ns::Int64,
+        rseq::UInt64,
+        wseq::UInt64,
+    )::Vector{DeadlineEntry{Registration}}
+    entries = DeadlineEntry{Registration}[]
+    if rd_ns > 0 && wd_ns > 0 && rd_ns == wd_ns
+        push!(entries, DeadlineEntry(rd_ns, registration, PollMode.READWRITE, rseq, wseq))
+        return entries
+    end
+    rd_ns > 0 && push!(entries, DeadlineEntry(rd_ns, registration, PollMode.READ, rseq, UInt64(0)))
+    wd_ns > 0 && push!(entries, DeadlineEntry(wd_ns, registration, PollMode.WRITE, UInt64(0), wseq))
+    return entries
+end
+
+function schedule_deadlines!(
+        registration::Registration,
+        rd_ns::Int64,
+        wd_ns::Int64,
+        rseq::UInt64,
+        wseq::UInt64,
+    )
+    isassigned(POLLER) || return nothing
+    state = POLLER[]
+    (@atomic :acquire state.running) || return nothing
+    new_earliest = Int64(0)
+    lock(state.lock)
+    try
+        _registration_active_locked(state, registration) || return nothing
+        for entry in _build_deadline_entries(registration, rd_ns, wd_ns, rseq, wseq)
+            _deadline_push_locked!(state, entry)
+            if new_earliest == 0 || entry.deadline_ns < new_earliest
+                new_earliest = entry.deadline_ns
+            end
+        end
+    finally
+        unlock(state.lock)
+    end
+    if new_earliest > 0
+        poll_until_ns = @atomic :acquire state.poll_until_ns
+        if poll_until_ns == 0 || new_earliest < poll_until_ns
+            errno = _backend_wake!(state)
+            errno == Int32(0) || _throw_errno("event loop wake", errno)
+        end
+    end
+    return nothing
+end
+
+function _poll_delay_ns(state::Poller)::Int64
+    deadline_ns = Int64(0)
+    lock(state.lock)
+    try
+        entry = _deadline_peek_locked(state)
+        deadline_ns = entry === nothing ? Int64(0) : entry.deadline_ns
+        @atomic :release state.poll_until_ns = deadline_ns
+    finally
+        unlock(state.lock)
+    end
+    deadline_ns == 0 && return Int64(-1)
+    now_ns = Int64(time_ns())
+    remaining_ns = deadline_ns - now_ns
+    remaining_ns <= 0 && return Int64(0)
+    return remaining_ns
+end
+
+function _drain_expired_deadlines!(state::Poller, now_ns::Int64)
+    expired = DeadlineEntry{Registration}[]
+    lock(state.lock)
+    try
+        while true
+            entry = _deadline_peek_locked(state)
+            (entry === nothing || entry.deadline_ns > now_ns) && break
+            push!(expired, _deadline_pop_locked!(state))
+        end
+    finally
+        unlock(state.lock)
+    end
+    for entry in expired
+        owner_ref = entry.registration.deadline_owner
+        owner_ref == C_NULL && continue
+        owner = unsafe_pointer_to_objref(owner_ref)
+        deadline_fire!(owner, entry.registration, entry.mode, entry.rseq, entry.wseq)
+    end
+    return nothing
 end
 
 function _notify_registration!(registration::Registration, mode::PollMode.T)
@@ -345,6 +564,7 @@ function deregister!(fd::Integer)
         (@atomic :acquire state.running) || return nothing
         registration = pop!(state.registrations, cfd, nothing)
         registration === nothing || delete!(state.registrations_by_token, registration.token)
+        registration === nothing || (registration.deadline_owner = C_NULL)
         errno = _backend_close_fd!(state, cfd)
     finally
         unlock(state.lock)
@@ -419,7 +639,10 @@ end
 
 function _poller_thread_main!(state::Poller)
     while @atomic state.running
-        errno = _backend_poll_once!(state, Int64(-1))
+        delay_ns = _poll_delay_ns(state)
+        errno = _backend_poll_once!(state, delay_ns)
+        @atomic :release state.poll_until_ns = Int64(0)
+        _drain_expired_deadlines!(state, Int64(time_ns()))
         errno == Int32(0) && continue
         if errno == Int32(Base.Libc.EINTR)
             continue

--- a/src/1_eventloops.jl
+++ b/src/1_eventloops.jl
@@ -99,6 +99,33 @@ struct PollEvent
     errored::Bool
 end
 
+mutable struct PollState
+    lock::ReentrantLock
+    sysfd::Cint
+    token::UInt64
+    @atomic pollable::Bool
+    @atomic closing::Bool
+    @atomic event_err::Bool
+    @atomic rd_ns::Int64
+    @atomic wd_ns::Int64
+    @atomic rseq::UInt64
+    @atomic wseq::UInt64
+    function PollState(sysfd::Integer = Cint(-1), token::UInt64 = UInt64(0))
+        return new(
+            ReentrantLock(),
+            Cint(sysfd),
+            token,
+            false,
+            false,
+            false,
+            Int64(0),
+            Int64(0),
+            UInt64(0),
+            UInt64(0),
+        )
+    end
+end
+
 """
     Registration
 
@@ -111,7 +138,7 @@ mutable struct Registration
     read_waiter::PollWaiter
     write_waiter::PollWaiter
     @atomic event_err::Bool
-    deadline_owner::Ptr{Cvoid}
+    pollstate::PollState
 end
 
 function Registration(
@@ -122,12 +149,12 @@ function Registration(
         write_waiter::PollWaiter,
         event_err::Bool,
     )
-    return Registration(fd, token, mode, read_waiter, write_waiter, event_err, C_NULL)
+    return Registration(fd, token, mode, read_waiter, write_waiter, event_err, PollState(fd, token))
 end
 
 struct DeadlineEntry
     deadline_ns::Int64
-    registration::Registration
+    pollstate::PollState
     mode::PollMode.T
     rseq::UInt64
     wseq::UInt64
@@ -210,14 +237,8 @@ function _new_registration(fd::Cint, token::UInt64, mode::PollMode.T)::Registrat
     return Registration(fd, token, mode, PollWaiter(), PollWaiter(), false)
 end
 
-function attach_deadline_owner!(registration::Registration, owner)
-    registration.deadline_owner = owner === nothing ? C_NULL : pointer_from_objref(owner)
-    return registration
-end
-
-function deadline_fire!(owner, registration::Registration, mode::PollMode.T, rseq::UInt64, wseq::UInt64)
+function deadline_fire!(owner, mode::PollMode.T, rseq::UInt64, wseq::UInt64)
     _ = owner
-    _ = registration
     _ = mode
     _ = rseq
     _ = wseq
@@ -228,8 +249,8 @@ end
     if a.deadline_ns != b.deadline_ns
         return a.deadline_ns < b.deadline_ns
     end
-    if a.registration.token != b.registration.token
-        return a.registration.token < b.registration.token
+    if a.pollstate.token != b.pollstate.token
+        return a.pollstate.token < b.pollstate.token
     end
     return UInt8(a.mode) < UInt8(b.mode)
 end
@@ -297,15 +318,15 @@ function _deadline_pop_locked!(state::Poller)::DeadlineEntry
     return entry
 end
 
-@inline function _registration_active_locked(state::Poller, registration::Registration)::Bool
-    current = get(() -> nothing, state.registrations_by_token, registration.token)
-    return current === registration
+@inline function _registration_active_locked(state::Poller, pd::PollState)::Bool
+    current = get(() -> nothing, state.registrations_by_token, pd.token)
+    return current !== nothing && current.fd == pd.sysfd && current.pollstate === pd
 end
 
 function _discard_stale_deadlines_locked!(state::Poller)
     while !isempty(state.deadline_heap)
         entry = state.deadline_heap[1]
-        _registration_active_locked(state, entry.registration) && return nothing
+        _registration_active_locked(state, entry.pollstate) && return nothing
         _ = _deadline_pop_locked!(state)
     end
     return nothing
@@ -318,7 +339,7 @@ function _deadline_peek_locked(state::Poller)
 end
 
 function _build_deadline_entries(
-        registration::Registration,
+        pd::PollState,
         rd_ns::Int64,
         wd_ns::Int64,
         rseq::UInt64,
@@ -326,16 +347,16 @@ function _build_deadline_entries(
     )::Vector{DeadlineEntry}
     entries = DeadlineEntry[]
     if rd_ns > 0 && wd_ns > 0 && rd_ns == wd_ns
-        push!(entries, DeadlineEntry(rd_ns, registration, PollMode.READWRITE, rseq, wseq))
+        push!(entries, DeadlineEntry(rd_ns, pd, PollMode.READWRITE, rseq, wseq))
         return entries
     end
-    rd_ns > 0 && push!(entries, DeadlineEntry(rd_ns, registration, PollMode.READ, rseq, UInt64(0)))
-    wd_ns > 0 && push!(entries, DeadlineEntry(wd_ns, registration, PollMode.WRITE, UInt64(0), wseq))
+    rd_ns > 0 && push!(entries, DeadlineEntry(rd_ns, pd, PollMode.READ, rseq, UInt64(0)))
+    wd_ns > 0 && push!(entries, DeadlineEntry(wd_ns, pd, PollMode.WRITE, UInt64(0), wseq))
     return entries
 end
 
 function schedule_deadlines!(
-        registration::Registration,
+        pd::PollState,
         rd_ns::Int64,
         wd_ns::Int64,
         rseq::UInt64,
@@ -347,8 +368,8 @@ function schedule_deadlines!(
     new_earliest = Int64(0)
     lock(state.lock)
     try
-        _registration_active_locked(state, registration) || return nothing
-        for entry in _build_deadline_entries(registration, rd_ns, wd_ns, rseq, wseq)
+        _registration_active_locked(state, pd) || return nothing
+        for entry in _build_deadline_entries(pd, rd_ns, wd_ns, rseq, wseq)
             _deadline_push_locked!(state, entry)
             if new_earliest == 0 || entry.deadline_ns < new_earliest
                 new_earliest = entry.deadline_ns
@@ -397,12 +418,26 @@ function _drain_expired_deadlines!(state::Poller, now_ns::Int64)
         unlock(state.lock)
     end
     for entry in expired
-        owner_ref = entry.registration.deadline_owner
-        owner_ref == C_NULL && continue
-        owner = unsafe_pointer_to_objref(owner_ref)
-        deadline_fire!(owner, entry.registration, entry.mode, entry.rseq, entry.wseq)
+        deadline_fire!(entry.pollstate, entry.mode, entry.rseq, entry.wseq)
     end
     return nothing
+end
+
+function current_registration(pd::PollState)
+    isassigned(POLLER) || return nothing
+    state = POLLER[]
+    lock(state.lock)
+    try
+        registration = get(() -> nothing, state.registrations_by_token, pd.token)
+        if registration === nothing
+            return nothing
+        end
+        registration.fd == pd.sysfd || return nothing
+        registration.pollstate === pd || return nothing
+        return registration
+    finally
+        unlock(state.lock)
+    end
 end
 
 function _notify_registration!(registration::Registration, mode::PollMode.T)
@@ -521,7 +556,7 @@ end
 
 Register an fd with the runtime poller and return its `Registration`.
 """
-function register!(fd::Integer; mode::PollMode.T = PollMode.READWRITE)::Registration
+function register!(fd::Integer; mode::PollMode.T = PollMode.READWRITE, pollstate::Union{Nothing, PollState} = nothing)::Registration
     _mode_is_empty(mode) && throw(ArgumentError("register! requires READ and/or WRITE mode"))
     state = init!()
     cfd = Cint(fd)
@@ -537,6 +572,11 @@ function register!(fd::Integer; mode::PollMode.T = PollMode.READWRITE)::Registra
         errno = _backend_open_fd!(state, cfd, mode, token)
         if errno == Int32(0)
             registration = _new_registration(cfd, token, mode)
+            if pollstate !== nothing
+                registration.pollstate = pollstate::PollState
+            end
+            registration.pollstate.sysfd = cfd
+            registration.pollstate.token = token
             state.registrations[cfd] = registration
             state.registrations_by_token[token] = registration
         end
@@ -564,7 +604,6 @@ function deregister!(fd::Integer)
         (@atomic :acquire state.running) || return nothing
         registration = pop!(state.registrations, cfd, nothing)
         registration === nothing || delete!(state.registrations_by_token, registration.token)
-        registration === nothing || (registration.deadline_owner = C_NULL)
         errno = _backend_close_fd!(state, cfd)
     finally
         unlock(state.lock)

--- a/src/3_internal_poll.jl
+++ b/src/3_internal_poll.jl
@@ -9,6 +9,7 @@ module IOPoll
 using EnumX
 using ..Reseau.EventLoops
 using ..Reseau.SocketOps
+import ..Reseau.EventLoops: deadline_fire!
 
 # FDLock state bits packed into one atomic word (close flag, lock flags, refs, waiter counts).
 const _MUTEX_CLOSED = UInt64(1) << 0
@@ -244,23 +245,10 @@ function _fdlock_rwunlock!(mu::FDLock, read_lock::Bool)::Bool
 end
 
 """
-Handle for an active deadline timer task.
-
-`canceled` lets a newer deadline update invalidate an older timer cheaply.
-"""
-mutable struct DeadlineTask
-    @atomic canceled::Bool
-    task::Union{Nothing, Task}
-    function DeadlineTask()
-        return new(false, nothing)
-    end
-end
-
-"""
 Per-descriptor poll integration state.
 
 This stores the `EventLoops` registration (`sysfd`, `token`), deadline state,
-and optional timer tasks for read/write deadlines.
+and deadline sequence state.
 """
 mutable struct PollState
     lock::ReentrantLock
@@ -274,8 +262,6 @@ mutable struct PollState
     @atomic wd_ns::Int64
     @atomic rseq::UInt64
     @atomic wseq::UInt64
-    rtask::Union{Nothing, DeadlineTask}
-    wtask::Union{Nothing, DeadlineTask}
     function PollState()
         return new(
             ReentrantLock(),
@@ -289,8 +275,6 @@ mutable struct PollState
             Int64(0),
             UInt64(0),
             UInt64(0),
-            nothing,
-            nothing,
         )
     end
 end
@@ -382,78 +366,45 @@ function _wake_waiters!(pd::PollState, mode::PollOp.T)
     return nothing
 end
 
-function _clear_deadline_task!(t::Union{Nothing, DeadlineTask})
-    t === nothing && return nothing
-    @atomic :release t.canceled = true
-    return nothing
-end
-
-function _deadline_fire!(pd::PollState, seq::UInt64, mode::PollOp.T)
-    wake_mode = PollOp.READWRITE
+function deadline_fire!(
+        pd::PollState,
+        registration::EventLoops.Registration,
+        mode::EventLoops.PollMode.T,
+        rseq::UInt64,
+        wseq::UInt64,
+    )
+    wake_read = false
+    wake_write = false
     lock(pd.lock)
     try
-        if _mode_has_read(mode)
-            (@atomic :acquire pd.rseq) == seq || return nothing
-            if (@atomic :acquire pd.rd_ns) > 0
+        (@atomic :acquire pd.closing) && return nothing
+        current = pd.registration
+        current === registration || return nothing
+        current.fd == pd.sysfd || return nothing
+        current.token == pd.token || return nothing
+        if (UInt8(mode) & UInt8(EventLoops.PollMode.READ)) != 0
+            if (@atomic :acquire pd.rseq) == rseq && (@atomic :acquire pd.rd_ns) > 0
                 @atomic :release pd.rd_ns = Int64(-1)
+                wake_read = true
             end
-            pd.rtask = nothing
-            wake_mode = PollOp.READ
         end
-        if _mode_has_write(mode)
-            (@atomic :acquire pd.wseq) == seq || return nothing
-            if (@atomic :acquire pd.wd_ns) > 0
+        if (UInt8(mode) & UInt8(EventLoops.PollMode.WRITE)) != 0
+            if (@atomic :acquire pd.wseq) == wseq && (@atomic :acquire pd.wd_ns) > 0
                 @atomic :release pd.wd_ns = Int64(-1)
+                wake_write = true
             end
-            pd.wtask = nothing
-            wake_mode = mode == PollOp.READ ? PollOp.READWRITE : PollOp.WRITE
         end
     finally
         unlock(pd.lock)
     end
-    _wake_waiters!(pd, wake_mode)
+    if wake_read && wake_write
+        _wake_waiters!(pd, PollOp.READWRITE)
+    elseif wake_read
+        _wake_waiters!(pd, PollOp.READ)
+    elseif wake_write
+        _wake_waiters!(pd, PollOp.WRITE)
+    end
     return nothing
-end
-
-function _deadline_task_current(pd::PollState, seq::UInt64, mode::PollOp.T)::Bool
-    if _mode_has_read(mode)
-        (@atomic :acquire pd.rseq) == seq || return false
-    end
-    if _mode_has_write(mode)
-        (@atomic :acquire pd.wseq) == seq || return false
-    end
-    return true
-end
-
-# TODO(phase-2): Replace this sleep loop with poller-integrated deadline timers
-# (Go-style runtime_pollSetDeadline semantics) instead of per-deadline usleep.
-function _sleep_until_ns(deadline_ns::Int64, t::DeadlineTask, pd::PollState, seq::UInt64, mode::PollOp.T)::Bool
-    while true
-        (@atomic :acquire t.canceled) && return false
-        _deadline_task_current(pd, seq, mode) || return false
-        remaining_ns = deadline_ns - _monotonic_ns()
-        remaining_ns <= 0 && return true
-        # Sleep in short chunks so cancellation/sequence updates are observed quickly.
-        @static if Sys.iswindows()
-            sleep_ms = max(Int64(1), min(cld(remaining_ns, Int64(1_000_000)), Int64(50)))
-            @ccall gc_safe = true "Kernel32".Sleep(UInt32(sleep_ms)::UInt32)::Cvoid
-        else
-            sleep_us = max(Int64(1), min(remaining_ns ÷ Int64(1000), Int64(50_000)))
-            @ccall gc_safe = true usleep(Cuint(sleep_us)::Cuint)::Cint
-        end
-    end
-end
-
-# TODO(phase-2): Remove one-task-per-deadline spawning in favor of a shared
-# timer queue owned by the event loop/poller thread.
-function _spawn_deadline_task!(pd::PollState, seq::UInt64, mode::PollOp.T, deadline_ns::Int64)::DeadlineTask
-    deadline_task = DeadlineTask()
-    deadline_task.task = errormonitor(Threads.@spawn begin
-        _sleep_until_ns(deadline_ns, deadline_task, pd, seq, mode) || return nothing
-        _deadline_fire!(pd, seq, mode)
-        return nothing
-    end)
-    return deadline_task
 end
 
 """
@@ -470,13 +421,16 @@ function _set_deadline_impl!(fd::FD, deadline_ns::Integer, mode::PollOp.T)
         (@atomic :acquire pd.pollable) || throw(NoDeadlineError())
         wake_read = false
         wake_write = false
+        registration = nothing
+        rd_ns = Int64(0)
+        wd_ns = Int64(0)
+        rseq = UInt64(0)
+        wseq = UInt64(0)
         lock(pd.lock)
         try
             (@atomic :acquire pd.closing) && return nothing
             if _mode_has_read(mode)
                 @atomic pd.rseq += UInt64(1)
-                _clear_deadline_task!(pd.rtask)
-                pd.rtask = nothing
                 if deadline == 0
                     @atomic :release pd.rd_ns = Int64(0)
                 elseif deadline <= _monotonic_ns()
@@ -484,14 +438,10 @@ function _set_deadline_impl!(fd::FD, deadline_ns::Integer, mode::PollOp.T)
                     wake_read = true
                 else
                     @atomic :release pd.rd_ns = deadline
-                    seq = @atomic :acquire pd.rseq
-                    pd.rtask = _spawn_deadline_task!(pd, seq, PollOp.READ, deadline)
                 end
             end
             if _mode_has_write(mode)
                 @atomic pd.wseq += UInt64(1)
-                _clear_deadline_task!(pd.wtask)
-                pd.wtask = nothing
                 if deadline == 0
                     @atomic :release pd.wd_ns = Int64(0)
                 elseif deadline <= _monotonic_ns()
@@ -499,13 +449,17 @@ function _set_deadline_impl!(fd::FD, deadline_ns::Integer, mode::PollOp.T)
                     wake_write = true
                 else
                     @atomic :release pd.wd_ns = deadline
-                    seq = @atomic :acquire pd.wseq
-                    pd.wtask = _spawn_deadline_task!(pd, seq, PollOp.WRITE, deadline)
                 end
             end
+            registration = pd.registration
+            rd_ns = @atomic :acquire pd.rd_ns
+            wd_ns = @atomic :acquire pd.wd_ns
+            rseq = @atomic :acquire pd.rseq
+            wseq = @atomic :acquire pd.wseq
         finally
             unlock(pd.lock)
         end
+        registration === nothing || EventLoops.schedule_deadlines!(registration::EventLoops.Registration, rd_ns, wd_ns, rseq, wseq)
         if wake_read && wake_write
             _wake_waiters!(pd, PollOp.READWRITE)
         elseif wake_read
@@ -535,6 +489,7 @@ function init!(fd::FD; net::Symbol = :tcp, pollable::Bool = true)
             registration = EventLoops.register!(fd.sysfd; mode = EventLoops.PollMode.READWRITE)
             pd.sysfd = fd.sysfd
             pd.token = registration.token
+            EventLoops.attach_deadline_owner!(registration, pd)
             pd.registration = registration
             @atomic :release pd.pollable = true
             @atomic :release pd.closing = false
@@ -558,18 +513,17 @@ Tear down polling state for a descriptor and deregister from `EventLoops`.
 """
 function close!(pd::PollState)
     was_pollable = false
+    registration = nothing
     lock(pd.lock)
     try
         was_pollable = @atomic :acquire pd.pollable
-        _clear_deadline_task!(pd.rtask)
-        _clear_deadline_task!(pd.wtask)
-        pd.rtask = nothing
-        pd.wtask = nothing
+        registration = pd.registration
         @atomic :release pd.pollable = false
     finally
         unlock(pd.lock)
     end
     was_pollable && pd.sysfd >= 0 && EventLoops.deregister!(pd.sysfd)
+    registration === nothing || EventLoops.attach_deadline_owner!(registration, nothing)
     pd.registration = nothing
     return nothing
 end
@@ -584,10 +538,6 @@ function evict!(pd::PollState)
         @atomic :release pd.closing = true
         @atomic pd.rseq += UInt64(1)
         @atomic pd.wseq += UInt64(1)
-        _clear_deadline_task!(pd.rtask)
-        _clear_deadline_task!(pd.wtask)
-        pd.rtask = nothing
-        pd.wtask = nothing
     finally
         unlock(pd.lock)
     end

--- a/src/3_internal_poll.jl
+++ b/src/3_internal_poll.jl
@@ -11,6 +11,8 @@ using ..Reseau.EventLoops
 using ..Reseau.SocketOps
 import ..Reseau.EventLoops: deadline_fire!
 
+const PollState = EventLoops.PollState
+
 # FDLock state bits packed into one atomic word (close flag, lock flags, refs, waiter counts).
 const _MUTEX_CLOSED = UInt64(1) << 0
 const _MUTEX_RLOCK = UInt64(1) << 1
@@ -245,41 +247,6 @@ function _fdlock_rwunlock!(mu::FDLock, read_lock::Bool)::Bool
 end
 
 """
-Per-descriptor poll integration state.
-
-This stores the `EventLoops` registration (`sysfd`, `token`), deadline state,
-and deadline sequence state.
-"""
-mutable struct PollState
-    lock::ReentrantLock
-    sysfd::Cint
-    token::UInt64
-    registration::Union{Nothing, EventLoops.Registration}
-    @atomic pollable::Bool
-    @atomic closing::Bool
-    @atomic event_err::Bool
-    @atomic rd_ns::Int64
-    @atomic wd_ns::Int64
-    @atomic rseq::UInt64
-    @atomic wseq::UInt64
-    function PollState()
-        return new(
-            ReentrantLock(),
-            Cint(-1),
-            UInt64(0),
-            nothing,
-            false,
-            false,
-            false,
-            Int64(0),
-            Int64(0),
-            UInt64(0),
-            UInt64(0),
-        )
-    end
-end
-
-"""
 Internal file descriptor wrapper used by the poll layer.
 
 This coordinates descriptor lifetime, read/write serialization, and integration
@@ -341,10 +308,8 @@ end
 
 function _refresh_event_err!(pd::PollState)
     (@atomic :acquire pd.pollable) || return nothing
-    registration = pd.registration
+    registration = EventLoops.current_registration(pd)
     registration === nothing && return nothing
-    registration.fd == pd.sysfd || return nothing
-    registration.token == pd.token || return nothing
     has_event_error = @atomic :acquire registration.event_err
     @atomic :release pd.event_err = has_event_error
     return nothing
@@ -352,10 +317,8 @@ end
 
 function _wake_waiters!(pd::PollState, mode::PollOp.T)
     (@atomic :acquire pd.pollable) || return nothing
-    registration = pd.registration
+    registration = EventLoops.current_registration(pd)
     registration === nothing && return nothing
-    registration.fd == pd.sysfd || return nothing
-    registration.token == pd.token || return nothing
     event_mode = EventLoops.PollMode.READWRITE
     if mode == PollOp.READ
         event_mode = EventLoops.PollMode.READ
@@ -368,7 +331,6 @@ end
 
 function deadline_fire!(
         pd::PollState,
-        registration::EventLoops.Registration,
         mode::EventLoops.PollMode.T,
         rseq::UInt64,
         wseq::UInt64,
@@ -378,10 +340,7 @@ function deadline_fire!(
     lock(pd.lock)
     try
         (@atomic :acquire pd.closing) && return nothing
-        current = pd.registration
-        current === registration || return nothing
-        current.fd == pd.sysfd || return nothing
-        current.token == pd.token || return nothing
+        EventLoops.current_registration(pd) === nothing && return nothing
         if (UInt8(mode) & UInt8(EventLoops.PollMode.READ)) != 0
             if (@atomic :acquire pd.rseq) == rseq && (@atomic :acquire pd.rd_ns) > 0
                 @atomic :release pd.rd_ns = Int64(-1)
@@ -451,7 +410,6 @@ function _set_deadline_impl!(fd::FD, deadline_ns::Integer, mode::PollOp.T)
                     @atomic :release pd.wd_ns = deadline
                 end
             end
-            registration = pd.registration
             rd_ns = @atomic :acquire pd.rd_ns
             wd_ns = @atomic :acquire pd.wd_ns
             rseq = @atomic :acquire pd.rseq
@@ -459,7 +417,7 @@ function _set_deadline_impl!(fd::FD, deadline_ns::Integer, mode::PollOp.T)
         finally
             unlock(pd.lock)
         end
-        registration === nothing || EventLoops.schedule_deadlines!(registration::EventLoops.Registration, rd_ns, wd_ns, rseq, wseq)
+        EventLoops.schedule_deadlines!(pd, rd_ns, wd_ns, rseq, wseq)
         if wake_read && wake_write
             _wake_waiters!(pd, PollOp.READWRITE)
         elseif wake_read
@@ -486,11 +444,9 @@ function init!(fd::FD; net::Symbol = :tcp, pollable::Bool = true)
     try
         if pollable
             _set_nonblocking!(fd.sysfd)
-            registration = EventLoops.register!(fd.sysfd; mode = EventLoops.PollMode.READWRITE)
+            registration = EventLoops.register!(fd.sysfd; mode = EventLoops.PollMode.READWRITE, pollstate = pd)
             pd.sysfd = fd.sysfd
             pd.token = registration.token
-            EventLoops.attach_deadline_owner!(registration, pd)
-            pd.registration = registration
             @atomic :release pd.pollable = true
             @atomic :release pd.closing = false
             @atomic :release pd.event_err = false
@@ -513,18 +469,14 @@ Tear down polling state for a descriptor and deregister from `EventLoops`.
 """
 function close!(pd::PollState)
     was_pollable = false
-    registration = nothing
     lock(pd.lock)
     try
         was_pollable = @atomic :acquire pd.pollable
-        registration = pd.registration
         @atomic :release pd.pollable = false
     finally
         unlock(pd.lock)
     end
     was_pollable && pd.sysfd >= 0 && EventLoops.deregister!(pd.sysfd)
-    registration === nothing || EventLoops.attach_deadline_owner!(registration, nothing)
-    pd.registration = nothing
     return nothing
 end
 
@@ -553,8 +505,8 @@ function pollable(pd::PollState)::Bool
 end
 
 @inline function _poll_registration(pd::PollState)::EventLoops.Registration
-    registration = pd.registration
-    (registration === nothing || registration.fd != pd.sysfd || registration.token != pd.token) && throw(SystemError("event loop wait", Int(Base.Libc.EBADF)))
+    registration = EventLoops.current_registration(pd)
+    registration === nothing && throw(SystemError("event loop wait", Int(Base.Libc.EBADF)))
     return registration
 end
 
@@ -605,11 +557,8 @@ Wait for readiness in a cancellation context (used by close/deadline wake paths)
 """
 function wait_canceled!(pd::PollState, mode::PollOp.T)
     pollable(pd) || return nothing
-    registration = pd.registration
+    registration = EventLoops.current_registration(pd)
     registration === nothing && return nothing
-    if registration.fd != pd.sysfd || registration.token != pd.token
-        return nothing
-    end
     if mode == PollOp.WRITE
         EventLoops.arm_waiter!(registration, EventLoops.PollMode.WRITE)
         EventLoops.pollwait!(registration.write_waiter)

--- a/test/eventloops_tests.jl
+++ b/test/eventloops_tests.jl
@@ -105,7 +105,7 @@ else
                     return err, time_ns() - t0
                 end)
                 sleep(0.03)
-                NP.schedule_deadlines!(registration, Int64(time_ns()) + Int64(20_000_000), Int64(0), UInt64(1), UInt64(0))
+                NP.schedule_deadlines!(registration.pollstate, Int64(time_ns()) + Int64(20_000_000), Int64(0), UInt64(1), UInt64(0))
                 err, elapsed_ns = fetch(poll_task)
                 @test err == Int32(0)
                 @test elapsed_ns < 500_000_000

--- a/test/eventloops_tests.jl
+++ b/test/eventloops_tests.jl
@@ -82,6 +82,45 @@ else
                 NP._backend_close!(state)
             end
         end
+        @testset "earlier scheduled deadline wakes poll early" begin
+            old_poller = NP.POLLER[]
+            state = NP.Poller()
+            poll_task = nothing
+            fd0 = Cint(-1)
+            fd1 = Cint(-1)
+            try
+                errno = NP._backend_init!(state)
+                @test errno == Int32(0)
+                @atomic :release state.running = true
+                NP.POLLER[] = state
+                fd0, fd1 = _el_socketpair_stream()
+                token = UInt64(41)
+                registration = NP.Registration(fd0, token, NP.PollMode.READWRITE, NP.PollWaiter(), NP.PollWaiter(), false)
+                state.registrations[fd0] = registration
+                state.registrations_by_token[token] = registration
+                @atomic :release state.poll_until_ns = Int64(time_ns()) + Int64(5_000_000_000)
+                poll_task = errormonitor(Threads.@spawn begin
+                    t0 = time_ns()
+                    err = NP._backend_poll_once!(state, Int64(5_000_000_000))
+                    return err, time_ns() - t0
+                end)
+                sleep(0.03)
+                NP.schedule_deadlines!(registration, Int64(time_ns()) + Int64(20_000_000), Int64(0), UInt64(1), UInt64(0))
+                err, elapsed_ns = fetch(poll_task)
+                @test err == Int32(0)
+                @test elapsed_ns < 500_000_000
+            finally
+                if poll_task isa Task && !istaskdone(poll_task)
+                    NP._backend_wake!(state)
+                    @test _el_wait_task_done(poll_task, 1.0) != :timed_out
+                end
+                poll_task isa Task && istaskdone(poll_task) && wait(poll_task)
+                NP.POLLER[] = old_poller
+                _el_close_fd(fd0)
+                _el_close_fd(fd1)
+                NP._backend_close!(state)
+            end
+        end
         @testset "runtime register/pollwait/deregister" begin
             NP.init!()
             fd0, fd1 = _el_socketpair_stream()

--- a/test/internal_poll_tests.jl
+++ b/test/internal_poll_tests.jl
@@ -105,6 +105,49 @@ else
                 EL.shutdown!()
             end
         end
+        @testset "combined deadline entry normalization" begin
+            registration = EL.Registration(Cint(7), UInt64(11), EL.PollMode.READWRITE, EL.PollWaiter(), EL.PollWaiter(), false)
+            combined = EL._build_deadline_entries(registration, Int64(10), Int64(10), UInt64(3), UInt64(5))
+            @test length(combined) == 1
+            @test combined[1].mode == EL.PollMode.READWRITE
+            @test combined[1].rseq == UInt64(3)
+            @test combined[1].wseq == UInt64(5)
+            split = EL._build_deadline_entries(registration, Int64(10), Int64(11), UInt64(3), UInt64(5))
+            @test length(split) == 2
+            @test split[1].mode == EL.PollMode.READ
+            @test split[2].mode == EL.PollMode.WRITE
+        end
+        @testset "set_deadline uses one combined heap entry and expires both sides" begin
+            fd0, fd1 = _ip_socketpair_stream()
+            ipfd = IP.FD(fd0)
+            fd0 = Cint(-1)
+            try
+                IP._set_nonblocking!(ipfd.sysfd)
+                IP.init!(ipfd)
+                state = EL.POLLER[]
+                future_deadline = Int64(time_ns()) + Int64(5_000_000_000)
+                IP.set_deadline!(ipfd, future_deadline)
+                lock(state.lock)
+                try
+                    entries = filter(x -> (x.registration::EL.Registration).token == ipfd.pd.token, state.deadline_heap)
+                    @test length(entries) == 1
+                    @test entries[1].mode == EL.PollMode.READWRITE
+                finally
+                    unlock(state.lock)
+                end
+                IP.set_deadline!(ipfd, Int64(time_ns()) + Int64(30_000_000))
+                sleep(0.06)
+                @test IP._check_error(ipfd.pd, IP.PollOp.READ) == Int32(2)
+                @test IP._check_error(ipfd.pd, IP.PollOp.WRITE) == Int32(2)
+                IP.set_deadline!(ipfd, Int64(0))
+                @test IP._check_error(ipfd.pd, IP.PollOp.READ) == Int32(0)
+                @test IP._check_error(ipfd.pd, IP.PollOp.WRITE) == Int32(0)
+            finally
+                ipfd.sysfd >= 0 && IP.close!(ipfd)
+                _ip_close_fd(fd1)
+                EL.shutdown!()
+            end
+        end
         @testset "close evicts blocked waiters" begin
             fd0, fd1 = _ip_socketpair_stream()
             ipfd = IP.FD(fd0)

--- a/test/internal_poll_tests.jl
+++ b/test/internal_poll_tests.jl
@@ -107,12 +107,12 @@ else
         end
         @testset "combined deadline entry normalization" begin
             registration = EL.Registration(Cint(7), UInt64(11), EL.PollMode.READWRITE, EL.PollWaiter(), EL.PollWaiter(), false)
-            combined = EL._build_deadline_entries(registration, Int64(10), Int64(10), UInt64(3), UInt64(5))
+            combined = EL._build_deadline_entries(registration.pollstate, Int64(10), Int64(10), UInt64(3), UInt64(5))
             @test length(combined) == 1
             @test combined[1].mode == EL.PollMode.READWRITE
             @test combined[1].rseq == UInt64(3)
             @test combined[1].wseq == UInt64(5)
-            split = EL._build_deadline_entries(registration, Int64(10), Int64(11), UInt64(3), UInt64(5))
+            split = EL._build_deadline_entries(registration.pollstate, Int64(10), Int64(11), UInt64(3), UInt64(5))
             @test length(split) == 2
             @test split[1].mode == EL.PollMode.READ
             @test split[2].mode == EL.PollMode.WRITE
@@ -129,7 +129,7 @@ else
                 IP.set_deadline!(ipfd, future_deadline)
                 lock(state.lock)
                 try
-                    entries = filter(x -> (x.registration::EL.Registration).token == ipfd.pd.token, state.deadline_heap)
+                    entries = filter(x -> x.pollstate.token == ipfd.pd.token, state.deadline_heap)
                     @test length(entries) == 1
                     @test entries[1].mode == EL.PollMode.READWRITE
                 finally


### PR DESCRIPTION
## Summary
- move IOPoll deadline scheduling into the EventLoops poller thread
- use backend `delay_ns` poll timeouts plus wake-shortening when earlier deadlines arrive
- combine equal read/write deadlines into a single heap entry
- add deadline wake-shortening and combined-deadline coverage

## Validation
- `julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`

## Notes
- keeps the dedicated poller-thread model while removing one-task-per-deadline sleepers
- leaves unrelated untracked local files untouched
