### PR TITLE
docs: expand runtime commentary and simplify connect APIs

### DIFF
--- a/src/1_eventloops.jl
+++ b/src/1_eventloops.jl
@@ -2,7 +2,19 @@
     EventLoops
 
 Cross-platform event loop abstraction for socket readiness polling.
-Current phase targets kqueue on macOS.
+
+This module is Reseau's analogue of Go's runtime netpoll layer:
+- backends translate OS readiness events into a small uniform `PollEvent`
+- one dedicated native poller thread blocks in the platform poll syscall
+- Julia tasks never call `epoll_wait`/`kevent`/`GetQueuedCompletionStatusEx`
+  directly; they instead park on `PollWaiter`s owned by registrations
+- deadlines are treated as part of poller state rather than as independent
+  Julia sleeper tasks, which mirrors how Go folds timer wakeups into the
+  scheduler-driven `netpoll(delay)` loop
+
+The backends differ substantially, but the exported surface aims to keep the
+rest of the runtime working in terms of registrations, waiters, and readiness
+notifications instead of backend-specific handles.
 """
 module EventLoops
 
@@ -26,6 +38,10 @@ end
 Go-style binary wake semaphore for one read waiter and one write waiter per fd.
 It uses the low-level `wait()` + `schedule(task)` ownership protocol documented in
 Julia's scheduler docs.
+
+The important invariant is that a single `PollWaiter` has at most one active
+waiting task. That matches Go's `pollDesc` model, where the runtime keeps one
+read waiter slot and one write waiter slot per descriptor.
 """
 mutable struct PollWaiter
     @atomic state::PollWaiterState.T
@@ -40,12 +56,18 @@ end
 
 Park the current Julia task until the waiter is notified.
 Concurrent waits on the same `PollWaiter` are forbidden.
+
+Returns `nothing`.
+
+Throws `ArgumentError` if two tasks try to wait on the same waiter
+simultaneously, or if the waiter state machine is observed in an invalid state.
 """
 function pollwait!(waiter::PollWaiter)
     task = current_task()
     task.sticky && (task.sticky = false)
     waiter.task = task
     try
+        # Fast path: transition directly from EMPTY -> WAITING and park.
         state, ok = @atomicreplace(waiter.state, PollWaiterState.EMPTY => PollWaiterState.WAITING)
         if ok
             wait()
@@ -53,6 +75,9 @@ function pollwait!(waiter::PollWaiter)
             state == PollWaiterState.NOTIFIED || throw(ArgumentError("concurrent wait on PollWaiter"))
         end
         while true
+            # A notifier can win the race before we actually reach `wait()`, so
+            # we loop until the NOTIFIED token is consumed or a clean EMPTY
+            # state is observed.
             state, ok = @atomicreplace(waiter.state, PollWaiterState.NOTIFIED => PollWaiterState.EMPTY)
             ok && return nothing
             state == PollWaiterState.EMPTY && return nothing
@@ -68,7 +93,11 @@ end
     pollnotify!(waiter)
 
 Mark waiter as notified and wake the waiter task if it has already parked.
-Returns `true` if a parked waiter was woken.
+Returns `true` if a parked waiter was woken and `false` if the waiter was
+already notified or had not yet parked.
+
+Throws `ArgumentError` if the waiter state machine is observed in an invalid
+state.
 """
 function pollnotify!(waiter::PollWaiter)::Bool
     state = @atomic :acquire waiter.state
@@ -78,6 +107,7 @@ function pollnotify!(waiter::PollWaiter)::Bool
         if state == PollWaiterState.WAITING
             task = waiter.task
             task isa Task || throw(ArgumentError("invalid PollWaiter task state"))
+            # `schedule(task)` is the low-level dual of the `wait()` above.
             schedule(task)
             return true
         end
@@ -91,6 +121,13 @@ end
     PollEvent
 
 Readiness event decoded from the platform backend.
+
+Fields:
+- `fd`: OS descriptor/socket identifier
+- `token`: monotonically increasing registration token used to reject stale
+  events after descriptor reuse
+- `mode`: which readiness direction fired
+- `errored`: whether the backend reported an error/hangup condition
 """
 struct PollEvent
     fd::Cint
@@ -99,6 +136,18 @@ struct PollEvent
     errored::Bool
 end
 
+"""
+    PollState(sysfd=-1, token=0)
+
+Descriptor-local state shared between `EventLoops` and `IOPoll`.
+
+This is intentionally close in spirit to Go's runtime `pollDesc`: it holds
+registration identity (`sysfd`, `token`), coarse descriptor state
+(`pollable`, `closing`, `event_err`), and the read/write deadline words plus
+their sequence numbers. The sequence counters are what let the poller heap
+discard stale deadline entries without mutating the heap in place whenever a
+deadline changes.
+"""
 mutable struct PollState
     lock::ReentrantLock
     sysfd::Cint
@@ -130,6 +179,12 @@ end
     Registration
 
 Per-fd registration state stored by the poller.
+
+Each active OS descriptor has one `Registration`, which is the home for:
+- the current token and interest mask known to the backend
+- one read waiter and one write waiter for parked Julia tasks
+- any backend-discovered persistent event error
+- the `PollState` consumed by higher layers
 """
 mutable struct Registration
     fd::Cint
@@ -152,6 +207,23 @@ function Registration(
     return Registration(fd, token, mode, read_waiter, write_waiter, event_err, PollState(fd, token))
 end
 
+"""
+    DeadlineEntry
+
+One scheduled deadline observation in the poller min-heap.
+
+The heap stores immutable snapshots: `(deadline_ns, mode, rseq, wseq)` capture
+the descriptor state at the moment the entry was scheduled. When an entry later
+reaches the top of the heap, `IOPoll.deadline_fire!` compares the saved
+sequence numbers against the current `PollState` to decide whether the timeout
+is still live or whether the entry became stale because the deadline was reset,
+cleared, or the descriptor was closed/re-registered.
+
+If read and write deadlines are equal, we intentionally store a single
+`READWRITE` entry. That is the same optimization Go applies with
+`netpollDeadline`: it reduces heap pressure while keeping the timeout semantics
+identical.
+"""
 struct DeadlineEntry
     deadline_ns::Int64
     pollstate::PollState
@@ -165,6 +237,14 @@ end
 
 Global event loop subsystem state. `lock` is a regular mutex because registration
 updates can run adjacent to syscalls where spin waiting would be wasteful.
+
+Notable fields:
+- `registrations`/`registrations_by_token` let us validate that an event or
+  deadline still belongs to the current occupant of an fd slot
+- `deadline_heap` is the min-heap that drives finite backend poll timeouts
+- `poll_until_ns` records the deadline currently being slept toward so that a
+  newly earlier deadline can call `_backend_wake!`, just like Go uses
+  `netpollBreak()` to shorten a blocking poll
 """
 mutable struct Poller
     lock::ReentrantLock
@@ -237,13 +317,7 @@ function _new_registration(fd::Cint, token::UInt64, mode::PollMode.T)::Registrat
     return Registration(fd, token, mode, PollWaiter(), PollWaiter(), false)
 end
 
-function deadline_fire!(owner, mode::PollMode.T, rseq::UInt64, wseq::UInt64)
-    _ = owner
-    _ = mode
-    _ = rseq
-    _ = wseq
-    return nothing
-end
+function deadline_fire! end
 
 @inline function _deadline_less(a::DeadlineEntry, b::DeadlineEntry)::Bool
     if a.deadline_ns != b.deadline_ns
@@ -326,6 +400,8 @@ end
 function _discard_stale_deadlines_locked!(state::Poller)
     while !isempty(state.deadline_heap)
         entry = state.deadline_heap[1]
+        # Descriptors are reused aggressively by the OS, so liveness must check
+        # both the fd and the monotonically increasing token.
         _registration_active_locked(state, entry.pollstate) && return nothing
         _ = _deadline_pop_locked!(state)
     end
@@ -346,6 +422,9 @@ function _build_deadline_entries(
         wseq::UInt64,
     )::Vector{DeadlineEntry}
     entries = DeadlineEntry[]
+    # Match Go's combined read/write deadline fast path when both deadlines are
+    # identical. Distinct deadlines stay as separate heap entries because they
+    # can expire independently.
     if rd_ns > 0 && wd_ns > 0 && rd_ns == wd_ns
         push!(entries, DeadlineEntry(rd_ns, pd, PollMode.READWRITE, rseq, wseq))
         return entries
@@ -355,6 +434,22 @@ function _build_deadline_entries(
     return entries
 end
 
+"""
+    schedule_deadlines!(pd, rd_ns, wd_ns, rseq, wseq)
+
+Publish the current deadline snapshot for `pd` into the poller heap.
+
+Arguments are the already-updated read/write deadline words and their sequence
+counters. Callers should hold any descriptor-local synchronization needed to
+produce a self-consistent snapshot before calling this function; the poller does
+not try to reconstruct that relationship after the fact.
+
+Returns `nothing`.
+
+If the newly scheduled entry becomes earlier than the deadline the poller thread
+is currently sleeping toward, the backend wake mechanism is triggered so the
+poll syscall can be reissued with the shorter timeout.
+"""
 function schedule_deadlines!(
         pd::PollState,
         rd_ns::Int64,
@@ -380,6 +475,10 @@ function schedule_deadlines!(
     end
     if new_earliest > 0
         poll_until_ns = @atomic :acquire state.poll_until_ns
+        # This is the local equivalent of Go's `netpollBreak()`: once the
+        # poller has committed to a sleep horizon, a newly earlier deadline must
+        # actively wake it so the blocking syscall can be retried with a
+        # shorter timeout.
         if poll_until_ns == 0 || new_earliest < poll_until_ns
             errno = _backend_wake!(state)
             errno == Int32(0) || _throw_errno("event loop wake", errno)
@@ -388,6 +487,17 @@ function schedule_deadlines!(
     return nothing
 end
 
+"""
+    _poll_delay_ns(state)
+
+Compute the timeout for the next backend poll call.
+
+Returns:
+- `-1` when no deadlines are pending and the backend may block indefinitely
+- `0` when at least one deadline is already due and the backend should poll
+  without blocking
+- a positive nanosecond timeout otherwise
+"""
 function _poll_delay_ns(state::Poller)::Int64
     deadline_ns = Int64(0)
     lock(state.lock)
@@ -405,6 +515,16 @@ function _poll_delay_ns(state::Poller)::Int64
     return remaining_ns
 end
 
+"""
+    _drain_expired_deadlines!(state, now_ns)
+
+Remove all expired deadline entries from the heap and dispatch them to
+`deadline_fire!`.
+
+The heap lock is not held across `deadline_fire!` calls. That keeps the critical
+section small and avoids lock-ordering problems with descriptor-local locks in
+`IOPoll`.
+"""
 function _drain_expired_deadlines!(state::Poller, now_ns::Int64)
     expired = DeadlineEntry[]
     lock(state.lock)
@@ -423,6 +543,16 @@ function _drain_expired_deadlines!(state::Poller, now_ns::Int64)
     return nothing
 end
 
+"""
+    current_registration(pd)
+
+Return the active `Registration` corresponding to `pd`, or `nothing` if `pd`
+has been deregistered or replaced.
+
+This extra indirection is what lets higher layers validate descriptor identity
+without trusting a cached registration reference through close/re-register
+races.
+"""
 function current_registration(pd::PollState)
     isassigned(POLLER) || return nothing
     state = POLLER[]
@@ -489,7 +619,12 @@ end
 """
     init!()
 
-Initialize the runtime poller state and start the dedicated foreign kqueue thread.
+Initialize the runtime poller state and start the dedicated poller thread.
+
+Returns the live `Poller` singleton.
+
+Throws `ArgumentError` if the current platform is unsupported and `SystemError`
+if backend initialization or thread creation fails.
 """
 function init!()::Poller
     if isassigned(POLLER)
@@ -520,7 +655,12 @@ end
 """
     shutdown!()
 
-Stop the dedicated poller thread and tear down kqueue resources.
+Stop the dedicated poller thread and tear down backend resources.
+
+Returns `nothing`.
+
+Waiting registrations are notified so blocked Julia tasks can observe close or
+shutdown on their next state check instead of remaining parked forever.
 """
 function shutdown!()
     isassigned(POLLER) || return nothing
@@ -552,9 +692,20 @@ function shutdown!()
 end
 
 """
-    register!(fd; mode=PollMode.READWRITE)
+    register!(fd; mode=PollMode.READWRITE, pollstate=nothing)
 
 Register an fd with the runtime poller and return its `Registration`.
+
+Keyword arguments:
+- `mode`: readiness directions to subscribe to
+- `pollstate`: optional pre-existing `PollState` to attach to the registration;
+  `IOPoll` uses this so the poller and the descriptor wrapper share one state
+  object
+
+Returns the created `Registration`.
+
+Throws `ArgumentError` if `mode` is empty, or `SystemError` if the descriptor is
+already registered or the backend registration syscall fails.
 """
 function register!(fd::Integer; mode::PollMode.T = PollMode.READWRITE, pollstate::Union{Nothing, PollState} = nothing)::Registration
     _mode_is_empty(mode) && throw(ArgumentError("register! requires READ and/or WRITE mode"))
@@ -591,6 +742,11 @@ end
     deregister!(fd)
 
 Unregister an fd from the runtime poller.
+
+Returns `nothing`.
+
+Any parked waiters are notified so they can re-check descriptor state and see
+the close/eviction condition promptly.
 """
 function deregister!(fd::Integer)
     isassigned(POLLER) || return nothing

--- a/src/2_socket_ops.jl
+++ b/src/2_socket_ops.jl
@@ -1,7 +1,20 @@
 """
     SocketOps
 
-Platform socket syscall facade and sockaddr helpers.
+Cross-platform socket syscall facade and sockaddr helpers.
+
+This module is intentionally lower level than `TCP`: it exposes thin wrappers
+around the OS socket APIs, normalizes the most important portability differences,
+and leaves policy decisions to higher layers.
+
+A few conventions are worth keeping in mind when reading the code:
+- successful mutating operations usually return `nothing`
+- operations that need to preserve transient errno values often return the raw
+  integer error code instead of throwing immediately
+- wrappers aim to look POSIX-like even on Windows so the polling and transport
+  layers can share most control flow
+- address helpers always build or decode structs in network byte order so callers
+  can treat the Julia-level tuples as ordinary host-order values
 """
 module SocketOps
 
@@ -163,9 +176,15 @@ end
 end
 
 """
-    sockaddr_in(ip::NTuple{4,UInt8}, port)
+    sockaddr_in(ip::NTuple{4,UInt8}, port) -> SockAddrIn
 
 Build a platform-compatible `sockaddr_in` from an IPv4 address tuple and port.
+
+`ip` is interpreted in presentation order, for example `(127, 0, 0, 1)`.
+`port` is validated to be in `[0, 65535]` and converted to network byte order
+inside the returned struct.
+
+Throws `ArgumentError` if the port is out of range.
 """
 function sockaddr_in(ip::NTuple{4, UInt8}, port::Integer)::SockAddrIn
     p = _hton16(_port_u16(port))
@@ -191,18 +210,34 @@ function sockaddr_in(ip::NTuple{4, <:Integer}, port::Integer)::SockAddrIn
     return sockaddr_in((_byte_u8(ip[1]), _byte_u8(ip[2]), _byte_u8(ip[3]), _byte_u8(ip[4])), port)
 end
 
+"""
+    sockaddr_in_loopback(port) -> SockAddrIn
+
+Convenience constructor for `127.0.0.1:port`.
+"""
 function sockaddr_in_loopback(port::Integer)::SockAddrIn
     return sockaddr_in((UInt8(127), UInt8(0), UInt8(0), UInt8(1)), port)
 end
 
+"""
+    sockaddr_in_any(port) -> SockAddrIn
+
+Convenience constructor for `0.0.0.0:port`, typically used for wildcard binds.
+"""
 function sockaddr_in_any(port::Integer)::SockAddrIn
     return sockaddr_in((UInt8(0), UInt8(0), UInt8(0), UInt8(0)), port)
 end
 
 """
-    sockaddr_in6(ip::NTuple{16,UInt8}, port; flowinfo=0, scope_id=0)
+    sockaddr_in6(ip::NTuple{16,UInt8}, port; flowinfo=0, scope_id=0) -> SockAddrIn6
 
 Build a platform-compatible `sockaddr_in6` from an IPv6 address tuple and port.
+
+`scope_id` is preserved for scoped addresses such as link-local endpoints and
+`flowinfo` is exposed for completeness even though higher layers usually leave it
+as zero.
+
+Throws `ArgumentError` if the port, `flowinfo`, or `scope_id` is out of range.
 """
 function sockaddr_in6(
         ip::NTuple{16, UInt8},
@@ -251,6 +286,11 @@ function sockaddr_in6(
     )
 end
 
+"""
+    sockaddr_in6_loopback(port; scope_id=0) -> SockAddrIn6
+
+Convenience constructor for the IPv6 loopback address `[::1]:port`.
+"""
 function sockaddr_in6_loopback(port::Integer; scope_id::Integer = 0)::SockAddrIn6
     return sockaddr_in6((
             UInt8(0), UInt8(0), UInt8(0), UInt8(0),
@@ -263,10 +303,20 @@ function sockaddr_in6_loopback(port::Integer; scope_id::Integer = 0)::SockAddrIn
     )
 end
 
+"""
+    sockaddr_in6_any(port; scope_id=0) -> SockAddrIn6
+
+Convenience constructor for the IPv6 wildcard bind address `[::]:port`.
+"""
 function sockaddr_in6_any(port::Integer; scope_id::Integer = 0)::SockAddrIn6
     return sockaddr_in6(ntuple(_ -> UInt8(0), 16), port; scope_id = scope_id)
 end
 
+"""
+    sockaddr_in_port(addr) -> UInt16
+
+Decode the IPv4 port from `addr` into host byte order.
+"""
 @inline function sockaddr_in_port(addr::SockAddrIn)::UInt16
     return _ntoh16(addr.sin_port)
 end
@@ -290,10 +340,20 @@ end
     return _ntoh16(addr.sin6_port)
 end
 
+"""
+    sockaddr_in6_ip(addr) -> NTuple{16,UInt8}
+
+Decode the raw IPv6 address bytes from `addr`.
+"""
 @inline function sockaddr_in6_ip(addr::SockAddrIn6)::NTuple{16, UInt8}
     return addr.sin6_addr
 end
 
+"""
+    sockaddr_in6_scopeid(addr) -> UInt32
+
+Return the IPv6 scope id stored in `addr`.
+"""
 @inline function sockaddr_in6_scopeid(addr::SockAddrIn6)::UInt32
     return addr.sin6_scope_id
 end
@@ -309,6 +369,10 @@ include("2_socket_ops_linux.jl")
 elseif Sys.iswindows()
 include("2_socket_ops_windows.jl")
 else
+
+# Unsupported platforms keep the same API surface but fail eagerly with ENOSYS.
+# This lets trim/smoke tests and higher-level code compile while still making the
+# lack of backend support obvious at runtime.
 
 function fd_is_cloexec(fd::Cint)::Bool
     _ = fd

--- a/src/2_socket_ops_darwin.jl
+++ b/src/2_socket_ops_darwin.jl
@@ -1,5 +1,9 @@
 # Darwin socket syscall bindings used by `SocketOps`.
-# Wrappers normalize retry/error behavior and expose consistent errno semantics.
+#
+# Darwin lacks Linux's atomic `SOCK_NONBLOCK`/`SOCK_CLOEXEC` and `accept4`
+# convenience flags, so this backend has a few more post-open/post-accept fixup
+# steps. The higher layers still get the same contract: sockets handed to the
+# poller are ready for non-blocking, close-on-exec use.
 const _F_GETFD = Cint(1)
 const _F_SETFD = Cint(2)
 const _F_GETFL = Cint(3)
@@ -104,6 +108,13 @@ end
     open_socket(family, sotype, proto=0)
 
 Create a socket and configure it as close-on-exec and non-blocking.
+
+Darwin requires setting both flags after `socket`, so there is a narrow race
+window compared with Linux. The TODO below mirrors the same concern in Go's
+runtime: ideally the descriptor would be protected from fork/exec inheritance
+even before `fcntl(F_SETFD)` runs.
+
+Returns the new file descriptor or throws `SystemError` on failure.
 """
 function open_socket(family::Integer, sotype::Integer, proto::Integer = 0)::Cint
     # TODO(go-parity): Go holds a spawn/exec fork lock around `socket` + CLOEXEC on Darwin
@@ -126,6 +137,10 @@ end
 
 Best-effort close that returns `0` for success/consumed close errors and
 `EBADF` when the descriptor is invalid.
+
+On BSD/Darwin, `close` usually consumes the descriptor number even if it reports
+an error. Surfacing only `EBADF` keeps callers from retrying `close` on an fd
+number that may already have been reused for a different socket.
 """
 function close_socket_nothrow(fd::Cint)::Int32
     ret = @ccall close(fd::Cint)::Cint
@@ -198,6 +213,17 @@ function connect_socket(fd::Cint, addr::SockAddrIn6)::Int32
     end
 end
 
+"""
+    connect_socket(fd, addr::Ptr{Cvoid}, addrlen::SockLen) -> Int32
+
+Attempt one non-blocking connect and return the raw errno-style result expected
+by the transport layer.
+
+`0` means the socket connected immediately. `EINPROGRESS` and similar values are
+not treated as exceptional here; they are returned so `TCP.connect_tcp_fd!` can
+switch into the poll-driven "wait writable, then inspect `SO_ERROR`" path used
+by Go as well.
+"""
 function connect_socket(fd::Cint, addr::Ptr{Cvoid}, addrlen::SockLen)::Int32
     # Exposes raw errno (e.g. EINPROGRESS) so upper layers can drive connect via poll.
     ret = @ccall gc_safe = true connect(fd::Cint, addr::Ptr{Cvoid}, addrlen::SockLen)::Cint
@@ -222,6 +248,11 @@ end
     try_accept_socket(fd)
 
 Perform one non-blocking `accept` attempt and return `(newfd, peer, errno)`.
+
+Because Darwin does not provide `accept4`, the accepted descriptor must be
+manually marked close-on-exec and non-blocking before it is handed upward. If
+either fixup fails, the child socket is immediately closed and the failure is
+reported through the returned errno.
 """
 function try_accept_socket(fd::Cint)::Tuple{Cint, AcceptPeer, Int32}
     addrbuf = Ref{NTuple{_ACCEPT_ADDRBUF_LEN, UInt8}}()
@@ -255,6 +286,9 @@ end
     accept_socket(fd)
 
 Accept a connection or throw `SystemError` on failure.
+
+This is the throwing wrapper over `try_accept_socket` for callers that prefer
+exception-based control flow.
 """
 function accept_socket(fd::Cint)::Cint
     newfd, _, errno = try_accept_socket(fd)
@@ -262,6 +296,11 @@ function accept_socket(fd::Cint)::Cint
     _throw_errno("accept", errno)
 end
 
+"""
+    get_sockopt_int(fd, level, optname) -> Int32
+
+Read an integer socket option and return it in host byte order.
+"""
 function get_sockopt_int(fd::Cint, level::Cint, optname::Cint)::Int32
     value = Ref{Cint}(0)
     optlen = Ref{SockLen}(SockLen(sizeof(Cint)))
@@ -280,6 +319,11 @@ function get_sockopt_int(fd::Cint, level::Cint, optname::Cint)::Int32
     end
 end
 
+"""
+    set_sockopt_int(fd, level, optname, value)
+
+Write an integer socket option.
+"""
 function set_sockopt_int(fd::Cint, level::Cint, optname::Cint, value::Integer)
     raw = Ref{Cint}(Cint(value))
     while true
@@ -297,6 +341,12 @@ function set_sockopt_int(fd::Cint, level::Cint, optname::Cint, value::Integer)
     end
 end
 
+"""
+    get_socket_error(fd) -> Int32
+
+Read `SO_ERROR`, primarily for completing non-blocking connect attempts after a
+write-readiness notification.
+"""
 function get_socket_error(fd::Cint)::Int32
     return get_sockopt_int(fd, SOL_SOCKET, SO_ERROR)
 end
@@ -349,6 +399,11 @@ function get_peer_name_in6(fd::Cint)::SockAddrIn6
     end
 end
 
+"""
+    shutdown_socket(fd, how)
+
+Half-close or fully close the directions designated by `how`.
+"""
 function shutdown_socket(fd::Cint, how::Integer)
     while true
         ret = @ccall gc_safe = true shutdown(fd::Cint, Cint(how)::Cint)::Cint
@@ -359,6 +414,11 @@ function shutdown_socket(fd::Cint, how::Integer)
     end
 end
 
+"""
+    read_once!(fd, ptr, nbytes) -> Cssize_t
+
+Perform exactly one raw `read(2)` attempt, retrying only `EINTR`.
+"""
 function read_once!(fd::Cint, ptr::Ptr{UInt8}, nbytes::Csize_t)::Cssize_t
     # Single read syscall with EINTR retry; caller owns EAGAIN and short-read handling.
     while true
@@ -370,6 +430,11 @@ function read_once!(fd::Cint, ptr::Ptr{UInt8}, nbytes::Csize_t)::Cssize_t
     end
 end
 
+"""
+    write_once!(fd, ptr, nbytes) -> Cssize_t
+
+Perform exactly one raw `write(2)` attempt, retrying only `EINTR`.
+"""
 function write_once!(fd::Cint, ptr::Ptr{UInt8}, nbytes::Csize_t)::Cssize_t
     # Single write syscall with EINTR retry; caller owns EAGAIN and short-write handling.
     while true

--- a/src/2_socket_ops_linux.jl
+++ b/src/2_socket_ops_linux.jl
@@ -1,5 +1,14 @@
 # Linux socket syscall bindings used by `SocketOps`.
-# Wrappers normalize retry/error behavior and expose consistent errno semantics.
+#
+# The higher layers assume Go-like invariants:
+# - newly created sockets are non-blocking and close-on-exec before they escape
+# - retryable syscall interruptions are handled here instead of in every caller
+# - connect/accept can surface raw errno so the poll layer can finish the state
+#   machine after readiness notifications
+#
+# Linux gives us the best-case primitives (`SOCK_NONBLOCK`, `SOCK_CLOEXEC`,
+# `accept4`) so this backend mostly tries to take the atomic fast path first and
+# only falls back to older-kernel behavior when required.
 const _F_GETFD = Cint(1)
 const _F_SETFD = Cint(2)
 const _F_GETFL = Cint(3)
@@ -120,6 +129,12 @@ end
     open_socket(family, sotype, proto=0)
 
 Create a socket and configure it as close-on-exec and non-blocking.
+
+On modern Linux kernels this is done atomically with `socket(..., SOCK_NONBLOCK |
+SOCK_CLOEXEC, ...)`, which avoids the small post-open race that exists when those
+flags must be applied with `fcntl`.
+
+Returns the new file descriptor or throws `SystemError` on failure.
 """
 function open_socket(family::Integer, sotype::Integer, proto::Integer = 0)::Cint
     raw_type = Cint(sotype)
@@ -292,6 +307,13 @@ end
     try_accept_socket(fd)
 
 Perform one non-blocking `accept` attempt and return `(newfd, peer, errno)`.
+
+This prefers `accept4` so the accepted descriptor inherits non-blocking and
+close-on-exec atomically. If the running kernel reports `ENOSYS` or `EINVAL`,
+the backend permanently falls back to plain `accept` plus post-accept flag
+fixups. That mirrors the strategy Go uses on older kernels.
+
+`newfd == -1` indicates failure and `errno` contains the mapped Linux errno.
 """
 function try_accept_socket(fd::Cint)::Tuple{Cint, AcceptPeer, Int32}
     state = _accept4_state[]
@@ -314,6 +336,9 @@ end
     accept_socket(fd)
 
 Accept a connection or throw `SystemError` on failure.
+
+This is a convenience wrapper over `try_accept_socket` for callers that want
+exception-based control flow instead of raw errno handling.
 """
 function accept_socket(fd::Cint)::Cint
     newfd, _, errno = try_accept_socket(fd)
@@ -321,6 +346,13 @@ function accept_socket(fd::Cint)::Cint
     _throw_errno("accept", errno)
 end
 
+"""
+    get_sockopt_int(fd, level, optname) -> Int32
+
+Read an integer socket option and return it in host byte order.
+
+Throws `SystemError` if `getsockopt` fails.
+"""
 function get_sockopt_int(fd::Cint, level::Cint, optname::Cint)::Int32
     value = Ref{Cint}(0)
     optlen = Ref{SockLen}(SockLen(sizeof(Cint)))
@@ -339,6 +371,13 @@ function get_sockopt_int(fd::Cint, level::Cint, optname::Cint)::Int32
     end
 end
 
+"""
+    set_sockopt_int(fd, level, optname, value)
+
+Write an integer socket option.
+
+Throws `SystemError` if `setsockopt` fails.
+"""
 function set_sockopt_int(fd::Cint, level::Cint, optname::Cint, value::Integer)
     raw = Ref{Cint}(Cint(value))
     while true
@@ -356,6 +395,13 @@ function set_sockopt_int(fd::Cint, level::Cint, optname::Cint, value::Integer)
     end
 end
 
+"""
+    get_socket_error(fd) -> Int32
+
+Read and return `SO_ERROR` for `fd`. This is primarily used to complete the
+non-blocking connect state machine after poll readiness says the socket is
+writable.
+"""
 function get_socket_error(fd::Cint)::Int32
     return get_sockopt_int(fd, SOL_SOCKET, SO_ERROR)
 end
@@ -408,6 +454,12 @@ function get_peer_name_in6(fd::Cint)::SockAddrIn6
     end
 end
 
+"""
+    shutdown_socket(fd, how)
+
+Half-close or fully close the socket send/receive direction designated by
+`how`, which should be one of `SHUT_RD`, `SHUT_WR`, or `SHUT_RDWR`.
+"""
 function shutdown_socket(fd::Cint, how::Integer)
     while true
         ret = @ccall gc_safe = true shutdown(fd::Cint, Cint(how)::Cint)::Cint
@@ -418,6 +470,15 @@ function shutdown_socket(fd::Cint, how::Integer)
     end
 end
 
+"""
+    read_once!(fd, ptr, nbytes) -> Cssize_t
+
+Perform one raw `read(2)` call.
+
+This wrapper intentionally does not loop on `EAGAIN` or short reads; higher
+layers use the return value together with readiness polling to drive the full
+read loop.
+"""
 function read_once!(fd::Cint, ptr::Ptr{UInt8}, nbytes::Csize_t)::Cssize_t
     # Single read syscall with EINTR retry; caller owns EAGAIN and short-read handling.
     while true
@@ -429,6 +490,14 @@ function read_once!(fd::Cint, ptr::Ptr{UInt8}, nbytes::Csize_t)::Cssize_t
     end
 end
 
+"""
+    write_once!(fd, ptr, nbytes) -> Cssize_t
+
+Perform one raw `write(2)` call.
+
+Short writes and `EAGAIN` are surfaced to the caller so `IOPoll` can decide
+whether to retry immediately or wait for write readiness.
+"""
 function write_once!(fd::Cint, ptr::Ptr{UInt8}, nbytes::Csize_t)::Cssize_t
     # Single write syscall with EINTR retry; caller owns EAGAIN and short-write handling.
     while true

--- a/src/2_socket_ops_windows.jl
+++ b/src/2_socket_ops_windows.jl
@@ -1,5 +1,12 @@
 # Windows socket syscall bindings used by `SocketOps`.
-# Wrappers normalize retry/error behavior and expose POSIX-like errno semantics.
+#
+# This backend deliberately translates WinSock behavior into a POSIX-flavored
+# contract so the rest of Reseau can share logic with the Unix implementations.
+# The main adaptations are:
+# - mapping WinSock and Win32 errors onto `Base.Libc` errno values
+# - remembering non-blocking state in Julia because WinSock does not expose the
+#   same `fcntl(F_GETFL)` style query API
+# - configuring handles to be non-inheritable so they behave like CLOEXEC fds
 
 const _WS2_32 = "Ws2_32"
 const _MSWSOCK = "Mswsock"
@@ -185,6 +192,14 @@ function _fd_nonblocking_enabled(fd::Cint)::Bool
     end
 end
 
+"""
+    ensure_winsock!()
+
+Initialize WinSock for the current process if it has not already been started.
+
+This is safe to call repeatedly. The per-process pid check matters because a
+Julia process can fork in ways that invalidate the inherited WinSock state.
+"""
 function ensure_winsock!()
     pid = Base.getpid()
     if _winsock_initialized[] && _winsock_init_pid[] == pid
@@ -247,6 +262,12 @@ function set_close_on_exec!(fd::Cint)
     return nothing
 end
 
+"""
+    set_nonblocking!(fd, enabled=true)
+
+Toggle WinSock non-blocking mode and update the Julia-side bookkeeping used by
+`fd_is_nonblocking`.
+"""
 function set_nonblocking!(fd::Cint, enabled::Bool = true)
     ensure_winsock!()
     arg = Ref{UInt32}(enabled ? UInt32(1) : UInt32(0))
@@ -256,6 +277,17 @@ function set_nonblocking!(fd::Cint, enabled::Bool = true)
     return nothing
 end
 
+"""
+    open_socket(family, sotype, proto=0) -> Cint
+
+Create a WinSock socket configured for overlapped I/O, non-inheritable handle
+semantics, and non-blocking operation.
+
+The preferred path uses `WSASocketW(..., WSA_FLAG_NO_HANDLE_INHERIT)` so the
+socket never becomes inheritable in the first place. If that flag is rejected,
+the backend falls back to manually clearing inheritability with
+`SetHandleInformation`, which is the closest analogue to Unix `FD_CLOEXEC`.
+"""
 function open_socket(family::Integer, sotype::Integer, proto::Integer = 0)::Cint
     ensure_winsock!()
     raw_type = Cint(sotype)
@@ -308,6 +340,13 @@ function open_socket(family::Integer, sotype::Integer, proto::Integer = 0)::Cint
     return fd
 end
 
+"""
+    close_socket_nothrow(fd) -> Int32
+
+Best-effort close that mirrors the Unix backends: return `0` for success or
+consumed close errors, and return `EBADF` only when the socket handle was
+already invalid.
+"""
 function close_socket_nothrow(fd::Cint)::Int32
     _clear_fd_state!(fd)
     ret = @ccall gc_safe = true _WS2_32.closesocket(
@@ -374,6 +413,15 @@ function connect_socket(fd::Cint, addr::SockAddrIn6)::Int32
     end
 end
 
+"""
+    connect_socket(fd, addr::Ptr{Cvoid}, addrlen::SockLen) -> Int32
+
+Attempt one non-blocking WinSock connect and return a POSIX-like errno code.
+
+WinSock reports deferred completion as `WSAEWOULDBLOCK`; this backend maps that
+to `EINPROGRESS` so the transport layer can use the same poll-driven connect
+completion path as it does on Unix.
+"""
 function connect_socket(fd::Cint, addr::Ptr{Cvoid}, addrlen::SockLen)::Int32
     ret = @ccall gc_safe = true "Ws2_32".connect(
         _socket_value(fd)::UInt,
@@ -386,6 +434,12 @@ function connect_socket(fd::Cint, addr::Ptr{Cvoid}, addrlen::SockLen)::Int32
     return _map_wsa_errno(err)
 end
 
+"""
+    sockaddr_bytes(addr) -> Vector{UInt8}
+
+Copy a sockaddr struct into a byte vector suitable for APIs like ConnectEx that
+want raw address buffers instead of typed Julia structs.
+"""
 function sockaddr_bytes(addr::SockAddrIn)::Vector{UInt8}
     bytes = Vector{UInt8}(undef, sizeof(SockAddrIn))
     addr_ref = Ref(addr)
@@ -425,6 +479,15 @@ end
     return nothing
 end
 
+"""
+    try_accept_socket(fd) -> Tuple{Cint, AcceptPeer, Int32}
+
+Perform one non-blocking WinSock `accept` attempt and return `(newfd, peer,
+errno)`.
+
+The returned child socket is normalized to the same invariants as Unix:
+non-inheritable and non-blocking before it escapes to higher layers.
+"""
 function try_accept_socket(fd::Cint)::Tuple{Cint, AcceptPeer, Int32}
     addrbuf = Ref{NTuple{_ACCEPT_ADDRBUF_LEN, UInt8}}()
     addrlen = Ref{SockLen}(SockLen(_ACCEPT_ADDRBUF_LEN))
@@ -477,6 +540,14 @@ function _set_sockopt_ptr!(fd::Cint, optname::Cint, ptr::Ptr{UInt8}, optlen::Int
     _throw_errno("setsockopt", _map_wsa_errno(_wsa_get_last_error()))
 end
 
+"""
+    update_connect_context!(fd)
+
+Finalize a socket that completed connection establishment through ConnectEx.
+
+Windows requires `SO_UPDATE_CONNECT_CONTEXT` before APIs like `getsockname` and
+`getpeername` reflect the connected state consistently.
+"""
 function update_connect_context!(fd::Cint)
     handle_ref = Ref{UInt}(_socket_value(fd))
     GC.@preserve handle_ref begin
@@ -490,6 +561,12 @@ function update_connect_context!(fd::Cint)
     return nothing
 end
 
+"""
+    finish_accept_ex!(listener_fd, acceptfd, addrbuf) -> AcceptPeer
+
+Finalize a socket accepted through AcceptEx and decode the remote peer address
+from the AcceptEx scratch buffer.
+"""
 function finish_accept_ex!(listener_fd::Cint, acceptfd::Cint, addrbuf::Vector{UInt8})::AcceptPeer
     listener_ref = Ref{UInt}(_socket_value(listener_fd))
     GC.@preserve listener_ref begin
@@ -520,6 +597,11 @@ function finish_accept_ex!(listener_fd::Cint, acceptfd::Cint, addrbuf::Vector{UI
     return _decode_accept_peer(remote_ptr[], SockLen(remote_len[]))
 end
 
+"""
+    get_sockopt_int(fd, level, optname) -> Int32
+
+Read an integer socket option and return it in host byte order.
+"""
 function get_sockopt_int(fd::Cint, level::Cint, optname::Cint)::Int32
     value = Ref{Cint}(0)
     optlen = Ref{Cint}(Cint(sizeof(Cint)))
@@ -539,6 +621,11 @@ function get_sockopt_int(fd::Cint, level::Cint, optname::Cint)::Int32
     _throw_errno("getsockopt", _map_wsa_errno(_wsa_get_last_error()))
 end
 
+"""
+    set_sockopt_int(fd, level, optname, value)
+
+Write an integer socket option.
+"""
 function set_sockopt_int(fd::Cint, level::Cint, optname::Cint, value::Integer)
     raw = Ref{Cint}(Cint(value))
     ret = GC.@preserve raw begin
@@ -557,6 +644,11 @@ function set_sockopt_int(fd::Cint, level::Cint, optname::Cint, value::Integer)
     _throw_errno("setsockopt", _map_wsa_errno(_wsa_get_last_error()))
 end
 
+"""
+    get_socket_error(fd) -> Int32
+
+Read `SO_ERROR`, primarily for finishing non-blocking connect attempts.
+"""
 function get_socket_error(fd::Cint)::Int32
     return get_sockopt_int(fd, SOL_SOCKET, SO_ERROR)
 end
@@ -621,6 +713,11 @@ function get_peer_name_in6(fd::Cint)::SockAddrIn6
     _throw_errno("getpeername", _map_wsa_errno(_wsa_get_last_error()))
 end
 
+"""
+    shutdown_socket(fd, how)
+
+Half-close or fully close the directions designated by `how`.
+"""
 function shutdown_socket(fd::Cint, how::Integer)
     ret = @ccall gc_safe = true _WS2_32.shutdown(
         _socket_value(fd)::UInt,
@@ -630,6 +727,13 @@ function shutdown_socket(fd::Cint, how::Integer)
     _throw_errno("shutdown", _map_wsa_errno(_wsa_get_last_error()))
 end
 
+"""
+    read_once!(fd, ptr, nbytes) -> Cssize_t
+
+Perform one raw `recv` call. WinSock already reports interruption through the
+error code, so this wrapper simply returns `-1` on failure and leaves error
+inspection to the caller.
+"""
 function read_once!(fd::Cint, ptr::Ptr{UInt8}, nbytes::Csize_t)::Cssize_t
     n = Int(min(nbytes, Csize_t(typemax(Cint))))
     ret = @ccall gc_safe = true "Ws2_32".recv(
@@ -642,6 +746,11 @@ function read_once!(fd::Cint, ptr::Ptr{UInt8}, nbytes::Csize_t)::Cssize_t
     return Cssize_t(-1)
 end
 
+"""
+    write_once!(fd, ptr, nbytes) -> Cssize_t
+
+Perform one raw `send` call and surface short writes or errors to the caller.
+"""
 function write_once!(fd::Cint, ptr::Ptr{UInt8}, nbytes::Csize_t)::Cssize_t
     n = Int(min(nbytes, Csize_t(typemax(Cint))))
     ret = @ccall gc_safe = true "Ws2_32".send(

--- a/src/3_internal_poll.jl
+++ b/src/3_internal_poll.jl
@@ -944,9 +944,21 @@ function accept!(fd::FD, family::Cint, sotype::Cint)::Tuple{Cint, SocketOps.Acce
 end
 
 """
-Read up to `length(p)` bytes into `p`.
+Read up to `length(p)` bytes into `p` and return the number of bytes read.
 
-In non-blocking mode this loops on `EAGAIN` by waiting for read readiness.
+Important behavior notes:
+- the return value may be smaller than `length(p)` whenever fewer bytes are
+  currently available than the caller requested; this is normal for stream
+  sockets and does not imply EOF
+- once at least one byte has been read, the call returns immediately instead of
+  waiting to fill the rest of `p`
+- if no bytes are currently available and the descriptor is pollable, the call
+  waits for read readiness and then retries
+- a zero-length `p` returns `0` immediately without touching the descriptor
+
+Throws `EOFError` when the peer cleanly closes a stream whose
+`zero_read_is_eof` flag is set, `DeadlineExceededError` when the read deadline
+expires while waiting, and `SystemError` for OS-level read failures.
 """
 function read!(fd::FD, p::Vector{UInt8})::Int
     _fd_read_lock!(fd)
@@ -974,9 +986,11 @@ function read!(fd::FD, p::Vector{UInt8})::Int
 end
 
 """
-Write all bytes from `p`.
+Write all bytes from `p` and return the number of bytes written.
 
-In non-blocking mode this loops on `EAGAIN` by waiting for write readiness.
+Unlike `read!`, a successful return means the full buffer was written. In
+non-blocking mode this loops on `EAGAIN` by waiting for write readiness and
+then resuming from the first unwritten byte.
 """
 function write!(fd::FD, p::Vector{UInt8})::Int
     GC.@preserve p begin
@@ -985,7 +999,10 @@ function write!(fd::FD, p::Vector{UInt8})::Int
 end
 
 """
-Write `nbytes` from a `Memory{UInt8}` buffer.
+Write exactly `nbytes` from a `Memory{UInt8}` buffer and return the byte count.
+
+This follows the same blocking/retry behavior as `write!(fd, ::Vector{UInt8})`
+and only returns successfully once all requested bytes have been accepted.
 """
 function write!(fd::FD, p::Memory{UInt8}, nbytes::Integer)::Int
     n = Int(nbytes)

--- a/src/3_internal_poll.jl
+++ b/src/3_internal_poll.jl
@@ -3,6 +3,12 @@
 
 Go-style poll descriptor layer built on `EventLoops`.
 Provides deadline-aware readiness waiting for network descriptors.
+
+Conceptually this sits where Go's `internal/poll` package sits:
+- `EventLoops` is the runtime-facing readiness engine
+- `IOPoll` turns readiness and deadlines into descriptor-centric operations
+- higher transport layers call `prepare_*`, `wait_*`, and deadline helpers
+  instead of talking to the event loop directly
 """
 module IOPoll
 
@@ -31,6 +37,9 @@ const _POLL_ERR_NOT_POLLABLE = Int32(3)
 
 """
 Bitmask of operations used for readiness waits and deadline management.
+
+`READWRITE` is intentionally the bitwise OR of `READ` and `WRITE` so callers can
+test or combine directions cheaply.
 """
 @enumx PollOp::UInt8 begin
     READ = 0x01
@@ -91,9 +100,13 @@ end
 end
 
 """
-Small counting semaphore used by `FDLock` lock wait paths.
+    RuntimeSema
 
-This is unbounded, so multiple wakeups can accumulate.
+Small counting semaphore used by `FDLock` slow paths.
+
+Unlike `PollWaiter`, this is deliberately unbounded: repeated wakeups must not
+be lost while a goroutine-like lock waiter is still making progress through the
+`FDLock` state machine.
 """
 mutable struct RuntimeSema
     lock::ReentrantLock
@@ -105,6 +118,13 @@ mutable struct RuntimeSema
     end
 end
 
+"""
+    _runtime_sema_acquire!(sema)
+
+Block until one semaphore unit is available, then consume it.
+
+Returns `nothing`.
+"""
 function _runtime_sema_acquire!(sema::RuntimeSema)
     lock(sema.lock)
     try
@@ -118,6 +138,13 @@ function _runtime_sema_acquire!(sema::RuntimeSema)
     return nothing
 end
 
+"""
+    _runtime_sema_release!(sema)
+
+Add one semaphore unit and notify one blocked waiter.
+
+Returns `nothing`.
+"""
 function _runtime_sema_release!(sema::RuntimeSema)
     lock(sema.lock)
     try
@@ -153,6 +180,16 @@ mutable struct FDLock
     end
 end
 
+"""
+    _fdlock_incref!(mu)
+
+Acquire one shared descriptor reference.
+
+Returns `true` on success and `false` if close has already started.
+
+Throws `ArgumentError` if the reference count overflows, which would indicate an
+unreasonable number of concurrent operations on one descriptor.
+"""
 function _fdlock_incref!(mu::FDLock)::Bool
     while true
         old = @atomic :acquire mu.state
@@ -164,6 +201,15 @@ function _fdlock_incref!(mu::FDLock)::Bool
     end
 end
 
+"""
+    _fdlock_incref_and_close!(mu)
+
+Start close, acquire one final shared reference, and wake all queued lock
+waiters.
+
+Returns `true` if this call successfully initiated close and `false` if another
+task had already done so.
+"""
 function _fdlock_incref_and_close!(mu::FDLock)::Bool
     while true
         old = @atomic :acquire mu.state
@@ -188,6 +234,15 @@ function _fdlock_incref_and_close!(mu::FDLock)::Bool
     end
 end
 
+"""
+    _fdlock_decref!(mu)
+
+Release one shared descriptor reference.
+
+Returns `true` exactly when the descriptor has already been marked closed and
+this call released the final outstanding reference, meaning the underlying OS
+handle may now be destroyed.
+"""
 function _fdlock_decref!(mu::FDLock)::Bool
     while true
         old = @atomic :acquire mu.state
@@ -199,6 +254,18 @@ function _fdlock_decref!(mu::FDLock)::Bool
     end
 end
 
+"""
+    _fdlock_rwlock!(mu, read_lock, wait_lock)
+
+Acquire the descriptor's read or write operation lock.
+
+Arguments:
+- `read_lock`: `true` for the read lock, `false` for the write lock
+- `wait_lock`: whether to queue and block if the lock is already held
+
+Returns `true` on success and `false` if the descriptor is closed or if
+`wait_lock == false` and the lock is already held.
+"""
 function _fdlock_rwlock!(mu::FDLock, read_lock::Bool, wait_lock::Bool)::Bool
     mutex_bit = read_lock ? _MUTEX_RLOCK : _MUTEX_WLOCK
     mutex_wait = read_lock ? _MUTEX_RWAIT : _MUTEX_WWAIT
@@ -225,6 +292,14 @@ function _fdlock_rwlock!(mu::FDLock, read_lock::Bool, wait_lock::Bool)::Bool
     end
 end
 
+"""
+    _fdlock_rwunlock!(mu, read_lock)
+
+Release the descriptor's read or write operation lock.
+
+Returns `true` when the descriptor has already been marked closed and this call
+released the final reference, so destruction should proceed.
+"""
 function _fdlock_rwunlock!(mu::FDLock, read_lock::Bool)::Bool
     mutex_bit = read_lock ? _MUTEX_RLOCK : _MUTEX_WLOCK
     mutex_wait = read_lock ? _MUTEX_RWAIT : _MUTEX_WWAIT
@@ -251,6 +326,12 @@ Internal file descriptor wrapper used by the poll layer.
 
 This coordinates descriptor lifetime, read/write serialization, and integration
 with `PollState`.
+
+Fields:
+- `fdlock`: Go-style reference and read/write lock state
+- `pd`: deadline/readiness state shared with `EventLoops`
+- `csema`: close semaphore used to wait for non-blocking operations to drain
+- `is_blocking`: whether the OS descriptor has been switched back to blocking
 """
 mutable struct FD
     fdlock::FDLock
@@ -280,6 +361,16 @@ mutable struct FD
     end
 end
 
+"""
+    _convert_poll_error!(res, is_file)
+
+Map a compact internal poll status code to the public exception surface.
+
+Returns `nothing` when `res` indicates success.
+
+Throws one of `NetClosingError`, `FileClosingError`, `DeadlineExceededError`,
+`NotPollableError`, or `ArgumentError` for an invalid status code.
+"""
 function _convert_poll_error!(res::Int32, is_file::Bool)
     res == _POLL_NO_ERROR && return nothing
     res == _POLL_ERR_CLOSING && throw(_closing_error(is_file))
@@ -290,6 +381,10 @@ end
 
 """
 Map current `PollState` state into a compact poll error code.
+
+This mirrors the shape of Go's `runtime_pollWait` checks: close and deadline
+state are consulted before and after parking so callers can distinguish "ready"
+from "woken because the descriptor was closed or timed out".
 """
 function _check_error(pd::PollState, mode::PollOp.T)::Int32
     (@atomic :acquire pd.closing) && return _POLL_ERR_CLOSING
@@ -306,6 +401,16 @@ function _check_error(pd::PollState, mode::PollOp.T)::Int32
     return _POLL_NO_ERROR
 end
 
+"""
+    _refresh_event_err!(pd)
+
+Synchronize the persistent backend error bit from the live registration into
+`pd.event_err`.
+
+Backends set `registration.event_err` when the OS reports an error/hangup event
+that should permanently make the descriptor non-pollable. Higher layers cache
+that on `PollState` because `PollState` outlives any single readiness wait.
+"""
 function _refresh_event_err!(pd::PollState)
     (@atomic :acquire pd.pollable) || return nothing
     registration = EventLoops.current_registration(pd)
@@ -315,6 +420,13 @@ function _refresh_event_err!(pd::PollState)
     return nothing
 end
 
+"""
+    _wake_waiters!(pd, mode)
+
+Notify the read and/or write waiters associated with `pd`.
+
+Returns `nothing`.
+"""
 function _wake_waiters!(pd::PollState, mode::PollOp.T)
     (@atomic :acquire pd.pollable) || return nothing
     registration = EventLoops.current_registration(pd)
@@ -329,6 +441,19 @@ function _wake_waiters!(pd::PollState, mode::PollOp.T)
     return nothing
 end
 
+"""
+    deadline_fire!(pd, mode, rseq, wseq)
+
+Consume one expired poller deadline entry.
+
+The poller thread passes in the sequence numbers captured when the deadline was
+scheduled. If they still match the current `PollState`, the deadline is live and
+the corresponding read/write deadline slot is flipped to `-1`, which is the
+local sentinel for "deadline exceeded". If the sequences no longer match, the
+entry is stale and ignored.
+
+Returns `nothing`.
+"""
 function deadline_fire!(
         pd::PollState,
         mode::EventLoops.PollMode.T,
@@ -371,6 +496,12 @@ Set read/write deadline state on an `FD`.
 
 `deadline_ns == 0` disables deadlines for the selected mode.
 `deadline_ns <= time_ns()` triggers immediate timeout.
+
+Returns `nothing`.
+
+Throws:
+- `NetClosingError` / `FileClosingError` if close has already started
+- `NoDeadlineError` if the descriptor is not managed by the poller
 """
 function _set_deadline_impl!(fd::FD, deadline_ns::Integer, mode::PollOp.T)
     deadline = Int64(deadline_ns)
@@ -389,6 +520,8 @@ function _set_deadline_impl!(fd::FD, deadline_ns::Integer, mode::PollOp.T)
         try
             (@atomic :acquire pd.closing) && return nothing
             if _mode_has_read(mode)
+                # The new sequence invalidates every previously scheduled read
+                # deadline entry for this descriptor.
                 @atomic pd.rseq += UInt64(1)
                 if deadline == 0
                     @atomic :release pd.rd_ns = Int64(0)
@@ -417,6 +550,10 @@ function _set_deadline_impl!(fd::FD, deadline_ns::Integer, mode::PollOp.T)
         finally
             unlock(pd.lock)
         end
+        # Publish the post-update snapshot to the poller heap. Stale entries are
+        # left in the heap and filtered by sequence/token checks when they reach
+        # the top, which keeps scheduling cheap and matches Go's timer seq
+        # invalidation strategy.
         EventLoops.schedule_deadlines!(pd, rd_ns, wd_ns, rseq, wseq)
         if wake_read && wake_write
             _wake_waiters!(pd, PollOp.READWRITE)
@@ -436,6 +573,15 @@ Initialize polling state for an `FD`.
 
 When `pollable=true`, the fd is registered with `EventLoops`; otherwise the fd
 is treated as blocking and deadline support is disabled.
+
+Keyword arguments:
+- `net`: reserved for parity with higher-level callers that track transport kind
+- `pollable`: whether the descriptor should be registered with the runtime
+  poller
+
+Returns `nothing`.
+
+Throws `SystemError` if event loop registration fails.
 """
 function init!(fd::FD; net::Symbol = :tcp, pollable::Bool = true)
     _ = net
@@ -466,6 +612,8 @@ end
 
 """
 Tear down polling state for a descriptor and deregister from `EventLoops`.
+
+Returns `nothing`.
 """
 function close!(pd::PollState)
     was_pollable = false
@@ -482,6 +630,9 @@ end
 
 """
 Mark descriptor as closing and wake all waiters.
+
+This does not itself destroy the OS descriptor; it only forces all future poll
+operations to observe closing and all parked waiters to wake up promptly.
 """
 function evict!(pd::PollState)
     lock(pd.lock)
@@ -512,6 +663,11 @@ end
 
 """
 Validate read path state before issuing a read syscall.
+
+Returns `nothing`.
+
+Throws the same exceptions as `_convert_poll_error!` if close, timeout, or
+backend error state is already visible.
 """
 function prepare_read!(pd::PollState, is_file::Bool = false)
     _convert_poll_error!(_check_error(pd, PollOp.READ), is_file)
@@ -520,6 +676,8 @@ end
 
 """
 Validate write path state before issuing a write syscall.
+
+Returns `nothing`.
 """
 function prepare_write!(pd::PollState, is_file::Bool = false)
     _convert_poll_error!(_check_error(pd, PollOp.WRITE), is_file)
@@ -528,6 +686,14 @@ end
 
 """
 Block until read readiness, then re-check for close/timeout/not-pollable errors.
+
+Returns `nothing`.
+
+Throws:
+- `ArgumentError` if the descriptor is not pollable
+- `NetClosingError` / `FileClosingError` if the descriptor closes while waiting
+- `DeadlineExceededError` if the read deadline expires
+- `NotPollableError` if the backend reports a permanent readiness error
 """
 function wait_read!(pd::PollState, is_file::Bool = false)
     _convert_poll_error!(_check_error(pd, PollOp.READ), is_file)
@@ -541,6 +707,8 @@ end
 
 """
 Block until write readiness, then re-check for close/timeout/not-pollable errors.
+
+Returns `nothing`.
 """
 function wait_write!(pd::PollState, is_file::Bool = false)
     _convert_poll_error!(_check_error(pd, PollOp.WRITE), is_file)
@@ -554,6 +722,12 @@ end
 
 """
 Wait for readiness in a cancellation context (used by close/deadline wake paths).
+
+Returns `nothing`.
+
+Unlike `wait_read!`/`wait_write!`, this helper intentionally does not translate
+the wakeup into exceptions; callers use it when they need a best-effort park
+that can be interrupted by close/cancel machinery.
 """
 function wait_canceled!(pd::PollState, mode::PollOp.T)
     pollable(pd) || return nothing
@@ -571,6 +745,9 @@ end
 
 """
 Set both read and write deadlines for `fd`.
+
+`deadline_ns` is interpreted as an absolute `time_ns()`-style monotonic
+timestamp. Use `0` to clear both deadlines.
 """
 function set_deadline!(fd::FD, deadline_ns::Integer)
     _set_deadline_impl!(fd, deadline_ns, PollOp.READWRITE)
@@ -643,6 +820,10 @@ end
 
 """
 Close the descriptor and wait for outstanding non-blocking operations to drain.
+
+Returns `nothing`.
+
+Throws `NetClosingError` or `FileClosingError` if close had already started.
 """
 function close!(fd::FD)
     _fdlock_incref_and_close!(fd.fdlock) || throw(_closing_error(fd.is_file))
@@ -656,6 +837,8 @@ end
 
 """
 Switch an `FD` into blocking mode via `ioctl(FIONBIO, 0)`.
+
+Returns `nothing`.
 """
 function set_blocking!(fd::FD)
     _fd_incref!(fd)

--- a/src/4_tcp.jl
+++ b/src/4_tcp.jl
@@ -2,6 +2,15 @@
     TCP
 
 Core TCP socket operations and connection/listener types.
+
+This layer sits directly above `SocketOps` and `IOPoll`. It is responsible for
+turning raw non-blocking sockets into higher-level connection/listener objects,
+while still keeping the control flow close to Go's `netFD` implementation:
+- sockets are created non-blocking and registered with the poller
+- non-blocking connect completes by waiting for write readiness and then reading
+  `SO_ERROR`
+- accept returns already-initialized child descriptors that are ready for the
+  same poll-driven read/write paths as outbound connections
 """
 module TCP
 
@@ -19,6 +28,10 @@ abstract type SocketAddr end
     SocketAddrV4
 
 IPv4 endpoint snapshot.
+
+The address bytes are stored in presentation order and the port is stored in
+host byte order. Conversion to platform sockaddr structs happens lazily when a
+socket operation actually needs one.
 """
 struct SocketAddrV4 <: SocketAddr
     ip::NTuple{4, UInt8}
@@ -32,7 +45,11 @@ end
 """
     SocketAddrV6
 
-IPv6 endpoint snapshot. `scope_id` is used for scoped link-local addresses.
+IPv6 endpoint snapshot.
+
+`scope_id` is used for scoped link-local addresses and is preserved all the way
+down to the platform sockaddr representation so bind/connect can target the same
+interface the caller selected.
 """
 struct SocketAddrV6 <: SocketAddr
     ip::NTuple{16, UInt8}
@@ -63,14 +80,29 @@ function SocketAddrV6(ip::NTuple{16, <:Integer}, port::Integer; scope_id::Intege
     )
 end
 
+"""
+    loopback_addr(port) -> SocketAddrV4
+
+Convenience constructor for `127.0.0.1:port`.
+"""
 function loopback_addr(port::Integer)::SocketAddrV4
     return SocketAddrV4((UInt8(127), UInt8(0), UInt8(0), UInt8(1)), port)
 end
 
+"""
+    any_addr(port) -> SocketAddrV4
+
+Convenience constructor for `0.0.0.0:port`, typically used for wildcard binds.
+"""
 function any_addr(port::Integer)::SocketAddrV4
     return SocketAddrV4((UInt8(0), UInt8(0), UInt8(0), UInt8(0)), port)
 end
 
+"""
+    loopback_addr6(port; scope_id=0) -> SocketAddrV6
+
+Convenience constructor for `[::1]:port`.
+"""
 function loopback_addr6(port::Integer; scope_id::Integer = 0)::SocketAddrV6
     return SocketAddrV6((
             UInt8(0), UInt8(0), UInt8(0), UInt8(0),
@@ -83,6 +115,11 @@ function loopback_addr6(port::Integer; scope_id::Integer = 0)::SocketAddrV6
     )
 end
 
+"""
+    any_addr6(port; scope_id=0) -> SocketAddrV6
+
+Convenience constructor for the IPv6 wildcard bind address `[::]:port`.
+"""
 function any_addr6(port::Integer; scope_id::Integer = 0)::SocketAddrV6
     return SocketAddrV6((
             UInt8(0), UInt8(0), UInt8(0), UInt8(0),
@@ -123,6 +160,11 @@ end
     FD
 
 Go-style network descriptor owner built on `IOPoll.FD`.
+
+This is the internal object that owns the actual socket. Public callers usually
+interact with `Conn` or `Listener`, but the transport implementation keeps the
+extra metadata here so it can cache local/remote addresses, remember the socket
+family, and share shutdown/close/deadline behavior with the poll layer.
 """
 mutable struct FD
     pfd::IOPoll.FD
@@ -138,6 +180,10 @@ end
     Conn
 
 User-facing connected TCP stream.
+
+Reads and writes are forwarded to `IOPoll`, which means blocking operations are
+actually readiness waits against the shared low-level poller rather than
+thread-per-socket blocking syscalls.
 """
 struct Conn
     fd::FD
@@ -147,6 +193,10 @@ end
     Listener
 
 User-facing passive TCP listener.
+
+Accepted children are returned as `Conn` values whose underlying sockets are
+already non-blocking, poll-registered, and configured with the default TCP
+options Reseau wants.
 """
 struct Listener
     fd::FD
@@ -237,6 +287,10 @@ function _set_remote_addr!(fd::FD)
 end
 
 function _finalize_connected_addrs!(fd::FD, fallback_remote::SocketAddr)
+    # `getpeername` can lag slightly behind the moment the kernel considers a
+    # non-blocking connect complete. We optimistically refresh both ends, but
+    # fall back to the requested remote address when the peer lookup is only
+    # temporarily unavailable.
     _set_local_addr!(fd)
     if fd.raddr === nothing
         try
@@ -281,6 +335,9 @@ function _wait_connect_complete!(
                     throw(ConnectCanceledError())
                 end
                 try
+                    # Windows completes the ConnectEx/IOCP path inside `IOPoll.connect!`.
+                    # Deadline expiry can still be the signal that the higher-level DNS
+                    # race lost, so we translate that case below.
                     IOPoll.connect!(fd.pfd, addrbuf, addrlen)
                 catch err
                     ex = err::Exception
@@ -298,6 +355,9 @@ function _wait_connect_complete!(
                 throw(ConnectCanceledError())
             end
             try
+                # This mirrors Go's non-blocking connect completion path:
+                # wait for writability, then inspect `SO_ERROR` to learn whether
+                # the connection actually succeeded.
                 IOPoll.wait_write!(fd.pfd.pd)
             catch err
                 ex = err::Exception
@@ -343,7 +403,14 @@ end
 """
     open_tcp_fd!(; family=AF_INET)
 
-Open a non-blocking, cloexec TCP socket and wrap it in `FD`.
+Open a non-blocking, close-on-exec TCP socket and wrap it in `FD`.
+
+This is the lowest-level TCP constructor exposed within the package. The
+returned descriptor is not yet registered with `IOPoll`; callers that plan to
+issue readiness-driven operations should call `IOPoll.init!` before use.
+
+Returns an internal `FD` object and throws `SystemError` on socket creation
+failure.
 """
 function open_tcp_fd!(; family::Cint = SocketOps.AF_INET)::FD
     sysfd = SocketOps.open_socket(family, SocketOps.SOCK_STREAM)
@@ -355,6 +422,21 @@ end
 
 Create and connect a non-blocking TCP `FD` using Go-style connect completion:
 wait write-ready, then verify with `SO_ERROR`.
+
+Arguments:
+- `remote_addr`: remote endpoint to connect to
+- `local_addr`: optional source address to bind before connecting
+- `connect_deadline_ns`: absolute monotonic deadline used for the write-wait path
+- `cancel_state`: internal cancellation hook used by parallel dial racing
+
+Returns the connected internal `FD`.
+
+Throws:
+- `ArgumentError` if local/remote address families do not match
+- `SystemError` for socket, bind, connect, or socket-option failures
+- `IOPoll.DeadlineExceededError` if the connect wait times out
+- `ConnectCanceledError` when a higher-level parallel dial path cancels the
+  attempt after another candidate wins
 """
 function connect_tcp_fd!(
         remote_addr::SocketAddr;
@@ -371,6 +453,8 @@ function connect_tcp_fd!(
         if local_addr !== nothing
             SocketOps.bind_socket(fd.pfd.sysfd, _to_sockaddr(local_addr))
         elseif Sys.iswindows()
+            # ConnectEx requires the socket to be bound first, even when the user
+            # did not request a specific local address.
             _bind_connectex_local!(fd, family)
         end
         # Defensive re-assert: keep connect path non-blocking even if platform state drifts.
@@ -435,6 +519,13 @@ end
     listen_tcp_fd!(local_addr; backlog=128, reuseaddr=true)
 
 Create a listening TCP `FD` bound to `local_addr`.
+
+Keyword arguments:
+- `backlog`: listen backlog passed to the kernel
+- `reuseaddr`: whether to enable `SO_REUSEADDR` before binding
+
+Returns an internal listening `FD`. Throws `SystemError` on bind/listen/setup
+failures.
 """
 function listen_tcp_fd!(local_addr::SocketAddr; backlog::Integer = 128, reuseaddr::Bool = true)::FD
     family = _addr_family(local_addr)
@@ -456,6 +547,9 @@ end
     accept_tcp_fd!(listener_fd)
 
 Accept a child TCP connection, retrying transient accept errors with Go parity.
+
+The returned child descriptor is already poll-initialized and has the default
+TCP options applied, so callers can immediately wrap it in `Conn`.
 """
 function accept_tcp_fd!(listener_fd::FD)::FD
     child_sysfd, peer_addr = IOPoll.accept!(listener_fd.pfd, listener_fd.family, listener_fd.sotype)
@@ -483,6 +577,9 @@ end
     connect(remote_addr; local_addr=nothing)
 
 Connect a TCP connection and return `Conn`.
+
+This is the simplest direct-address API. For name resolution, timeouts, local
+bind preferences, or Happy Eyeballs-style racing, use `HostResolvers.connect`.
 """
 function connect(remote_addr::SocketAddr; local_addr::Union{Nothing, SocketAddr} = nothing)::Conn
     return Conn(connect_tcp_fd!(remote_addr; local_addr = local_addr))
@@ -492,6 +589,8 @@ end
     listen(local_addr; backlog=128, reuseaddr=true)
 
 Create a TCP listener from a bound local address.
+
+This is the direct-address equivalent of `HostResolvers.listen`.
 """
 function listen(local_addr::SocketAddr; backlog::Integer = 128, reuseaddr::Bool = true)::Listener
     return Listener(listen_tcp_fd!(local_addr; backlog = backlog, reuseaddr = reuseaddr))
@@ -501,38 +600,80 @@ end
     accept!(listener)
 
 Accept a new `Conn` from `listener`.
+
+Throws `SystemError`, `IOPoll.DeadlineExceededError`, or other poll/transport
+errors if the underlying accept path fails.
 """
 function accept!(listener::Listener)::Conn
     return Conn(accept_tcp_fd!(listener.fd))
 end
 
+"""
+    read!(conn, buf) -> Int
+
+Read up to `length(buf)` bytes into `buf` and return the number of bytes read.
+
+Throws the same errors as `IOPoll.read!`, including deadline and close-related
+exceptions.
+"""
 function Base.read!(conn::Conn, buf::Vector{UInt8})::Int
     return IOPoll.read!(conn.fd.pfd, buf)
 end
 
+"""
+    write(conn, buf) -> Int
+
+Write bytes from `buf` and return the number of bytes written.
+"""
 function Base.write(conn::Conn, buf::Vector{UInt8})::Int
     return IOPoll.write!(conn.fd.pfd, buf)
 end
 
+"""
+    write(conn, buf, nbytes) -> Int
+
+Write the first `nbytes` bytes from `buf` and return the number of bytes
+written.
+"""
 function Base.write(conn::Conn, buf::Memory{UInt8}, nbytes::Integer)::Int
     return IOPoll.write!(conn.fd.pfd, buf, nbytes)
 end
 
+"""
+    close!(conn)
+
+Close the connection. Repeated closes are treated as no-ops.
+"""
 function close!(conn::Conn)
     close!(conn.fd)
     return nothing
 end
 
+"""
+    close!(listener)
+
+Close the listening socket. Repeated closes are treated as no-ops.
+"""
 function close!(listener::Listener)
     close!(listener.fd)
     return nothing
 end
 
+"""
+    close_read!(conn)
+
+Shut down the read side of the TCP connection.
+"""
 function close_read!(conn::Conn)
     SocketOps.shutdown_socket(conn.fd.pfd.sysfd, SocketOps.SHUT_RD)
     return nothing
 end
 
+"""
+    close_write!(conn)
+
+Shut down the write side of the TCP connection.
+"""
 function close_write!(conn::Conn)
     SocketOps.shutdown_socket(conn.fd.pfd.sysfd, SocketOps.SHUT_WR)
     return nothing
@@ -598,6 +739,11 @@ function set_write_deadline!(conn::Conn, deadline_ns::Integer)
     return nothing
 end
 
+"""
+    set_nodelay!(conn, enabled=true)
+
+Enable or disable `TCP_NODELAY` on `conn`.
+"""
 function set_nodelay!(conn::Conn, enabled::Bool = true)
     SocketOps.set_sockopt_int(
         conn.fd.pfd.sysfd,
@@ -608,6 +754,11 @@ function set_nodelay!(conn::Conn, enabled::Bool = true)
     return nothing
 end
 
+"""
+    set_keepalive!(conn, enabled=true)
+
+Enable or disable `SO_KEEPALIVE` on `conn`.
+"""
 function set_keepalive!(conn::Conn, enabled::Bool = true)
     SocketOps.set_sockopt_int(
         conn.fd.pfd.sysfd,
@@ -618,14 +769,29 @@ function set_keepalive!(conn::Conn, enabled::Bool = true)
     return nothing
 end
 
+"""
+    local_addr(conn) -> Union{Nothing, SocketAddr}
+
+Return the cached local endpoint for `conn`, if known.
+"""
 function local_addr(conn::Conn)::Union{Nothing, SocketAddr}
     return conn.fd.laddr
 end
 
+"""
+    remote_addr(conn) -> Union{Nothing, SocketAddr}
+
+Return the cached remote endpoint for `conn`, if known.
+"""
 function remote_addr(conn::Conn)::Union{Nothing, SocketAddr}
     return conn.fd.raddr
 end
 
+"""
+    addr(listener) -> Union{Nothing, SocketAddr}
+
+Return the listener's bound local endpoint, if known.
+"""
 function addr(listener::Listener)::Union{Nothing, SocketAddr}
     return listener.fd.laddr
 end

--- a/src/4_tcp.jl
+++ b/src/4_tcp.jl
@@ -613,8 +613,17 @@ end
 
 Read up to `length(buf)` bytes into `buf` and return the number of bytes read.
 
-Throws the same errors as `IOPoll.read!`, including deadline and close-related
-exceptions.
+Important behavior notes:
+- the result may be smaller than `length(buf)` whenever fewer bytes are
+  presently available on the stream than the caller asked for
+- once at least one byte is read, the call returns immediately instead of
+  waiting to fill the remainder of `buf`
+- if no bytes are currently available, the underlying descriptor waits for read
+  readiness and then retries, subject to any active read deadline
+- `length(buf) == 0` returns `0` immediately
+
+Throws the same errors as `IOPoll.read!`, including `EOFError`,
+`IOPoll.DeadlineExceededError`, and close-related exceptions.
 """
 function Base.read!(conn::Conn, buf::Vector{UInt8})::Int
     return IOPoll.read!(conn.fd.pfd, buf)
@@ -623,7 +632,11 @@ end
 """
     write(conn, buf) -> Int
 
-Write bytes from `buf` and return the number of bytes written.
+Write all bytes from `buf` and return the number of bytes written.
+
+On success, the return value is always `length(buf)`. If the socket cannot
+currently accept data, the call waits for write readiness and resumes until the
+entire buffer has been written or an error/deadline interrupts the operation.
 """
 function Base.write(conn::Conn, buf::Vector{UInt8})::Int
     return IOPoll.write!(conn.fd.pfd, buf)
@@ -634,6 +647,10 @@ end
 
 Write the first `nbytes` bytes from `buf` and return the number of bytes
 written.
+
+On success, the return value is always exactly `nbytes`. Like the `Vector`
+overload, this may block waiting for write readiness between partial kernel
+writes.
 """
 function Base.write(conn::Conn, buf::Memory{UInt8}, nbytes::Integer)::Int
     return IOPoll.write!(conn.fd.pfd, buf, nbytes)

--- a/src/4_tcp.jl
+++ b/src/4_tcp.jl
@@ -18,6 +18,20 @@ using ..Reseau.IOPoll
 using ..Reseau.SocketOps
 
 """
+    connect
+    listen
+
+Primary user-facing TCP entry points.
+
+This file defines the concrete-address methods like `connect(::SocketAddr)` and
+`listen(::SocketAddr)`. String/hostname-based overloads are added later by the
+`HostResolvers` module so callers can still use one unified `TCP.connect` /
+`TCP.listen` surface.
+"""
+function connect end
+function listen end
+
+"""
     SocketAddr
 
 Abstract network endpoint type for TCP socket addresses.
@@ -578,8 +592,9 @@ end
 
 Connect a TCP connection and return `Conn`.
 
-This is the simplest direct-address API. For name resolution, timeouts, local
-bind preferences, or Happy Eyeballs-style racing, use `HostResolvers.connect`.
+This is the simplest direct-address API. For host/port strings, name
+resolution, and timeout-aware connect policy, use the `connect(network,
+address...)` overloads on the same `TCP.connect` generic.
 """
 function connect(remote_addr::SocketAddr; local_addr::Union{Nothing, SocketAddr} = nothing)::Conn
     return Conn(connect_tcp_fd!(remote_addr; local_addr = local_addr))
@@ -590,7 +605,8 @@ end
 
 Create a TCP listener from a bound local address.
 
-This is the direct-address equivalent of `HostResolvers.listen`.
+This is the direct-address equivalent of the `listen(network, address; ...)`
+overloads on the same `TCP.listen` generic.
 """
 function listen(local_addr::SocketAddr; backlog::Integer = 128, reuseaddr::Bool = true)::Listener
     return Listener(listen_tcp_fd!(local_addr; backlog = backlog, reuseaddr = reuseaddr))

--- a/src/5_host_resolvers.jl
+++ b/src/5_host_resolvers.jl
@@ -2,6 +2,14 @@
     HostResolvers
 
 Address parsing, name resolution, and connect/listen orchestration APIs.
+
+This layer is the bridge between string-oriented user input like
+`"example.com:443"` and the lower-level `TCP` primitives that operate on concrete
+socket addresses. The overall shape intentionally follows Go's `net` package:
+- parse and canonicalize host/port strings
+- resolve hostnames according to a resolver policy
+- attempt connections serially or in a Happy Eyeballs-style race
+- wrap failures in an operation-specific error that preserves context
 """
 module HostResolvers
 
@@ -81,6 +89,14 @@ abstract type AbstractResolver end
     ResolverPolicy
 
 Host-resolution filtering and preference policy.
+
+Fields:
+- `prefer_ipv6`: sort mixed-family results so IPv6 candidates come first for the
+  generic `tcp` network
+- `allow_ipv4`: keep IPv4 candidates in the result set
+- `allow_ipv6`: keep IPv6 candidates in the result set
+
+At least one family must remain enabled.
 """
 struct ResolverPolicy
     prefer_ipv6::Bool
@@ -96,7 +112,9 @@ end
 """
     SystemResolver
 
-Resolver backed by the platform name service (native `getaddrinfo`).
+Resolver backed by the platform name service (`getaddrinfo`).
+
+This is the default resolver used by the convenience APIs.
 """
 struct SystemResolver <: AbstractResolver end
 
@@ -104,6 +122,9 @@ struct SystemResolver <: AbstractResolver end
     StaticResolver
 
 Resolver with fixed host/service mappings and optional fallback resolver.
+
+This is useful in tests and controlled environments where you want deterministic
+name/service lookup without consulting the operating system.
 """
 struct StaticResolver <: AbstractResolver
     hosts::Dict{String, Vector{TCP.SocketEndpoint}}
@@ -457,6 +478,8 @@ end
 
 Join host and port into `host:port`, bracket-quoting IPv6 literals.
 `port` may be numeric or an opaque service string.
+
+Returns the combined string and never performs resolution.
 """
 function join_host_port(host::AbstractString, port::AbstractString)::String
     host_s = String(host)
@@ -475,6 +498,8 @@ end
     split_host_port(hostport)
 
 Split `host:port` or `[host]:port` into `(host, port)`.
+
+Throws `AddressError` if the string is malformed.
 """
 function split_host_port(hostport::AbstractString)::Tuple{String, String}
     s = String(hostport)
@@ -525,7 +550,10 @@ end
 """
     parse_port(service)
 
-Parse decimal service port; returns `(port, needs_lookup)`.
+Parse a decimal service port and return `(port, needs_lookup)`.
+
+If `needs_lookup` is `true`, the caller should treat `service` as a symbolic
+service name such as `"https"` and consult the resolver's service tables.
 """
 function parse_port(service::AbstractString)::Tuple{Int, Bool}
     isempty(service) && return 0, false
@@ -579,6 +607,8 @@ end
     lookup_port(network, service)
 
 Resolve numeric or named service into a port number.
+
+This convenience form uses `DEFAULT_RESOLVER`.
 """
 function lookup_port(network::AbstractString, service::AbstractString)::Int
     return lookup_port(DEFAULT_RESOLVER, network, service)
@@ -746,6 +776,21 @@ end
     resolve_tcp_addrs(resolver, network, address; op=:connect, policy=ResolverPolicy())
 
 Resolve a TCP `host:port` string into concrete socket addresses.
+
+Arguments:
+- `resolver`: resolver implementation used for host and service lookup
+- `network`: one of `"tcp"`, `"tcp4"`, or `"tcp6"`
+- `address`: host/port string
+
+Keyword arguments:
+- `op`: context for wildcard handling, typically `:connect`, `:listen`, or
+  `:resolve`
+- `policy`: address-family filtering and ordering policy
+
+Returns a `Vector{TCP.SocketEndpoint}` in the order that subsequent connection
+logic should attempt.
+
+Throws `AddressError` or `UnknownNetworkError` when parsing or resolution fails.
 """
 function resolve_tcp_addrs(
         resolver::AbstractResolver,
@@ -773,6 +818,11 @@ function resolve_tcp_addrs(
     return out
 end
 
+"""
+    resolve_tcp_addrs(network, address) -> Vector{TCP.SocketEndpoint}
+
+Resolve concrete TCP endpoints using `DEFAULT_RESOLVER`.
+"""
 function resolve_tcp_addrs(network::AbstractString, address::AbstractString)::Vector{TCP.SocketEndpoint}
     return resolve_tcp_addrs(DEFAULT_RESOLVER, network, address)
 end
@@ -781,6 +831,9 @@ end
     resolve_tcp_addr(resolver, network, address; policy=ResolverPolicy())
 
 Resolve and return the first preferred TCP endpoint.
+
+This is a convenience wrapper over `resolve_tcp_addrs` that returns only the
+first candidate after policy ordering is applied.
 """
 function resolve_tcp_addr(
         resolver::AbstractResolver,
@@ -792,6 +845,11 @@ function resolve_tcp_addr(
     return addrs[1]
 end
 
+"""
+    resolve_tcp_addr(network, address) -> TCP.SocketEndpoint
+
+Resolve the first preferred endpoint using `DEFAULT_RESOLVER`.
+"""
 function resolve_tcp_addr(network::AbstractString, address::AbstractString)::TCP.SocketEndpoint
     return resolve_tcp_addr(DEFAULT_RESOLVER, network, address)
 end
@@ -799,7 +857,20 @@ end
 """
     HostResolver
 
-Go-like connect configuration for timeout/deadline/local-bind and resolver injection.
+Go-like connect configuration for timeout/deadline/local-bind and resolver
+injection.
+
+Fields:
+- `timeout_ns`: relative timeout budget for the whole resolve+connect operation
+- `deadline_ns`: absolute monotonic deadline for the whole operation
+- `local_addr`: optional local bind address for outbound connects
+- `fallback_delay_ns`: delay before starting the secondary address-family racer;
+  negative disables the parallel race
+- `resolver`: resolver implementation for host/service lookup
+- `policy`: address ordering/filtering policy
+
+The effective deadline is the earlier of `now + timeout_ns` and `deadline_ns`,
+mirroring Go's "minimum non-zero deadline wins" behavior.
 """
 struct HostResolver{R<:AbstractResolver}
     timeout_ns::Int64
@@ -873,6 +944,9 @@ function _resolve_with_deadline(
     done = Ref(false)
     timed_out = Ref(false)
     result_ref = Ref{Union{Nothing, Vector{TCP.SocketEndpoint}, Exception}}(nothing)
+    # Resolution still relies on Julia tasks + Timer rather than the lower-level
+    # poller timer heap. That is acceptable here because DNS resolution is not
+    # currently driven by the socket event loop itself.
     timer = Timer(timeout_s) do _
         lock(mtx)
         try
@@ -922,6 +996,8 @@ function _partial_deadline_ns(now_ns::Int64, deadline_ns::Int64, addrs_remaining
     deadline_ns == 0 && return Int64(0)
     time_remaining = deadline_ns - now_ns
     time_remaining <= 0 && throw(DNSTimeoutError(""))
+    # Like Go's dialer, we avoid spending the entire remaining budget on the
+    # first address candidate when multiple endpoints remain to be tried.
     timeout = time_remaining ÷ addrs_remaining
     sane_min = Int64(2_000_000_000)
     if timeout < sane_min
@@ -1088,6 +1164,9 @@ function _resolve_parallel(
     end
     _start_racer(true, primaries)
     delay_ns = _effective_fallback_delay_ns(d)
+    # This is the Happy Eyeballs-style stagger: start one address family first,
+    # then launch the fallback family if the primary path has not succeeded
+    # quickly enough.
     fallback_timer = Timer(delay_ns / 1.0e9) do _
         _emit_event!(:fallback_timer)
     end
@@ -1153,6 +1232,14 @@ end
     connect(d, network, address)
 
 Connect a TCP connection from a `host:port` string.
+
+This is the main Go-style dialing entry point. It resolves the address, applies
+deadline and policy rules, optionally runs a dual-stack race, and returns a
+connected `TCP.Conn`.
+
+Throws `DNSOpError` on failure. The wrapped `err` may be an `AddressError`,
+`DNSTimeoutError`, `UnknownNetworkError`, `SystemError`, or a lower-level poll
+error depending on which phase failed.
 """
 function connect(d::HostResolver, network::AbstractString, address::AbstractString)::TCP.Conn
     deadline_ns = _connect_deadline_ns(d)
@@ -1192,14 +1279,29 @@ function connect(d::HostResolver, network::AbstractString, address::AbstractStri
     ))
 end
 
+"""
+    connect(network, address) -> TCP.Conn
+
+Connect using a default `HostResolver`.
+"""
 function connect(network::AbstractString, address::AbstractString)::TCP.Conn
     return connect(HostResolver(), network, address)
 end
 
+"""
+    connect(address) -> TCP.Conn
+
+Convenience shorthand for `connect("tcp", address)`.
+"""
 function connect(address::AbstractString)::TCP.Conn
     return connect(HostResolver(), "tcp", address)
 end
 
+"""
+    connect_timeout(network, address, timeout_ns) -> TCP.Conn
+
+Connect using a default `HostResolver` with a relative timeout budget.
+"""
 function connect_timeout(network::AbstractString, address::AbstractString, timeout_ns::Integer)::TCP.Conn
     return connect(HostResolver(; timeout_ns = Int64(timeout_ns)), network, address)
 end
@@ -1208,6 +1310,15 @@ end
     listen(d, network, address; backlog=128, reuseaddr=true)
 
 Listen on a resolved local endpoint.
+
+The address string is resolved into one or more concrete local endpoints. Each
+candidate is tried in order until one bind/listen succeeds.
+
+Keyword arguments:
+- `backlog`: listen backlog passed to the kernel
+- `reuseaddr`: whether to enable `SO_REUSEADDR` on the underlying socket
+
+Throws `DNSOpError` if resolution fails or no candidate can be bound.
 """
 function listen(
         d::HostResolver,
@@ -1243,6 +1354,11 @@ function listen(
     ))
 end
 
+"""
+    listen(network, address; backlog=128, reuseaddr=true) -> TCP.Listener
+
+Listen using a default `HostResolver`.
+"""
 function listen(
         network::AbstractString,
         address::AbstractString;

--- a/src/5_host_resolvers.jl
+++ b/src/5_host_resolvers.jl
@@ -1,7 +1,7 @@
 """
     HostResolvers
 
-Address parsing, name resolution, and connect/listen orchestration APIs.
+Address parsing, name resolution, and TCP string-address helpers.
 
 This layer is the bridge between string-oriented user input like
 `"example.com:443"` and the lower-level `TCP` primitives that operate on concrete
@@ -10,6 +10,10 @@ socket addresses. The overall shape intentionally follows Go's `net` package:
 - resolve hostnames according to a resolver policy
 - attempt connections serially or in a Happy Eyeballs-style race
 - wrap failures in an operation-specific error that preserves context
+
+The public-facing string overloads for `TCP.connect` and `TCP.listen` are
+implemented here so users can stay on the `TCP` surface while the host/service
+resolution logic remains factored into its own file.
 """
 module HostResolvers
 
@@ -17,6 +21,7 @@ using ..Reseau.SocketOps
 using ..Reseau.IOPoll
 
 using ..Reseau.TCP
+import ..Reseau.TCP: connect, listen
 
 """
     AddressError
@@ -1280,30 +1285,30 @@ function connect(d::HostResolver, network::AbstractString, address::AbstractStri
 end
 
 """
-    connect(network, address) -> TCP.Conn
+    connect(network, address; kwargs...) -> TCP.Conn
 
 Connect using a default `HostResolver`.
+
+All keyword arguments are forwarded to `HostResolver(; kwargs...)`, so callers
+can configure `timeout_ns`, `deadline_ns`, `local_addr`, `fallback_delay_ns`,
+`resolver`, and `policy` without explicitly constructing a resolver first.
 """
-function connect(network::AbstractString, address::AbstractString)::TCP.Conn
-    return connect(HostResolver(), network, address)
+function connect(
+        network::AbstractString,
+        address::AbstractString;
+        kwargs...,
+    )::TCP.Conn
+    resolver = isempty(kwargs) ? HostResolver() : HostResolver(; kwargs...)
+    return connect(resolver, network, address)
 end
 
 """
-    connect(address) -> TCP.Conn
+    connect(address; kwargs...) -> TCP.Conn
 
-Convenience shorthand for `connect("tcp", address)`.
+Convenience shorthand for `connect("tcp", address; kwargs...)`.
 """
-function connect(address::AbstractString)::TCP.Conn
-    return connect(HostResolver(), "tcp", address)
-end
-
-"""
-    connect_timeout(network, address, timeout_ns) -> TCP.Conn
-
-Connect using a default `HostResolver` with a relative timeout budget.
-"""
-function connect_timeout(network::AbstractString, address::AbstractString, timeout_ns::Integer)::TCP.Conn
-    return connect(HostResolver(; timeout_ns = Int64(timeout_ns)), network, address)
+function connect(address::AbstractString; kwargs...)::TCP.Conn
+    return connect("tcp", address; kwargs...)
 end
 
 """

--- a/src/6_tls.jl
+++ b/src/6_tls.jl
@@ -1074,7 +1074,17 @@ The return value matches Julia's standard `read!` convention:
 - `0` means EOF
 - positive values report the number of bytes written into `buf`
 
+The result may be smaller than `length(buf)` for the same reasons as plain TCP:
+OpenSSL may already have only part of a TLS record decrypted, the underlying
+socket may currently have less data available than requested, or EOF may arrive
+before the buffer is filled. Once at least one plaintext byte is produced, the
+call returns immediately instead of waiting to fill the rest of `buf`.
+
 The handshake is performed lazily before the first application read.
+
+If no application bytes are currently available, the call waits for whichever
+underlying socket readiness OpenSSL requests (`WANT_READ` or `WANT_WRITE`),
+subject to any active connection deadline.
 
 Throws `TLSError`, `TLSHandshakeTimeoutError`, or transport-layer close/timeout errors
 wrapped as TLS failures.
@@ -1122,6 +1132,11 @@ Write plaintext application bytes through the TLS connection.
 allows callers to cap the write at `nbytes`.
 
 Returns the number of plaintext bytes accepted by OpenSSL.
+
+On success, the return value is always the full requested length. If OpenSSL or
+the underlying transport cannot make progress immediately, the call waits for
+the requested readiness (`WANT_READ`/`WANT_WRITE`) and then resumes until the
+whole payload is written or an error occurs.
 
 Throws `TLSError` on TLS failure. A write timeout becomes a permanent write error for
 the connection, matching Go's behavior that a timed-out TLS write leaves record framing

--- a/src/6_tls.jl
+++ b/src/6_tls.jl
@@ -303,26 +303,6 @@ struct Listener
     config::Config
 end
 
-"""
-    Connector
-
-TLS connector using a `HostResolvers.HostResolver` for the underlying TCP connect.
-
-This bundles dial policy and TLS policy together so repeated outbound connections can
-share both the host-resolution behavior and the immutable `Config`.
-"""
-struct Connector
-    host_resolver::HostResolvers.HostResolver
-    config::Config
-end
-
-function Connector(;
-        host_resolver::HostResolvers.HostResolver = HostResolvers.HostResolver(),
-        config::Config = Config(),
-    )
-    return Connector(host_resolver, config)
-end
-
 @inline function _verify_allow_all_cb(_preverify_ok::Cint, _store_ctx::Ptr{Cvoid})::Cint
     return Cint(1)
 end
@@ -1437,7 +1417,7 @@ Create a TLS listener by first creating a TCP listener and then associating a se
 Accepted `Conn`s are returned in lazy-handshake form.
 
 Throws `ConfigError` if the server config is invalid and propagates any listener creation
-errors from `HostResolvers.listen`.
+errors from `TCP.listen`.
 """
 function listen(
         network::AbstractString,
@@ -1447,7 +1427,7 @@ function listen(
         reuseaddr::Bool = true,
     )::Listener
     _validate_config(config; is_server = true)
-    listener = HostResolvers.listen(network, address; backlog = backlog, reuseaddr = reuseaddr)
+    listener = TCP.listen(network, address; backlog = backlog, reuseaddr = reuseaddr)
     return Listener(listener, config)
 end
 
@@ -1506,29 +1486,15 @@ function _prepare_connect_config(config::Config, address::AbstractString)::Confi
     return _config_with_server_name(config, host)
 end
 
-"""
-    connect_with_resolver(host_resolver, network, address, config=Config()) -> Conn
-
-Dial a TCP connection through `host_resolver`, wrap it in client-side TLS, and complete
-the handshake before returning.
-
-If `config.server_name` is unset, this derives it from `address` when possible so
-certificate verification and SNI behave as expected.
-
-Returns a fully handshaken `Conn`.
-
-Throws `ConfigError`, `TLSHandshakeTimeoutError`, `TLSError`, or any underlying
-connection/resolution exceptions.
-"""
-function connect_with_resolver(
+function _connect(
         host_resolver::HostResolvers.HostResolver,
         network::AbstractString,
         address::AbstractString,
-        config::Config = Config(),
+        config::Config,
     )::Conn
     tls_config = _prepare_connect_config(config, address)
     connect_deadline_ns = HostResolvers._connect_deadline_ns(host_resolver)
-    tcp = HostResolvers.connect(host_resolver, network, address)
+    tcp = TCP.connect(host_resolver, network, address)
     tls_conn = nothing
     try
         tls_conn = client(tcp, tls_config)
@@ -1554,22 +1520,57 @@ function connect_with_resolver(
 end
 
 """
-    connect(connector, network, address) -> Conn
+    connect(network, address; kwargs...) -> Conn
 
-Connect using the `HostResolver` and `Config` bundled in `connector`.
+Connect to `address`, negotiate TLS, and return a fully handshaken client
+connection.
+
+Host-resolution keyword arguments are forwarded to `HostResolvers.HostResolver`:
+- `timeout_ns`
+- `deadline_ns`
+- `local_addr`
+- `fallback_delay_ns`
+- `resolver`
+- `policy`
+
+TLS keyword arguments are forwarded to `Config`:
+- `server_name`
+- `verify_peer`
+- `client_auth`
+- `cert_file`
+- `key_file`
+- `ca_file`
+- `client_ca_file`
+- `alpn_protocols`
+- `handshake_timeout_ns`
+- `min_version`
+- `max_version`
+
+If `server_name` is omitted, it is derived from `address` when possible so SNI
+and peer verification behave like Go's client defaults.
 """
-function connect(connector::Connector, network::AbstractString, address::AbstractString)::Conn
-    return connect_with_resolver(connector.host_resolver, network, address, connector.config)
+function connect(
+        network::AbstractString,
+        address::AbstractString;
+        timeout_ns::Integer = Int64(0),
+        deadline_ns::Integer = Int64(0),
+        local_addr::Union{Nothing, TCP.SocketEndpoint} = nothing,
+        fallback_delay_ns::Integer = Int64(300_000_000),
+        resolver::HostResolvers.AbstractResolver = HostResolvers.DEFAULT_RESOLVER,
+        policy::HostResolvers.ResolverPolicy = HostResolvers.ResolverPolicy(),
+        kw...
+    )::Conn
+    host_resolver = HostResolvers.HostResolver(; timeout_ns, deadline_ns, local_addr, fallback_delay_ns, resolver, policy)
+    return _connect(host_resolver, network, address, Config(; kw...))
 end
 
 """
-    connect(network, address, config=Config()) -> Conn
+    connect(address; kwargs...) -> Conn
 
-Convenience wrapper that connects with the default `HostResolver` and returns a fully
-handshaken client TLS connection.
+Convenience shorthand for `connect("tcp", address; kwargs...)`.
 """
-function connect(network::AbstractString, address::AbstractString, config::Config = Config())::Conn
-    return connect_with_resolver(HostResolvers.HostResolver(), network, address, config)
+function connect(address::AbstractString; kwargs...)::Conn
+    return connect("tcp", address; kwargs...)
 end
 
 end

--- a/src/6_tls.jl
+++ b/src/6_tls.jl
@@ -2,6 +2,12 @@
     TLS
 
 TLS client/server layer built on OpenSSL and `TCP` connections.
+
+The design intentionally tracks the shape of Go's `crypto/tls` package:
+- `Config` is an immutable policy object that can be shared across connections
+- `Conn` lazily completes the handshake on first I/O unless `handshake!` is called eagerly
+- deadline handling is delegated to the underlying transport so TLS retries follow the
+  same timeout model as plain TCP
 """
 module TLS
 
@@ -62,6 +68,9 @@ end
     ConfigError
 
 Raised when TLS configuration is invalid.
+
+This is thrown before any network I/O starts, typically while normalizing a `Config`
+or constructing an `SSL_CTX`.
 """
 struct ConfigError <: Exception
     message::String
@@ -71,6 +80,11 @@ end
     TLSError
 
 Raised when TLS handshake/read/write/close operations fail.
+
+`code` is usually an OpenSSL `SSL_get_error` result, though wrapper paths may set it to
+`0` when the failure is higher-level than one OpenSSL call. `cause` preserves the
+underlying Julia-side exception when the failure originated in the transport/poller
+layer instead of OpenSSL itself.
 """
 struct TLSError <: Exception
     op::String
@@ -83,6 +97,9 @@ end
     TLSHandshakeTimeoutError
 
 Raised when handshake exceeds the configured timeout.
+
+This is kept separate from `TLSError` because handshake timeouts are often configured
+and handled distinctly from generic TLS failures.
 """
 struct TLSHandshakeTimeoutError <: Exception
     timeout_ns::Int64
@@ -114,6 +131,27 @@ end
     Config(; ...)
 
 Go-style TLS configuration for client/server TLS sessions.
+
+Keyword arguments:
+- `server_name`: hostname or IP literal used for certificate verification. For clients,
+  this also drives SNI when it is a hostname. If omitted, `connect` will try to derive
+  it from the dial target.
+- `verify_peer`: whether to validate the remote certificate chain and peer name.
+- `client_auth`: server-side client certificate policy.
+- `cert_file` / `key_file`: PEM-encoded certificate chain and private key. Servers must
+  provide both; clients may provide both for mutual TLS.
+- `ca_file`: PEM bundle used to verify remote servers. When omitted, the platform/OpenSSL
+  defaults are used when possible.
+- `client_ca_file`: PEM bundle used by servers to verify client certificates.
+- `alpn_protocols`: ordered ALPN protocol preference list.
+- `handshake_timeout_ns`: optional cap, in monotonic nanoseconds, applied only while the
+  handshake is running. Existing transport deadlines still win if they are earlier.
+- `min_version` / `max_version`: TLS protocol version bounds. `nothing` leaves the bound
+  unset.
+
+Returns a reusable immutable `Config`.
+
+Throws `ConfigError` if the keyword combination is internally inconsistent.
 """
 struct Config
     server_name::Union{Nothing, String}
@@ -165,6 +203,8 @@ function Config(;
         min_version::Union{Nothing, UInt16} = TLS1_2_VERSION,
         max_version::Union{Nothing, UInt16} = nothing,
     )
+    # Normalize to owned `String` storage so shared configs do not depend on caller-owned
+    # string buffers or views.
     server_name_s = server_name === nothing ? nothing : String(server_name)
     cert_file_s = cert_file === nothing ? nothing : String(cert_file)
     key_file_s = key_file === nothing ? nothing : String(key_file)
@@ -214,6 +254,11 @@ end
     ConnectionState
 
 Snapshot of negotiated TLS connection state.
+
+Fields:
+- `handshake_complete`: whether the TLS handshake has finished successfully.
+- `version`: negotiated TLS protocol version string as reported by OpenSSL.
+- `alpn_protocol`: negotiated ALPN protocol, or `nothing` if ALPN was not used.
 """
 struct ConnectionState
     handshake_complete::Bool
@@ -225,6 +270,11 @@ end
     Conn
 
 TLS stream wrapper over one `TCP.Conn`.
+
+`Conn` is safe for one concurrent reader and one concurrent writer, mirroring the
+underlying TCP transport and Go's `tls.Conn`. Handshake, read, and write all have
+separate locks so lazy handshakes and shutdown can coordinate without corrupting the
+OpenSSL state machine.
 """
 mutable struct Conn
     tcp::TCP.Conn
@@ -244,6 +294,9 @@ end
     Listener
 
 TLS listener wrapper over `TCP.Listener`.
+
+Accepted connections are wrapped in server-side TLS state but are not handshaken until
+`handshake!` or the first read/write call.
 """
 struct Listener
     listener::TCP.Listener
@@ -254,6 +307,9 @@ end
     Connector
 
 TLS connector using a `HostResolvers.HostResolver` for the underlying TCP connect.
+
+This bundles dial policy and TLS policy together so repeated outbound connections can
+share both the host-resolution behavior and the immutable `Config`.
 """
 struct Connector
     host_resolver::HostResolvers.HostResolver
@@ -279,6 +335,9 @@ function _ssl_alpn_select_cb(
         inlen::Cuint,
         arg::Ptr{Cvoid},
     )::Cint
+    # OpenSSL stores the callback argument as an opaque pointer. We root the actual Julia
+    # object in `_CTX_SERVER_ALPN`, then recover it here so the ALPN preference bytes stay
+    # alive for as long as the shared `SSL_CTX` remains cached.
     arg == C_NULL && return _SSL_TLSEXT_ERR_NOACK
     data = unsafe_pointer_to_objref(arg)::_ALPNServerData
     wire = data.wire
@@ -303,6 +362,9 @@ function _ssl_alpn_select_cb(
 end
 
 function __init__()
+    # Module initialization is also where we discover which OpenSSL entry points exist on
+    # the linked library. Some version-bounding APIs are absent on older builds, so later
+    # config code falls back to `SSL_OP_NO_*` masks when needed.
     _ = @ccall gc_safe = true _LIBSSL.OPENSSL_init_ssl(
         Culong(0)::Culong,
         C_NULL::Ptr{Cvoid},
@@ -359,6 +421,8 @@ end
 end
 
 function _apply_client_server_name!(ssl::Ptr{Cvoid}, config::Config)
+    # Match Go's client behavior: SNI is sent only for hostnames, while peer verification
+    # still supports both DNS names and IP literals.
     config.server_name === nothing && return nothing
     configured = config.server_name::String
     verify_name = _verify_name(configured)
@@ -468,6 +532,8 @@ function _encode_alpn_protocols(protocols::Vector{String})::Vector{UInt8}
 end
 
 function _validate_config(config::Config; is_server::Bool)
+    # Keep validation centralized so callers can rely on `Config` being cheap to construct
+    # while the expensive filesystem/OpenSSL checks happen only when a context is needed.
     has_cert = config.cert_file !== nothing
     has_key = config.key_file !== nothing
     has_cert == has_key || throw(ConfigError("both `cert_file` and `key_file` must be set together"))
@@ -594,6 +660,9 @@ function _set_ctx_max_version!(ctx::Ptr{Cvoid}, version::UInt16)
 end
 
 function _ssl_ctx_new(config::Config; is_server::Bool)::Ptr{Cvoid}
+    # `SSL_CTX` is the expensive, shareable part of OpenSSL configuration. We mirror Go's
+    # preference for immutable shared config objects by fully configuring the context up
+    # front, then reusing it across many live `Conn`s.
     _validate_config(config; is_server = is_server)
     method = ccall((:TLS_method, _LIBSSL), Ptr{Cvoid}, ())
     method == C_NULL && throw(_make_tls_error("TLS_method", Int32(0)))
@@ -610,6 +679,8 @@ function _ssl_ctx_new(config::Config; is_server::Bool)::Ptr{Cvoid}
         else
             C_NULL
         end
+        # Verification mode lives on the context so every connection built from it starts
+        # with the same authentication policy.
         ccall((:SSL_CTX_set_verify, _LIBSSL), Cvoid, (Ptr{Cvoid}, Cint, Ptr{Cvoid}), ctx, verify_mode, verify_cb)
         if config.min_version !== nothing
             _set_ctx_min_version!(ctx, config.min_version::UInt16)
@@ -658,6 +729,8 @@ function _ssl_ctx_new(config::Config; is_server::Bool)::Ptr{Cvoid}
                 cb = _ALPN_SELECT_CB[]
                 cb == C_NULL && throw(ConfigError("ALPN select callback is not initialized"))
                 alpn_data = _ALPNServerData(_encode_alpn_protocols(config.alpn_protocols))
+                # The callback receives an opaque pointer, so cache the Julia owner next to
+                # the shared context to keep the ALPN wire bytes rooted.
                 ccall(
                     (:SSL_CTX_set_alpn_select_cb, _LIBSSL),
                     Cvoid,
@@ -728,6 +801,9 @@ end
 end
 
 function _shared_ssl_ctx(config::Config; is_server::Bool)::Ptr{Cvoid}
+    # Context reuse matters for throughput-oriented clients/servers because parsing PEM
+    # files, loading CA bundles, and allocating OpenSSL tables per connection would be
+    # needlessly expensive.
     key = _ssl_context_key(config; is_server = is_server)
     lock(_CTX_CACHE_LOCK)
     try
@@ -744,6 +820,8 @@ function _shared_ssl_ctx(config::Config; is_server::Bool)::Ptr{Cvoid}
 end
 
 function _ssl_new(ctx::Ptr{Cvoid}, tcp::TCP.Conn, config::Config; is_server::Bool)::Ptr{Cvoid}
+    # `SSL_new` creates the per-connection state machine. The shared `SSL_CTX` contributes
+    # configuration; the resulting `SSL*` binds that policy to one live socket.
     ssl = ccall((:SSL_new, _LIBSSL), Ptr{Cvoid}, (Ptr{Cvoid},), ctx)
     ssl == C_NULL && throw(_make_tls_error("SSL_new", Int32(0)))
     try
@@ -768,10 +846,28 @@ function _new_conn(tcp::TCP.Conn, config::Config; is_server::Bool)::Conn
     return Conn(tcp, ctx, ssl, is_server, config, ReentrantLock(), ReentrantLock(), ReentrantLock(), false, false, nothing)
 end
 
+"""
+    client(tcp, config) -> Conn
+
+Wrap an established `TCP.Conn` in client-side TLS state.
+
+The handshake is deferred until `handshake!` or the first read/write operation.
+
+Throws `ConfigError` or `TLSError` if the TLS state cannot be initialized.
+"""
 function client(tcp::TCP.Conn, config::Config)::Conn
     return _new_conn(tcp, config; is_server = false)
 end
 
+"""
+    server(tcp, config) -> Conn
+
+Wrap an established `TCP.Conn` in server-side TLS state.
+
+The handshake is deferred until `handshake!` or the first read/write operation.
+
+Throws `ConfigError` or `TLSError` if the TLS state cannot be initialized.
+"""
 function server(tcp::TCP.Conn, config::Config)::Conn
     return _new_conn(tcp, config; is_server = true)
 end
@@ -818,6 +914,8 @@ function _ensure_open!(conn::Conn, op::AbstractString)
 end
 
 function _wait_ssl_ready!(conn::Conn, ssl_err::Cint, op::AbstractString)
+    # OpenSSL's nonblocking contract is the same basic model Go's tls.Conn builds on:
+    # retry the operation after the underlying socket becomes readable or writable.
     if ssl_err == _SSL_ERROR_WANT_READ
         IOPoll.wait_read!(conn.tcp.fd.pfd.pd)
         return true
@@ -847,6 +945,9 @@ end
 end
 
 function _with_handshake_deadline(f::F, conn::Conn) where {F}
+    # Go overlays handshake timeouts onto the transport deadline rather than inventing a
+    # separate timer path. We do the same by temporarily tightening the read/write
+    # deadlines on the underlying poll descriptor, then restoring the prior values.
     timeout_ns = conn.config.handshake_timeout_ns
     if timeout_ns <= 0
         return f()
@@ -875,6 +976,9 @@ function _with_handshake_deadline(f::F, conn::Conn) where {F}
 end
 
 function _with_temporary_deadline_cap(f::F, conn::Conn, deadline_ns::Int64) where {F}
+    # Used when the outer dial path already computed an overall connect deadline. TLS
+    # should respect that cap during the initial handshake without permanently mutating
+    # the caller's long-lived socket deadlines.
     deadline_ns == 0 && return f()
     pfd = conn.tcp.fd.pfd
     pd = pfd.pd
@@ -898,6 +1002,21 @@ function _with_temporary_deadline_cap(f::F, conn::Conn, deadline_ns::Int64) wher
     end
 end
 
+"""
+    handshake!(conn)
+
+Run the TLS handshake to completion if it has not already finished.
+
+This method is idempotent. Concurrent callers serialize through `handshake_lock`, so
+only one task drives OpenSSL while the others observe the completed state afterward.
+
+Returns `nothing`.
+
+Throws:
+- `TLSHandshakeTimeoutError` when `config.handshake_timeout_ns` expires
+- `TLSError` for OpenSSL or transport failures
+- `EOFError` if the peer closes cleanly during the handshake
+"""
 function handshake!(conn::Conn)
     _ensure_open!(conn, "handshake")
     _handshake_complete(conn) && return nothing
@@ -946,6 +1065,20 @@ end
     return nothing
 end
 
+"""
+    read!(conn, buf) -> Int
+
+Read decrypted application data into `buf`.
+
+The return value matches Julia's standard `read!` convention:
+- `0` means EOF
+- positive values report the number of bytes written into `buf`
+
+The handshake is performed lazily before the first application read.
+
+Throws `TLSError`, `TLSHandshakeTimeoutError`, or transport-layer close/timeout errors
+wrapped as TLS failures.
+"""
 function Base.read!(conn::Conn, buf::Vector{UInt8})::Int
     length(buf) == 0 && return 0
     _ensure_open!(conn, "read")
@@ -979,6 +1112,21 @@ function Base.read!(conn::Conn, buf::Vector{UInt8})::Int
     end
 end
 
+"""
+    write(conn, buf) -> Int
+    write(conn, buf, nbytes) -> Int
+
+Write plaintext application bytes through the TLS connection.
+
+`write(conn, buf)` attempts to write the entire buffer. The `Memory{UInt8}` overload
+allows callers to cap the write at `nbytes`.
+
+Returns the number of plaintext bytes accepted by OpenSSL.
+
+Throws `TLSError` on TLS failure. A write timeout becomes a permanent write error for
+the connection, matching Go's behavior that a timed-out TLS write leaves record framing
+state ambiguous for future writes.
+"""
 function Base.write(conn::Conn, buf::Vector{UInt8})::Int
     return _write!(conn, buf, length(buf))
 end
@@ -1038,6 +1186,9 @@ function _write!(conn::Conn, buf, nbytes::Integer)::Int
 end
 
 function _ssl_shutdown!(conn::Conn)
+    # `SSL_shutdown` may need multiple rounds because a close-notify alert can require
+    # additional socket readiness before OpenSSL considers the shutdown complete. We cap
+    # the write side so close does not hang forever on an unresponsive peer.
     try
         TCP.set_write_deadline!(conn.tcp, Int64(time_ns()) + Int64(5_000_000_000))
     catch
@@ -1081,6 +1232,14 @@ end
     return nothing
 end
 
+"""
+    close!(conn)
+
+Close the TLS connection and the underlying TCP transport.
+
+If the handshake completed, this best-effort sends a TLS `close_notify` alert before
+closing the socket. The method is idempotent and returns `nothing`.
+"""
 function close!(conn::Conn)
     _mark_closed!(conn) || return nothing
     if _handshake_complete(conn) && conn.ssl != C_NULL
@@ -1111,6 +1270,18 @@ function close!(conn::Conn)
     return nothing
 end
 
+"""
+    close_write!(conn)
+
+Send TLS shutdown on the write side and mark future writes as permanently failed.
+
+This is the TLS analogue of half-closing a TCP socket. It requires the handshake to
+have completed because the TLS close-notify alert is itself a TLS record.
+
+Returns `nothing`.
+
+Throws `TLSError` if the TLS shutdown path fails.
+"""
 function close_write!(conn::Conn)
     _ensure_open!(conn, "close_write")
     _handshake_complete(conn) || throw(TLSError("close_write", Int32(0), "close_write before handshake complete", nothing))
@@ -1137,29 +1308,68 @@ function Base.close(conn::Conn)
     return nothing
 end
 
+"""
+    set_deadline!(conn, deadline_ns)
+
+Set both read and write deadlines on the underlying transport.
+
+`deadline_ns` is interpreted using the same monotonic-clock convention as `TCP` and
+`IOPoll`: `0` clears the deadline, negative values mean the deadline has already
+expired, and positive values are absolute `time_ns()` values.
+"""
 function set_deadline!(conn::Conn, deadline_ns::Integer)
     TCP.set_deadline!(conn.tcp, deadline_ns)
     return nothing
 end
 
+"""
+    set_read_deadline!(conn, deadline_ns)
+
+Set the read deadline on the underlying transport. See `set_deadline!` for the timestamp
+convention.
+"""
 function set_read_deadline!(conn::Conn, deadline_ns::Integer)
     TCP.set_read_deadline!(conn.tcp, deadline_ns)
     return nothing
 end
 
+"""
+    set_write_deadline!(conn, deadline_ns)
+
+Set the write deadline on the underlying transport. See `set_deadline!` for the
+timestamp convention.
+"""
 function set_write_deadline!(conn::Conn, deadline_ns::Integer)
     TCP.set_write_deadline!(conn.tcp, deadline_ns)
     return nothing
 end
 
+"""
+    local_addr(conn)
+
+Return the local `TCP.SocketAddr` for the wrapped transport.
+"""
 function local_addr(conn::Conn)
     return TCP.local_addr(conn.tcp)
 end
 
+"""
+    remote_addr(conn)
+
+Return the remote `TCP.SocketAddr` for the wrapped transport.
+"""
 function remote_addr(conn::Conn)
     return TCP.remote_addr(conn.tcp)
 end
 
+"""
+    net_conn(conn) -> TCP.Conn
+
+Expose the underlying TCP connection.
+
+This mirrors Go's `(*tls.Conn).NetConn()` idea: callers that need transport-level
+inspection can reach through the TLS wrapper without reconstructing the socket state.
+"""
 function net_conn(conn::Conn)::TCP.Conn
     return conn.tcp
 end
@@ -1187,6 +1397,14 @@ function _ssl_alpn_protocol(conn::Conn)::Union{Nothing, String}
     return unsafe_string(Ptr{Cchar}(data), len)
 end
 
+"""
+    connection_state(conn) -> ConnectionState
+
+Return a snapshot of the currently negotiated TLS state.
+
+This does not force a handshake; if the handshake has not yet run, the returned
+`ConnectionState` reports `handshake_complete=false`.
+"""
 function connection_state(conn::Conn)::ConnectionState
     return ConnectionState(
         _handshake_complete(conn),
@@ -1195,6 +1413,17 @@ function connection_state(conn::Conn)::ConnectionState
     )
 end
 
+"""
+    listen(network, address, config; backlog=128, reuseaddr=true) -> Listener
+
+Create a TLS listener by first creating a TCP listener and then associating a server
+`Config` with accepted connections.
+
+Accepted `Conn`s are returned in lazy-handshake form.
+
+Throws `ConfigError` if the server config is invalid and propagates any listener creation
+errors from `HostResolvers.listen`.
+"""
 function listen(
         network::AbstractString,
         address::AbstractString,
@@ -1207,11 +1436,23 @@ function listen(
     return Listener(listener, config)
 end
 
+"""
+    accept!(listener) -> Conn
+
+Accept one inbound TCP connection and wrap it in server-side TLS state.
+
+The returned `Conn` has not handshaken yet.
+"""
 function accept!(listener::Listener)::Conn
     tcp = TCP.accept!(listener.listener)
     return server(tcp, listener.config)
 end
 
+"""
+    close!(listener)
+
+Close the underlying TCP listener. Returns `nothing`.
+"""
 function close!(listener::Listener)
     TCP.close!(listener.listener)
     return nothing
@@ -1222,11 +1463,18 @@ function Base.close(listener::Listener)
     return nothing
 end
 
+"""
+    addr(listener)
+
+Return the local listening address for the wrapped TCP listener.
+"""
 function addr(listener::Listener)
     return TCP.addr(listener.listener)
 end
 
 function _prepare_connect_config(config::Config, address::AbstractString)::Config
+    # Match the ergonomic Go behavior where client TLS verification can infer the peer
+    # name from the dial target unless the caller explicitly overrides it.
     if config.server_name !== nothing
         return config
     end
@@ -1243,6 +1491,20 @@ function _prepare_connect_config(config::Config, address::AbstractString)::Confi
     return _config_with_server_name(config, host)
 end
 
+"""
+    connect_with_resolver(host_resolver, network, address, config=Config()) -> Conn
+
+Dial a TCP connection through `host_resolver`, wrap it in client-side TLS, and complete
+the handshake before returning.
+
+If `config.server_name` is unset, this derives it from `address` when possible so
+certificate verification and SNI behave as expected.
+
+Returns a fully handshaken `Conn`.
+
+Throws `ConfigError`, `TLSHandshakeTimeoutError`, `TLSError`, or any underlying
+connection/resolution exceptions.
+"""
 function connect_with_resolver(
         host_resolver::HostResolvers.HostResolver,
         network::AbstractString,
@@ -1276,10 +1538,21 @@ function connect_with_resolver(
     end
 end
 
+"""
+    connect(connector, network, address) -> Conn
+
+Connect using the `HostResolver` and `Config` bundled in `connector`.
+"""
 function connect(connector::Connector, network::AbstractString, address::AbstractString)::Conn
     return connect_with_resolver(connector.host_resolver, network, address, connector.config)
 end
 
+"""
+    connect(network, address, config=Config()) -> Conn
+
+Convenience wrapper that connects with the default `HostResolver` and returns a fully
+handshaken client TLS connection.
+"""
 function connect(network::AbstractString, address::AbstractString, config::Config = Config())::Conn
     return connect_with_resolver(HostResolvers.HostResolver(), network, address, config)
 end

--- a/src/70_http_core.jl
+++ b/src/70_http_core.jl
@@ -28,22 +28,46 @@ export cancel!
 export canceled
 export expired
 
-"""Raised for malformed HTTP syntax during parsing."""
+"""
+    ParseError
+
+Raised when byte-level HTTP syntax cannot be parsed. This is used for malformed
+request/status lines, invalid header syntax, truncated framed bodies, and other
+wire-format failures where the peer did not send valid HTTP.
+"""
 struct ParseError <: Exception
     message::String
 end
 
-"""Raised for semantic HTTP protocol violations."""
+"""
+    ProtocolError
+
+Raised when the bytes are syntactically valid but violate higher-level HTTP
+rules. Examples include mismatched `Content-Length` values, impossible frame
+ordering, or unsupported control-flow states in the client/server stacks.
+"""
 struct ProtocolError <: Exception
     message::String
 end
 
-"""Raised when request processing is explicitly canceled."""
+"""
+    CanceledError
+
+Raised when request processing is canceled explicitly through `RequestContext`.
+Unlike `ParseError` and `ProtocolError`, this usually reflects local control
+flow rather than a bad peer.
+"""
 struct CanceledError <: Exception
     message::String
 end
 
-"""Raised when a timeout/deadline expires for an HTTP operation."""
+"""
+    HTTPTimeoutError
+
+Raised when an HTTP-layer deadline expires. This is intentionally separate from
+lower-level socket timeout exceptions so higher layers can distinguish "request
+context expired" from transport-specific readiness or handshake failures.
+"""
 struct HTTPTimeoutError <: Exception
     operation::String
     timeout_ns::Int64
@@ -119,9 +143,16 @@ const _COMMON_CANONICAL_HEADER_KEYS = let headers = (
 end
 
 """
-    canonical_header_key(key)
+    canonical_header_key(key) -> String
 
-Canonicalize header keys using Go-like MIME canonicalization rules.
+Canonicalize a header field name using the same "MIME canonical form" used by
+Go's `textproto.CanonicalMIMEHeaderKey`: the first character and every
+character after `-` is uppercased; other ASCII letters are lowercased.
+
+Returns a newly owned `String` unless `key` is already in canonical form, in
+which case a cached common-header string may be reused. This function does not
+validate that `key` is a legal HTTP token; callers are still responsible for
+protocol validation where needed.
 """
 function canonical_header_key(key::AbstractString)::String
     isempty(key) && return ""
@@ -165,18 +196,31 @@ end
     Headers
 
 Ordered, case-canonicalized HTTP header map.
+
+`Headers` deliberately preserves insertion order for keys while storing one
+vector of values per canonicalized name. That mirrors the parts of Go's
+`http.Header` behavior that are useful to higher layers:
+- key lookups are case-insensitive after canonicalization
+- repeated headers preserve value order
+- header iteration is stable and reflects the original append/replace pattern
 """
 mutable struct Headers
     order::Vector{String}
     values::Dict{String, Vector{String}}
 end
 
-"""Create an empty ordered header collection."""
+"""Create and return an empty `Headers` collection."""
 function Headers()
     return Headers(String[], Dict{String, Vector{String}}())
 end
 
-"""Create an empty ordered header collection with preallocation hint."""
+"""
+    Headers(hint)
+
+Create an empty `Headers` collection and use `hint` as a preallocation hint for
+both the key-order vector and backing dictionary. Throws `ArgumentError` when
+`hint < 0`.
+"""
 function Headers(hint::Integer)
     hint < 0 && throw(ArgumentError("hint must be >= 0"))
     order = String[]
@@ -186,7 +230,13 @@ function Headers(hint::Integer)
     return Headers(order, values)
 end
 
-"""Deep copy constructor for header collections."""
+"""
+    Headers(headers)
+
+Deep-copy constructor for header collections. Both the ordered key list and
+every value vector are copied, so mutating the result does not affect the
+source.
+"""
 function Headers(headers::Headers)
     copied = Dict{String, Vector{String}}()
     for key in headers.order
@@ -213,18 +263,23 @@ function Base.empty!(headers::Headers)
     return headers
 end
 
-"""Return header keys in insertion order."""
+"""Return a newly allocated `Vector{String}` of header keys in insertion order."""
 function header_keys(headers::Headers)::Vector{String}
     return copy(headers.order)
 end
 
-"""Check whether a header key exists."""
+"""Return `true` when `headers` contains at least one value for `key`."""
 function has_header(headers::Headers, key::AbstractString)::Bool
     canon = canonical_header_key(key)
     return haskey(headers.values, canon)
 end
 
-"""Return all values for a header key."""
+"""
+    get_headers(headers, key) -> Vector{String}
+
+Return a freshly allocated vector containing all values for `key` in stored
+order. Returns `String[]` when the header is absent.
+"""
 function get_headers(headers::Headers, key::AbstractString)::Vector{String}
     canon = canonical_header_key(key)
     values = get(() -> nothing, headers.values, canon)
@@ -232,7 +287,7 @@ function get_headers(headers::Headers, key::AbstractString)::Vector{String}
     return copy(values::Vector{String})
 end
 
-"""Return first header value for a key, or `nothing`."""
+"""Return the first value for `key`, or `nothing` if the header is absent."""
 function get_header(headers::Headers, key::AbstractString)::Union{Nothing, String}
     canon = canonical_header_key(key)
     values = get(() -> nothing, headers.values, canon)
@@ -241,7 +296,13 @@ function get_header(headers::Headers, key::AbstractString)::Union{Nothing, Strin
     return values[1]
 end
 
-"""Replace header key with a single value."""
+"""
+    set_header!(headers, key, value) -> Headers
+
+Replace all existing values for `key` with a single `value`, preserving the
+original key position if the key already exists and appending it otherwise.
+Returns the mutated `headers`.
+"""
 function set_header!(headers::Headers, key::AbstractString, value::AbstractString)
     canon = canonical_header_key(key)
     if haskey(headers.values, canon)
@@ -253,7 +314,7 @@ function set_header!(headers::Headers, key::AbstractString, value::AbstractStrin
     return headers
 end
 
-"""Append one value for a header key."""
+"""Append one additional value for `key` and return the mutated `headers`."""
 function add_header!(headers::Headers, key::AbstractString, value::AbstractString)
     canon = canonical_header_key(key)
     values = get(() -> nothing, headers.values, canon)
@@ -266,7 +327,7 @@ function add_header!(headers::Headers, key::AbstractString, value::AbstractStrin
     return headers
 end
 
-"""Delete a header key and all associated values."""
+"""Delete `key` and all associated values, then return the mutated `headers`."""
 function delete_header!(headers::Headers, key::AbstractString)
     canon = canonical_header_key(key)
     haskey(headers.values, canon) || return headers
@@ -310,10 +371,14 @@ end
 end
 
 """
-    has_header_token(headers, key, token)
+    has_header_token(headers, key, token) -> Bool
 
-Return `true` when a comma-separated header value contains `token`
-case-insensitively (e.g. `Connection: close`).
+Return `true` when a comma-separated header field contains `token`
+case-insensitively after trimming optional whitespace.
+
+This is the helper used for semantics like `Connection: close` and
+`Transfer-Encoding: chunked`, where RFCs define one header line as a list of
+tokens rather than one opaque string.
 """
 function has_header_token(headers::Headers, key::AbstractString, token::AbstractString)::Bool
     needle = _ascii_lowercase_string(_trim_http_ows(token))
@@ -349,7 +414,15 @@ end
 """
     RequestContext(; deadline_ns=0)
 
-Per-request cancellation and deadline metadata.
+Per-request cancellation and deadline metadata shared across the HTTP client and
+server layers.
+
+Arguments:
+- `deadline_ns`: absolute monotonic deadline in nanoseconds, or `0` to disable
+  deadline tracking.
+
+The context itself does not schedule timers; it is a passive state container
+that transport code consults before or during blocking operations.
 """
 mutable struct RequestContext
     deadline_ns::Int64
@@ -357,64 +430,106 @@ mutable struct RequestContext
     cancel_message::Union{Nothing, String}
 end
 
-"""Create a request context with optional absolute deadline (ns)."""
+"""Construct a `RequestContext`; throws `ArgumentError` when `deadline_ns < 0`."""
 function RequestContext(; deadline_ns::Integer = Int64(0))
     deadline_ns < 0 && throw(ArgumentError("deadline_ns must be >= 0"))
     return RequestContext(Int64(deadline_ns), false, nothing)
 end
 
-"""Set absolute deadline timestamp in nanoseconds."""
+"""
+    set_deadline!(ctx, deadline_ns) -> RequestContext
+
+Set an absolute monotonic deadline in nanoseconds. Passing `0` clears any
+deadline. Throws `ArgumentError` when `deadline_ns < 0`.
+"""
 function set_deadline!(ctx::RequestContext, deadline_ns::Integer)
     deadline_ns < 0 && throw(ArgumentError("deadline_ns must be >= 0"))
     ctx.deadline_ns = Int64(deadline_ns)
     return ctx
 end
 
-"""Mark context canceled with an optional message."""
+"""
+    cancel!(ctx; message="request canceled") -> RequestContext
+
+Mark `ctx` canceled and store a human-readable message for higher layers. This
+does not throw on its own; callers typically check `canceled(ctx)` or turn the
+state into a `CanceledError`.
+"""
 function cancel!(ctx::RequestContext; message::AbstractString = "request canceled")
     @atomic :release ctx.canceled_flag = true
     ctx.cancel_message = String(message)
     return ctx
 end
 
-"""Return whether context has been canceled."""
+"""Return `true` once `cancel!` has been called for `ctx`."""
 function canceled(ctx::RequestContext)::Bool
     return @atomic :acquire ctx.canceled_flag
 end
 
-"""Return whether context deadline has passed."""
+"""
+    expired(ctx, now_ns=time_ns()) -> Bool
+
+Return `true` when `ctx.deadline_ns` is non-zero and less than or equal to
+`now_ns`. `now_ns` is injectable so tests and higher-level schedulers can reuse
+an already-sampled monotonic timestamp.
+"""
 function expired(ctx::RequestContext, now_ns::Integer = time_ns())::Bool
     deadline = ctx.deadline_ns
     deadline <= 0 && return false
     return Int64(now_ns) >= deadline
 end
 
+"""
+    AbstractBody
+
+Abstract streaming body interface used throughout the HTTP stack.
+
+Concrete subtypes are expected to implement:
+- `body_read!(body, dst)::Int`
+- `body_close!(body)`
+- `body_closed(body)::Bool`
+
+`body_read!` must return the number of bytes written into `dst`, with `0`
+signaling EOF. Implementations may throw transport-specific exceptions.
+"""
 abstract type AbstractBody end
 
-"""Empty body implementation."""
+"""Zero-length body that immediately reports EOF and ignores close requests."""
 struct EmptyBody <: AbstractBody
 end
 
-"""In-memory byte-backed body implementation."""
+"""
+    BytesBody(data)
+
+Simple in-memory body backed by a copied `Vector{UInt8}`. Reads advance an
+internal cursor until EOF; closing marks the body closed but does not free or
+truncate the stored bytes.
+"""
 mutable struct BytesBody <: AbstractBody
     data::Vector{UInt8}
     next_index::Int
     @atomic closed::Bool
 end
 
-"""Create a byte body from a vector-like input."""
+"""Copy `data` into a new `BytesBody` and reset the read cursor to the start."""
 function BytesBody(data::AbstractVector{UInt8})
     return BytesBody(copy(data), 1, false)
 end
 
-"""Callback-driven streaming body implementation."""
+"""
+    CallbackBody(read_cb, close_cb)
+
+Callback-driven streaming body. `read_cb(dst)` must return the number of bytes
+written into `dst`, and `close_cb()` is invoked once when the body is closed.
+This is the escape hatch for non-buffered request or response bodies.
+"""
 mutable struct CallbackBody{R, C} <: AbstractBody
     read_cb::R
     close_cb::C
     @atomic closed::Bool
 end
 
-"""Create a callback body from read and close callbacks."""
+"""Construct a `CallbackBody` from read and close callbacks."""
 function CallbackBody(read_cb::R, close_cb::C) where {R, C}
     return CallbackBody{R, C}(read_cb, close_cb, false)
 end
@@ -431,7 +546,14 @@ function body_closed(body::CallbackBody)::Bool
     return @atomic :acquire body.closed
 end
 
-"""Generic body read API (returns bytes read, `0` on EOF)."""
+"""
+    body_read!(body, dst) -> Int
+
+Read up to `length(dst)` bytes into `dst`. Returns `0` on EOF.
+
+Concrete body types may throw `ProtocolError`, transport errors, or body-
+specific exceptions if the stream is malformed or the backing connection fails.
+"""
 function body_read!(::EmptyBody, dst::Vector{UInt8})::Int
     _ = dst
     return 0
@@ -456,7 +578,12 @@ function body_read!(body::CallbackBody, dst::Vector{UInt8})::Int
     return n
 end
 
-"""Generic body close API."""
+"""
+    body_close!(body)
+
+Release any resources held by `body`. Implementations should be idempotent so
+callers can safely close in `finally` blocks.
+"""
 function body_close!(::EmptyBody)
     return nothing
 end
@@ -475,9 +602,24 @@ function body_close!(body::CallbackBody)
 end
 
 """
-    Request(method, target; ...)
+    Request(method, target; headers=Headers(), trailers=Headers(), body=EmptyBody(), host=nothing,
+            content_length=-1, proto_major=1, proto_minor=1, close=false,
+            context=RequestContext())
 
-HTTP request object used across client and server stacks.
+HTTP request object shared by the client and server stacks.
+
+Keyword arguments:
+- `headers`, `trailers`: copied into the request.
+- `body`: any `AbstractBody`; ownership stays with the request.
+- `host`: optional authority used for HTTP/1 `Host` and HTTP/2 `:authority`.
+- `content_length`: exact byte length, or `-1` when unknown.
+- `proto_major`, `proto_minor`: protocol version metadata.
+- `close`: request/connection-close hint.
+- `context`: cancellation/deadline metadata consulted by higher layers.
+
+Returns a new `Request{B}` where `B` is the concrete body type. Throws
+`ArgumentError` for invalid protocol numbers, empty method/target, or
+`content_length < -1`.
 """
 mutable struct Request{B <: AbstractBody}
     method::String
@@ -493,7 +635,6 @@ mutable struct Request{B <: AbstractBody}
     context::RequestContext
 end
 
-"""Construct a `Request` with validated metadata and copied headers."""
 function Request(
         method::AbstractString,
         target::AbstractString;
@@ -529,9 +670,18 @@ function Request(
 end
 
 """
-    Response(status_code; ...)
+    Response(status_code; reason="", headers=Headers(), trailers=Headers(), body=EmptyBody(),
+             content_length=-1, proto_major=1, proto_minor=1, close=false,
+             request=nothing)
 
-HTTP response object used across client and server stacks.
+HTTP response object shared by the client and server stacks.
+
+Keyword arguments mirror `Request` closely. `request` optionally links the
+response back to the originating request, which is especially useful in client
+redirect flows and server handler pipelines.
+
+Returns a new `Response{B}` where `B` is the concrete body type. Throws
+`ArgumentError` for invalid status or protocol metadata.
 """
 mutable struct Response{B <: AbstractBody}
     status_code::Int
@@ -546,7 +696,6 @@ mutable struct Response{B <: AbstractBody}
     request::Union{Nothing, Request}
 end
 
-"""Construct a `Response` with validated metadata and copied headers."""
 function Response(
         status_code::Integer;
         reason::AbstractString = "",

--- a/src/71_http1.jl
+++ b/src/71_http1.jl
@@ -15,6 +15,9 @@ const _HTTP1_DEFAULT_MAX_HEADER_BYTES = 1 * 1024 * 1024
     FixedLengthBody
 
 HTTP/1 body reader for a known `Content-Length`.
+
+Reads are bounded strictly by `remaining`; once the counter reaches zero the
+body reports EOF even if more bytes are available on the underlying stream.
 """
 mutable struct FixedLengthBody{I <: IO} <: AbstractBody
     io::I
@@ -26,6 +29,10 @@ end
     ChunkedBody
 
 HTTP/1 body reader for `Transfer-Encoding: chunked`.
+
+This reader owns the chunk parser state. It lazily advances from chunk-size
+line to chunk payload to trailing CRLF, and after the terminal zero-sized chunk
+it parses trailer headers into `trailers`.
 """
 mutable struct ChunkedBody{I <: IO} <: AbstractBody
     io::I
@@ -42,6 +49,9 @@ end
 
 HTTP/1 body reader that consumes until EOF (typically response bodies without
 length/chunk framing on non-keepalive connections).
+
+Because EOF is the framing signal, these bodies generally imply that the
+connection cannot be safely reused afterwards.
 """
 mutable struct EOFBody{I <: IO} <: AbstractBody
     io::I
@@ -62,6 +72,10 @@ end
     ChunkedBody(io; max_line_bytes=..., max_header_bytes=...)
 
 Create a chunked body reader with parser limits.
+
+Throws `ArgumentError` when either limit is non-positive. The returned reader
+converts malformed chunk syntax and trailer overflows into `ParseError` or
+`ProtocolError`.
 """
 function ChunkedBody(io::I; max_line_bytes::Integer = _HTTP1_DEFAULT_MAX_LINE_BYTES, max_header_bytes::Integer = _HTTP1_DEFAULT_MAX_HEADER_BYTES) where {I <: IO}
     max_line_bytes <= 0 && throw(ArgumentError("max_line_bytes must be > 0"))
@@ -108,7 +122,11 @@ end
 """
     trailers(body)
 
-Return parsed trailer headers for a chunked body; empty headers for other body types.
+Return parsed trailer headers for a chunked body; empty headers for other body
+types.
+
+The returned `Headers` object is copied so callers can inspect or mutate it
+without racing the body reader.
 """
 function trailers(body::ChunkedBody)::Headers
     return copy(body.trailers)
@@ -263,6 +281,9 @@ end
 
 function _read_next_chunk!(body::ChunkedBody)
     body.done && return nothing
+    # Chunked framing is a tiny state machine: parse the next size line, switch
+    # into payload-reading mode, and after a zero-sized chunk parse trailers
+    # instead of more body bytes.
     line = _readline_crlf(body.io, body.max_line_bytes)
     size = _parse_chunk_size(line)
     if size == 0
@@ -464,6 +485,15 @@ end
     write_request!(io, request)
 
 Serialize an HTTP/1 request to `io`, including body framing.
+
+Behavior:
+- injects `Host` from `request.host` when missing
+- normalizes connection-close signaling
+- chooses between `Content-Length` and chunked transfer-coding
+- serializes trailers only for chunked bodies
+
+Returns `nothing`. May throw `ProtocolError` for inconsistent framing or
+propagate exceptions from `io` and the request body.
 """
 function write_request!(io::IO, request::Request{B}) where {B <: AbstractBody}
     headers = copy(request.headers)
@@ -502,6 +532,10 @@ end
     write_response!(io, response)
 
 Serialize an HTTP/1 response to `io`, including body framing.
+
+Body suppression rules for status codes like `1xx`, `204`, and `304` are
+enforced here so callers can hand the function a regular `Response` object and
+let the serializer apply wire-level HTTP/1 rules.
 """
 function write_response!(io::IO, response::Response{B}) where {B <: AbstractBody}
     headers = copy(response.headers)
@@ -635,6 +669,16 @@ end
     read_request(io; max_line_bytes=..., max_header_bytes=...)
 
 Parse one HTTP/1 request from `io`.
+
+Returns a `Request` whose body is one of `EmptyBody`, `FixedLengthBody`, or
+`ChunkedBody` depending on the incoming framing headers.
+
+Throws:
+- `ArgumentError` for invalid parser limits
+- `ParseError` for malformed syntax or truncated framed bodies
+- `ProtocolError` for invalid semantic combinations such as conflicting length
+  metadata
+- any exception propagated by the underlying `IO`
 """
 function read_request(io::IO; max_line_bytes::Integer = _HTTP1_DEFAULT_MAX_LINE_BYTES, max_header_bytes::Integer = _HTTP1_DEFAULT_MAX_HEADER_BYTES)
     line = _readline_crlf(io, max_line_bytes)
@@ -696,6 +740,10 @@ end
 
 Parse one HTTP/1 response from `io`.
 `request` is optional but allows HEAD/no-body response handling parity.
+
+Returns a `Response` whose body is one of `EmptyBody`, `FixedLengthBody`,
+`ChunkedBody`, or `EOFBody` depending on the status code and framing headers.
+Exception behavior mirrors `read_request`.
 """
 function read_response(
         io::IO,

--- a/src/72_hpack.jl
+++ b/src/72_hpack.jl
@@ -11,6 +11,12 @@ export set_max_dynamic_table_size!
     HeaderField
 
 One HPACK header field entry.
+
+Fields:
+- `name`: lower-level header name exactly as encoded/decoded
+- `value`: header value
+- `sensitive`: when `true`, the encoder avoids dynamic-table indexing so the
+  value is not retained in compression state
 """
 struct HeaderField
     name::String
@@ -28,6 +34,10 @@ end
     DynamicTable(max_size=4096)
 
 Mutable HPACK dynamic table for recently indexed header fields.
+
+The table follows RFC 7541's size accounting rules (`32 + |name| + |value|` per
+entry) and evicts from the end when the size limit is lowered or new indexed
+entries would overflow capacity.
 """
 mutable struct DynamicTable
     entries::Vector{DynamicTableEntry}
@@ -38,7 +48,11 @@ end
 """
     Encoder(; max_table_size=4096)
 
-Stateful HPACK encoder that tracks dynamic table updates.
+Stateful HPACK encoder that tracks peer-visible dynamic table updates.
+
+Like Go's HPACK encoder, this object is stateful: successive calls to
+`encode_header_block` reuse the same dynamic table and may emit table-size
+update instructions before the next header block.
 """
 mutable struct Encoder
     table::DynamicTable
@@ -50,7 +64,8 @@ end
 """
     Decoder(; max_table_size=4096)
 
-Stateful HPACK decoder that tracks peer dynamic table state.
+Stateful HPACK decoder that tracks peer dynamic table state across header
+blocks.
 """
 mutable struct Decoder
     table::DynamicTable
@@ -714,7 +729,9 @@ end
 function _encode_string!(out::Vector{UInt8}, value::String)
     raw_len = ncodeunits(value)
     huff_len = _huffman_encoded_length(value)
-    # Same policy as Go: use Huffman only when encoded payload is strictly smaller.
+    # Match Go's HPACK policy: Huffman is only chosen when it produces a
+    # strictly smaller payload. This keeps encode/decode behavior predictable
+    # and avoids paying the CPU cost for ties.
     if huff_len < raw_len
         _encode_integer!(out, huff_len, 7, 0x80)
         _append_huffman_string!(out, value)
@@ -816,12 +833,20 @@ end
 """
     encode_header_block(encoder, headers)
 
-Encode HPACK header fields into a header block fragment.
+Encode HPACK header fields into one HPACK header block fragment.
+
+The returned `Vector{UInt8}` is suitable for a single HEADERS/CONTINUATION
+fragment sequence. The encoder's dynamic table may be mutated as a side effect.
+Throws `ArgumentError` for invalid sizing inputs and `ProtocolError` if an
+indexed lookup becomes inconsistent.
 """
 function encode_header_block(encoder::Encoder, headers::Vector{HeaderField})::Vector{UInt8}
     out = UInt8[]
     _emit_table_size_updates!(out, encoder)
     for header in headers
+        # Prefer the most compact representation available, in the same order
+        # Go's HPACK encoder reasons about it: exact indexed match, indexed-name
+        # literal with optional insertion, then literal new-name forms.
         exact = _find_exact_index(encoder.table, header.name, header.value)
         if exact > 0
             _encode_indexed!(out, exact)
@@ -866,7 +891,11 @@ end
 """
     decode_header_block(decoder, block)
 
-Decode an HPACK header block fragment into header fields.
+Decode one HPACK header block fragment into a `Vector{HeaderField}`.
+
+The decoder's dynamic table is updated as encoded instructions are processed.
+Throws `ParseError` for malformed integer/string encodings and `ProtocolError`
+for invalid indexing semantics.
 """
 function decode_header_block(decoder::Decoder, block::Vector{UInt8})::Vector{HeaderField}
     headers = HeaderField[]

--- a/src/73_http2.jl
+++ b/src/73_http2.jl
@@ -137,6 +137,10 @@ end
     Framer(io; max_frame_size=16384)
 
 Frame reader/writer for an `IO` stream.
+
+`Framer` is intentionally low-level: it deals only with HTTP/2 frame boundaries
+and per-frame validation, not stream state machines or HPACK. Higher layers are
+responsible for enforcing sequencing rules such as CONTINUATION ownership.
 """
 mutable struct Framer{I <: IO}
     io::I
@@ -147,6 +151,10 @@ end
     Framer(io; max_frame_size=16384)
 
 Construct an HTTP/2 framer with the configured frame-size limit.
+
+`max_frame_size` is the receive/send safety limit enforced by this local
+framer, not necessarily the peer's advertised SETTINGS value. Throws
+`ArgumentError` unless the size is within RFC 7540's legal range.
 """
 function Framer(io::I; max_frame_size::Integer = 16_384) where {I <: IO}
     max_frame_size >= 16_384 || throw(ArgumentError("HTTP/2 max_frame_size must be >= 16384"))
@@ -229,11 +237,21 @@ end
     read_frame!(framer)
 
 Read and decode one HTTP/2 frame from `framer.io`.
+
+Returns a concrete `AbstractFrame` subtype.
+
+Throws:
+- `ParseError` for malformed wire payloads
+- `ProtocolError` for locally enforced invariants such as frame-size overflow
+- `EOFError` or other I/O exceptions from the underlying stream
 """
 function read_frame!(framer::Framer)::AbstractFrame
     header = _read_frame_header!(framer.io)
     header.length <= framer.max_frame_size || throw(ProtocolError("HTTP/2 frame exceeds max_frame_size"))
     payload = _read_exact_bytes!(framer.io, header.length)
+    # This function intentionally validates only frame-local invariants. Stream-
+    # level rules such as "HEADERS must precede DATA" live in the client/server
+    # state machines above the framer.
     if header.type == FRAME_DATA
         return DataFrame(header.stream_id, (header.flags & FLAG_END_STREAM) != 0, payload)
     end
@@ -375,6 +393,10 @@ end
     write_frame!(framer, frame)
 
 Serialize and write one HTTP/2 frame to `framer.io`.
+
+Returns `nothing`. Throws `ProtocolError` or `ArgumentError` for frames that
+cannot be represented legally, plus any exception raised by the underlying
+`IO`.
 """
 function write_frame!(framer::Framer, frame::AbstractFrame)
     header, payload = _serialize_frame(frame)

--- a/src/74_http2_client.jl
+++ b/src/74_http2_client.jl
@@ -10,6 +10,12 @@ using ..Reseau.IOPoll
 
 const _H2_PREFACE = collect(codeunits("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"))
 
+"""
+    H2NegotiationError
+
+Raised when the connection transport succeeds but cannot be used for HTTP/2,
+most notably when TLS ALPN negotiates a protocol other than `h2`.
+"""
 struct H2NegotiationError <: Exception
     message::String
 end
@@ -22,7 +28,11 @@ end
 """
     H2StreamState
 
-Per-stream response assembly state owned by the HTTP/2 client read loop.
+Per-stream response assembly state owned by the shared HTTP/2 client read loop.
+
+Each active stream has exactly one `H2StreamState`. The read loop appends
+header fragments and DATA payloads here, while the response body reader drains
+them and returns HTTP/2 flow-control credits back to the peer.
 """
 mutable struct H2StreamState
     stream_id::UInt32
@@ -58,7 +68,12 @@ end
 """
     H2Connection
 
-Stateful HTTP/2 client connection with HPACK encoder/decoder state.
+Stateful HTTP/2 client connection with HPACK codec state, stream registry, and
+connection-level flow-control bookkeeping.
+
+One `H2Connection` multiplexes many logical requests over a single TCP or TLS
+transport. A dedicated background read task owns frame intake, similar in spirit
+to Go's separation between connection reader state and per-stream consumers.
 """
 mutable struct H2Connection{F <: Framer}
     address::String
@@ -86,6 +101,10 @@ end
     H2Body
 
 Streaming HTTP/2 response body backed by per-stream read-loop buffers.
+
+Reading from `H2Body` drains the buffered DATA bytes accumulated by the read
+loop, and each successful read sends WINDOW_UPDATE frames so the peer can keep
+transmitting.
 """
 mutable struct H2Body{C <: H2Connection} <: AbstractBody
     conn::C
@@ -144,6 +163,8 @@ function _reserve_send_window!(conn::H2Connection, stream_id::UInt32, wanted::In
             conn.conn_error === nothing || throw(conn.conn_error::Exception)
             stream_window = get(() -> Int64(0), conn.stream_send_window, stream_id)
             if stream_window <= 0 || conn.conn_send_window <= 0
+                # Both the connection-level and per-stream windows must allow
+                # progress. The read loop replenishes these via WINDOW_UPDATE.
                 wait(conn.window_condition)
                 continue
             end
@@ -386,6 +407,8 @@ function _send_window_updates!(conn::H2Connection, stream_id::UInt32, nbytes::In
 end
 
 function _process_incoming_frame!(conn::H2Connection, frame::AbstractFrame)
+    # Frame-local validation already happened in `read_frame!`; this function is
+    # responsible for connection- and stream-level state transitions.
     if frame isa SettingsFrame
         settings = frame::SettingsFrame
         if !settings.ack
@@ -537,7 +560,17 @@ end
 """
     connect_h2!(address; secure=false, host_resolver=HostResolver(), tls_config=nothing)
 
-Open and initialize an HTTP/2 client connection, including SETTINGS exchange.
+Open and initialize an HTTP/2 client connection, including client preface,
+SETTINGS exchange, optional TLS handshake, and ALPN verification.
+
+Keyword arguments:
+- `secure`: when `true`, connect over TLS and require ALPN `h2`
+- `host_resolver`: resolver/dialer used for the underlying TCP connection
+- `tls_config`: optional TLS configuration, augmented as needed to advertise `h2`
+
+Returns a ready-to-use `H2Connection`. Throws `H2NegotiationError` for ALPN
+failures, `ProtocolError` for invalid peer behavior during setup, and any TCP,
+TLS, or I/O exceptions from the underlying transport.
 """
 function connect_h2!(
         address::AbstractString;
@@ -604,6 +637,10 @@ end
     close(conn::H2Connection)
 
 Close the HTTP/2 connection and underlying transport.
+
+All active streams are failed, buffered readers are awakened, and the
+background read loop is given a chance to exit. The function is idempotent and
+returns `nothing`.
 """
 function Base.close(conn::H2Connection)
     stream_states = H2StreamState[]
@@ -698,7 +735,14 @@ end
 """
     h2_roundtrip!(conn, request)
 
-Send one request on `conn` and read the matching response stream.
+Send one request on `conn` and return the matching HTTP/2 `Response`.
+
+The returned response body is either:
+- `EmptyBody` when the peer completed the stream without DATA payload
+- `H2Body` when the response body must be streamed incrementally
+
+This function may throw `ProtocolError`, `ParseError`, `H2NegotiationError`,
+transport exceptions, or any stream-level error synthesized by the read loop.
 """
 @inline function _stream_available_bytes(state::H2StreamState)::Int
     available = (length(state.body) - state.body_read_index) + 1

--- a/src/74_http2_client.jl
+++ b/src/74_http2_client.jl
@@ -578,7 +578,7 @@ function connect_h2!(
         host_resolver::HostResolvers.HostResolver = HostResolvers.HostResolver(),
         tls_config::Union{Nothing, TLS.Config} = nothing,
     )::H2Connection
-    tcp = HostResolvers.connect(host_resolver, "tcp", address)
+    tcp = TCP.connect(host_resolver, "tcp", address)
     tls_conn = nothing
     try
         stream_reader = nothing

--- a/src/75_http2_server.jl
+++ b/src/75_http2_server.jl
@@ -8,6 +8,16 @@ using ..Reseau.TCP
 using ..Reseau.HostResolvers
 using ..Reseau.IOPoll
 
+"""
+    H2Server
+
+Minimal HTTP/2 server wrapper around a TCP listener and request handler.
+
+The current implementation keeps the concurrency model intentionally simple:
+one connection task reads frames, aggregates a full request per stream, and then
+invokes the handler. That is enough for parity-focused testing even though it is
+not yet a fully general production scheduler.
+"""
 mutable struct H2Server{F}
     network::String
     address::String
@@ -24,6 +34,14 @@ end
     H2Server(; network="tcp", address="127.0.0.1:0", handler)
 
 Create an HTTP/2 server configured with a request handler.
+
+Arguments:
+- `network`: transport network passed to `HostResolvers.listen`
+- `address`: bind address, typically `host:port`
+- `handler`: function taking `Request` and returning `Response`
+
+Returns a new `H2Server`. Handler validation is deferred until requests are
+served.
 """
 function H2Server(; network::AbstractString = "tcp", address::AbstractString = "127.0.0.1:0", handler)
     return H2Server{typeof(handler)}(
@@ -47,6 +65,8 @@ end
     h2_server_addr(server)
 
 Return the bound `host:port` after the server starts listening.
+
+Throws `ProtocolError` if the server has not started listening yet.
 """
 function h2_server_addr(server::H2Server)::String
     lock(server.lock)
@@ -213,8 +233,10 @@ function _serve_h2_conn!(server::H2Server, conn::TCP.Conn)
         client_settings isa SettingsFrame || throw(ProtocolError("expected initial h2 SETTINGS frame"))
         _write_frame_h2_server!(conn, SettingsFrame(false, Pair{UInt16, UInt32}[]))
         _write_frame_h2_server!(conn, SettingsFrame(true, Pair{UInt16, UInt32}[]))
-        # Simple per-stream aggregation: collect HEADERS/CONTINUATION and DATA until
-        # both header and body sides complete, then dispatch to the handler.
+        # The server keeps a deliberately simple stream model for now: collect
+        # HEADERS/CONTINUATION fragments and DATA bytes until the full request
+        # is available, then dispatch once. That keeps the implementation easy
+        # to reason about while the lower-level protocol pieces settle.
         headers_block = Dict{UInt32, Vector{UInt8}}()
         body_block = Dict{UInt32, Vector{UInt8}}()
         headers_done = Dict{UInt32, Bool}()
@@ -346,6 +368,9 @@ end
     start_h2_server!(server)
 
 Start accepting HTTP/2 connections on a background task.
+
+Returns the spawned listener `Task`. The server's effective bound address can
+be queried afterwards with `h2_server_addr`.
 """
 function start_h2_server!(server::H2Server)::Task
     listener = HostResolvers.listen(server.network, server.address; backlog = 128)
@@ -374,7 +399,13 @@ end
 """
     shutdown_h2_server!(server; force=true)
 
-Stop listener accept loop and optionally close active connections.
+Stop the listener accept loop and optionally close active connections.
+
+Arguments:
+- `force`: when `true`, immediately closes all currently tracked connections
+
+Returns `nothing`. Shutdown is best-effort; close failures are suppressed so the
+server can continue unwinding other resources.
 """
 function shutdown_h2_server!(server::H2Server; force::Bool = true)
     @atomic :release server.shutting_down = true

--- a/src/75_http2_server.jl
+++ b/src/75_http2_server.jl
@@ -36,7 +36,7 @@ end
 Create an HTTP/2 server configured with a request handler.
 
 Arguments:
-- `network`: transport network passed to `HostResolvers.listen`
+- `network`: transport network passed to `TCP.listen`
 - `address`: bind address, typically `host:port`
 - `handler`: function taking `Request` and returning `Response`
 
@@ -373,7 +373,7 @@ Returns the spawned listener `Task`. The server's effective bound address can
 be queried afterwards with `h2_server_addr`.
 """
 function start_h2_server!(server::H2Server)::Task
-    listener = HostResolvers.listen(server.network, server.address; backlog = 128)
+    listener = TCP.listen(server.network, server.address; backlog = 128)
     lock(server.lock)
     try
         server.listener = listener

--- a/src/76_http_client.jl
+++ b/src/76_http_client.jl
@@ -228,7 +228,7 @@ function _effective_tls_config(transport::Transport, address::String, server_nam
 end
 
 function _new_conn!(transport::Transport, key::String, address::String; secure::Bool, server_name::Union{Nothing, String})::ClientConn
-    tcp = HostResolvers.connect(transport.host_resolver, "tcp", address)
+    tcp = TCP.connect(transport.host_resolver, "tcp", address)
     if secure
         cfg = _effective_tls_config(transport, address, server_name)
         tls = TLS.client(tcp, cfg)

--- a/src/76_http_client.jl
+++ b/src/76_http_client.jl
@@ -20,6 +20,16 @@ mutable struct _ConnReader{C} <: IO
     stop::Int
 end
 
+"""
+    _ConnReader(conn; buffer_bytes=16*1024)
+
+Buffered `IO` adapter layered over `TCP.Conn` or `TLS.Conn`.
+
+HTTP/1 parsing wants a byte-oriented reader with a small amount of lookahead so
+it can parse lines and then continue reading bodies from the same transport.
+This type provides that without forcing the transport types themselves to own
+HTTP-specific buffering policy.
+"""
 function _ConnReader(conn::C; buffer_bytes::Integer = _CONN_READER_DEFAULT_BUFFER_BYTES) where {C}
     buffer_bytes > 0 || throw(ArgumentError("buffer_bytes must be > 0"))
     return _ConnReader{C}(conn, Vector{UInt8}(undef, Int(buffer_bytes)), 1, 0)
@@ -64,6 +74,13 @@ end
 
 const _ClientConnReader = Union{_ConnReader{TCP.Conn}, _ConnReader{TLS.Conn}}
 
+"""
+    ClientConn
+
+Internal pooled HTTP/1 connection record. It bundles the underlying transport,
+the parser's `_ConnReader`, a reusable request serialization buffer, and a few
+small pieces of pooling metadata such as `reused` and `last_used_ns`.
+"""
 mutable struct ClientConn
     key::String
     address::String
@@ -81,6 +98,10 @@ end
     Transport(; ...)
 
 Connection-pooling transport for HTTP/1 requests.
+
+This is the closest analogue to Go's `http.Transport` in the current codebase.
+It owns dial/TLS policy and decides when an idle connection can be reused versus
+closed.
 """
 mutable struct Transport
     host_resolver::HostResolvers.HostResolver
@@ -99,6 +120,11 @@ end
 
 Response body wrapper that returns/tears down pooled connections once the body
 is fully consumed or closed.
+
+If the caller drains the body to EOF, `ManagedBody` returns the underlying
+connection to the idle pool when it is safe to do so. If the body is abandoned
+early or an error occurs, the connection is closed instead so the next request
+does not observe leftover bytes.
 """
 mutable struct ManagedBody{B <: AbstractBody} <: AbstractBody
     inner::B
@@ -287,6 +313,12 @@ function _put_idle_conn!(transport::Transport, conn::ClientConn)
     return nothing
 end
 
+"""
+    close_idle_connections!(transport)
+
+Close and discard all currently idle pooled connections. Active in-flight
+requests are unaffected. Returns `nothing`.
+"""
 function close_idle_connections!(transport::Transport)
     lock(transport.lock)
     try
@@ -303,6 +335,12 @@ function close_idle_connections!(transport::Transport)
     return nothing
 end
 
+"""
+    close(transport)
+
+Close `transport` and eagerly drop every idle connection it owns. In-flight
+requests are allowed to finish on the connections they already hold.
+"""
 function Base.close(transport::Transport)
     _transport_closed(transport) && return nothing
     @atomic :release transport.closed = true
@@ -314,6 +352,9 @@ end
     idle_connection_count(transport; key=nothing)
 
 Return idle pooled connection count globally or for one host key.
+
+When `key === nothing`, returns the transport-wide count. Otherwise `key`
+should match the transport's internal pool key such as `https://example.com:443`.
 """
 function idle_connection_count(transport::Transport; key::Union{Nothing, AbstractString} = nothing)::Int
     lock(transport.lock)
@@ -495,6 +536,13 @@ end
     roundtrip!(transport, address, request; secure=false, server_name=nothing)
 
 Execute one HTTP/1 request/response exchange through `transport`.
+
+This is the low-level HTTP/1 path used by the higher-level client APIs. It
+returns a `Response`, potentially wrapping the body in `ManagedBody` so the
+connection can be recycled when the caller finishes consuming it.
+
+Throws parser, protocol, transport, TLS, and timeout exceptions depending on
+where the exchange fails.
 """
 function roundtrip!(
         transport::Transport,
@@ -528,6 +576,9 @@ function roundtrip!(
             n == request_bytes || throw(ProtocolError("transport short write"))
             reader = conn.reader
             raw_response = read_response(reader, current_request)
+            # HTTP/1 informational responses are consumed internally so callers
+            # observe the final non-1xx response, matching the behavior of Go's
+            # client transport.
             while (raw_response.status_code >= 100 && raw_response.status_code < 200) && raw_response.status_code != 101
                 try
                     body_close!(raw_response.body)
@@ -593,6 +644,9 @@ abstract type AbstractCookieJar end
     Cookie
 
 Minimal in-memory cookie representation used by `MemoryCookieJar`.
+
+Only the subset of attributes the current client uses is modeled here: name,
+value, path, and whether the cookie requires a secure transport.
 """
 struct Cookie
     name::String
@@ -605,6 +659,10 @@ end
     MemoryCookieJar()
 
 Simple host-keyed cookie jar for client redirect/session flows.
+
+This is intentionally small and conservative. It stores cookies per host, uses
+prefix path matching, and ignores advanced attributes such as expiry, domain
+wildcards, and SameSite.
 """
 mutable struct MemoryCookieJar <: AbstractCookieJar
     lock::ReentrantLock
@@ -615,6 +673,10 @@ end
     ClientTrace(; ...)
 
 Optional callback hooks for client request lifecycle events.
+
+Each field may be `nothing` or a callback function. Callbacks are invoked
+synchronously from the request path, so they should stay lightweight and may
+throw to abort a request.
 """
 struct ClientTrace
     on_get_conn::Union{Nothing, Function}
@@ -626,7 +688,17 @@ end
 """
     Client(; ...)
 
-High-level HTTP client with transport pooling, redirect policy, cookies, and optional HTTP/2.
+High-level HTTP client with transport pooling, redirect policy, cookies, and
+optional HTTP/2.
+
+Keyword arguments:
+- `transport`: lower-level HTTP/1 transport/pool implementation
+- `check_redirect`: optional callback deciding whether a redirect should be
+  followed
+- `jar`: cookie jar implementation, or `nothing` to disable cookies
+- `max_redirects`: maximum redirect hops before failing
+- `trace`: optional lifecycle callback bundle
+- `prefer_http2`: whether secure requests should try HTTP/2 when available
 """
 mutable struct Client
     transport::Transport
@@ -1087,7 +1159,14 @@ end
 """
     do!(client, address, request; secure=false, server_name=nothing, protocol=:auto)
 
-Send a request with redirect handling and return the final response.
+Send `request` with redirect handling and return the final low-level `Response`.
+
+This method preserves streaming bodies, so callers are responsible for draining
+or closing `response.body`.
+
+`protocol` accepts `:auto`, `:h1`, or `:h2`. In `:auto` mode the client may try
+HTTP/2 first for secure requests and fall back to HTTP/1 when negotiation says
+that h2 is unavailable.
 """
 function do!(
         client::Client,
@@ -1187,6 +1266,8 @@ end
     get!(client, address, target; secure=false, protocol=:auto)
 
 Convenience GET request using an existing `Client`.
+
+Returns the same low-level `Response` shape as `do!`.
 """
 function get!(client::Client, address::AbstractString, target::AbstractString; secure::Bool = false, protocol::Symbol = :auto)
     request = Request("GET", target; host = String(address), body = EmptyBody(), content_length = 0)
@@ -1199,6 +1280,9 @@ import Base: get
     ClientResponse
 
 Materialized high-level response returned by `request/get/post/...` helpers.
+
+Unlike the lower-level `Response`, the response body has already been fully read
+into memory as `body::Vector{UInt8}`.
 """
 struct ClientResponse
     status::Int
@@ -1557,7 +1641,24 @@ end
 """
     request(method, url, headers=Pair{String,String}[], body=nothing; kwargs...)
 
-High-level one-shot HTTP request API (similar shape to HTTP.jl convenience methods).
+High-level one-shot HTTP request API (similar shape to HTTP.jl convenience
+methods).
+
+Keyword arguments:
+- `status_exception`: throw `StatusError` for non-success responses
+- `redirect`: follow redirects through `do!`
+- `query`: optional query string or key/value collection appended to the URL
+- `client`: optional explicit `Client`; otherwise a default or ephemeral client
+  is created
+- `connect_timeout`: connection timeout in seconds for implicit clients
+- `readtimeout`: overall request deadline in seconds
+- `require_ssl_verification`: disable certificate verification only for testing
+- `protocol`: `:auto`, `:h1`, or `:h2`
+
+Returns a fully materialized `ClientResponse`. Throws `ArgumentError` for
+unsupported inputs, `StatusError` when `status_exception=true` and the response
+status is considered failing, plus any lower-level transport or protocol
+exception raised during the request.
 """
 function request(
         method::AbstractString,

--- a/src/77_http_server.jl
+++ b/src/77_http_server.jl
@@ -10,6 +10,15 @@ using ..Reseau.TCP
 using ..Reseau.HostResolvers
 using ..Reseau.IOPoll
 
+"""
+    Server
+
+HTTP/1 server state for one listening endpoint plus its active connection set.
+
+The server is intentionally small and synchronous in the style of Go's early
+`net/http` building blocks: each accepted connection is handled on its own task
+and request parsing/writing is performed directly against the TCP stream.
+"""
 mutable struct Server
     network::String
     address::String
@@ -32,6 +41,18 @@ end
     Server(; network="tcp", address="127.0.0.1:0", handler, ...)
 
 Create an HTTP server with timeouts and parser limits.
+
+Keyword arguments:
+- `network`, `address`: bind information passed to `HostResolvers.listen`
+- `handler`: function taking `Request` and returning `Response`
+- `read_timeout_ns`: whole-request read deadline once a request is underway
+- `read_header_timeout_ns`: stricter deadline while waiting for request headers
+- `write_timeout_ns`: response write deadline
+- `idle_timeout_ns`: keep-alive idle timeout between requests
+- `max_header_bytes`: aggregate request-header size cap
+
+Returns a mutable `Server`. Throws `ArgumentError` for invalid timeout or size
+limits.
 """
 function Server(;
         network::AbstractString = "tcp",
@@ -75,6 +96,8 @@ end
     server_addr(server)
 
 Return the effective bound `host:port` once listening starts.
+
+Throws `ProtocolError` if the server has not started listening yet.
 """
 function server_addr(server::Server)::String
     lock(server.lock)
@@ -225,6 +248,10 @@ end
     serve!(server, listener)
 
 Serve requests from an existing listener until shutdown.
+
+Each accepted connection is handed to a background task that processes
+sequential HTTP/1 requests on that socket until the peer closes, an error
+occurs, or shutdown is requested.
 """
 function serve!(server::Server, listener::TCP.Listener)
     _server_shutting_down(server) && throw(ProtocolError("server is shutting down"))
@@ -269,7 +296,10 @@ end
 """
     listen_and_serve!(server)
 
-Listen then serve using `server.network` and `server.address`.
+Listen and then serve using `server.network` and `server.address`.
+
+Returns `nothing` when serving stops. Listener cleanup is performed in a
+`finally` block so shutdown paths do not leak the bound socket.
 """
 function listen_and_serve!(server::Server)
     listener = HostResolvers.listen(server.network, server.address; backlog = 128)
@@ -288,6 +318,8 @@ end
     start!(server)
 
 Start `listen_and_serve!` on a background task.
+
+Returns the spawned `Task`, which is also stored on `server.serve_task`.
 """
 function start!(server::Server)::Task
     task = errormonitor(Threads.@spawn listen_and_serve!(server))
@@ -343,6 +375,13 @@ end
     shutdown!(server; force=false, timeout_s=5.0)
 
 Request graceful shutdown, optionally force-closing active connections.
+
+Arguments:
+- `force`: when `true`, close active connections after the listener stops
+- `timeout_s`: best-effort waiting budget for listener and connection tasks
+
+Returns `nothing`. Shutdown suppresses close errors so one stuck connection does
+not prevent the rest of the server from unwinding.
 """
 function shutdown!(server::Server; force::Bool = false, timeout_s::Float64 = 5.0)
     @atomic :release server.shutting_down = true

--- a/src/77_http_server.jl
+++ b/src/77_http_server.jl
@@ -43,7 +43,7 @@ end
 Create an HTTP server with timeouts and parser limits.
 
 Keyword arguments:
-- `network`, `address`: bind information passed to `HostResolvers.listen`
+- `network`, `address`: bind information passed to `TCP.listen`
 - `handler`: function taking `Request` and returning `Response`
 - `read_timeout_ns`: whole-request read deadline once a request is underway
 - `read_header_timeout_ns`: stricter deadline while waiting for request headers
@@ -302,7 +302,7 @@ Returns `nothing` when serving stops. Listener cleanup is performed in a
 `finally` block so shutdown paths do not leak the bound socket.
 """
 function listen_and_serve!(server::Server)
-    listener = HostResolvers.listen(server.network, server.address; backlog = 128)
+    listener = TCP.listen(server.network, server.address; backlog = 128)
     try
         serve!(server, listener)
     finally

--- a/src/7_http.jl
+++ b/src/7_http.jl
@@ -3,11 +3,19 @@
 
 HTTP protocol layer built on top of `TCP` and `TLS`.
 
-Includes:
-- core HTTP request/response/header/body types
-- HTTP/1 parser/serializer
-- HPACK + HTTP/2 framing/client/server
-- high-level client and server interfaces
+The code is split roughly the same way Go's `net/http`, `x/net/http2`, and
+supporting wire-format packages are split:
+- `70_http_core.jl` defines protocol-neutral request, response, header, body,
+  and cancellation types shared by client and server code.
+- `71_http1.jl` implements HTTP/1.1 parsing and serialization.
+- `72_hpack.jl` and `73_http2.jl` implement the HPACK and HTTP/2 wire layers.
+- `74_http2_client.jl`, `76_http_client.jl`, `75_http2_server.jl`, and
+  `77_http_server.jl` build higher-level client/server behavior on top.
+
+This module exports both the low-level wire APIs and the convenience client and
+server entry points. Most public functions either return one of the shared
+`Request`/`Response`/`Headers` types or mutate a caller-supplied transport/body
+object in place.
 """
 module HTTP
 

--- a/src/8_precompile_workload.jl
+++ b/src/8_precompile_workload.jl
@@ -310,7 +310,21 @@ function _pc_run_tls_workload!()
             server_name = "localhost",
             handshake_timeout_ns = 1_000_000_000,
         )
-        client = TL.connect("tcp", "127.0.0.1:$(Int(laddr.port))", client_cfg)
+        client = TL.connect(
+            "tcp",
+            "127.0.0.1:$(Int(laddr.port))";
+            server_name = client_cfg.server_name,
+            verify_peer = client_cfg.verify_peer,
+            client_auth = client_cfg.client_auth,
+            cert_file = client_cfg.cert_file,
+            key_file = client_cfg.key_file,
+            ca_file = client_cfg.ca_file,
+            client_ca_file = client_cfg.client_ca_file,
+            alpn_protocols = copy(client_cfg.alpn_protocols),
+            handshake_timeout_ns = client_cfg.handshake_timeout_ns,
+            min_version = client_cfg.min_version,
+            max_version = client_cfg.max_version,
+        )
         status = timedwait(() -> istaskdone(accept_task), 2.0; pollint = 0.001)
         status == :timed_out && throw(ArgumentError("TLS precompile workload timed out during accept"))
         server = fetch(accept_task)

--- a/test/host_resolvers_tests.jl
+++ b/test/host_resolvers_tests.jl
@@ -50,7 +50,7 @@ end
 function _nd_ipv6_supported()::Bool
     listener = nothing
     try
-        listener = ND.listen("tcp6", "[::1]:0"; backlog = 4)
+        listener = NC.listen("tcp6", "[::1]:0"; backlog = 4)
         return true
     catch
         return false
@@ -234,10 +234,10 @@ else
             server = nothing
             accept_task = nothing
             try
-                listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 16)
+                listener = NC.listen("tcp", "127.0.0.1:0"; backlog = 16)
                 laddr = NC.addr(listener)
                 accept_task = errormonitor(Threads.@spawn NC.accept!(listener))
-                client = ND.connect("tcp", ND.join_host_port("127.0.0.1", Int((laddr::NC.SocketAddrV4).port)))
+                client = NC.connect("tcp", ND.join_host_port("127.0.0.1", Int((laddr::NC.SocketAddrV4).port)); timeout_ns = 1_000_000_000)
                 status = _nd_wait_task_done(accept_task, 2.0)
                 @test status != :timed_out
                 server = fetch(accept_task)
@@ -259,7 +259,7 @@ else
             connected = nothing
             accepted = nothing
             try
-                listener = ND.listen("tcp4", "127.0.0.1:0"; backlog = 16)
+                listener = NC.listen("tcp4", "127.0.0.1:0"; backlog = 16)
                 laddr = NC.addr(listener)::NC.SocketAddrV4
                 port = Int(laddr.port)
                 resolver = ND.StaticResolver(
@@ -271,13 +271,13 @@ else
                     ),
                 )
                 warm_accept = errormonitor(Threads.@spawn NC.accept!(listener))
-                warm_client = ND.connect(ND.HostResolver(; resolver = resolver, fallback_delay_ns = 1_000_000), "tcp", "dual.test:$port")
+                warm_client = NC.connect("tcp", "dual.test:$port"; resolver = resolver, fallback_delay_ns = 1_000_000)
                 @test _nd_wait_task_done(warm_accept, 2.0) != :timed_out
                 warm_server = fetch(warm_accept)
                 _nd_close_quiet!(warm_server)
                 _nd_close_quiet!(warm_client)
                 accept_task = errormonitor(Threads.@spawn NC.accept!(listener))
-                connect_task = errormonitor(Threads.@spawn ND.connect(ND.HostResolver(; resolver = resolver, fallback_delay_ns = 5_000_000_000), "tcp", "dual.test:$port"))
+                connect_task = errormonitor(Threads.@spawn NC.connect("tcp", "dual.test:$port"; resolver = resolver, fallback_delay_ns = 5_000_000_000))
                 @test _nd_wait_task_done(connect_task, 1.5) != :timed_out
                 @test _nd_wait_task_done(accept_task, 1.5) != :timed_out
                 connected = fetch(connect_task)
@@ -301,10 +301,10 @@ else
                 server = nothing
                 accept_task = nothing
                 try
-                    listener = ND.listen("tcp6", "[::1]:0"; backlog = 16)
+                    listener = NC.listen("tcp6", "[::1]:0"; backlog = 16)
                     laddr = NC.addr(listener)::NC.SocketAddrV6
                     accept_task = errormonitor(Threads.@spawn NC.accept!(listener))
-                    client = ND.connect("tcp6", ND.join_host_port("::1", Int(laddr.port)))
+                    client = NC.connect("tcp6", ND.join_host_port("::1", Int(laddr.port)); timeout_ns = 1_000_000_000)
                     @test _nd_wait_task_done(accept_task, 2.0) != :timed_out
                     server = fetch(accept_task)
                     payload = UInt8[0x90, 0x91, 0x92]
@@ -322,10 +322,9 @@ else
         end
         @testset "error typing and wrapping (phase 5C)" begin
             slow_resolver = _SlowResolver(0.25, NC.SocketEndpoint[NC.loopback_addr(1)])
-            timeout_resolver = ND.HostResolver(timeout_ns = 20_000_000, resolver = slow_resolver)
             started_ns = time_ns()
             timeout_err = try
-                ND.connect(timeout_resolver, "tcp", "slow.local:80")
+                NC.connect("tcp", "slow.local:80"; timeout_ns = 20_000_000, resolver = slow_resolver)
                 nothing
             catch ex
                 ex
@@ -344,7 +343,7 @@ else
             end
             @test empty_net_err isa ND.UnknownNetworkError
             err_unknown = try
-                ND.connect("udp", "127.0.0.1:1")
+                NC.connect("udp", "127.0.0.1:1")
                 nothing
             catch ex
                 ex
@@ -354,7 +353,7 @@ else
                 @test err_unknown.err isa ND.UnknownNetworkError
             end
             err_bad_addr = try
-                ND.listen("tcp", "bad-address")
+                NC.listen("tcp", "bad-address")
                 nothing
             catch ex
                 ex
@@ -365,7 +364,7 @@ else
             end
             past_deadline = Int64(time_ns()) - Int64(1)
             err_timeout = try
-                ND.connect(ND.HostResolver(; deadline_ns = past_deadline), "tcp", "127.0.0.1:1")
+                NC.connect("tcp", "127.0.0.1:1"; deadline_ns = past_deadline)
                 nothing
             catch ex
                 ex

--- a/test/tls_tests.jl
+++ b/test/tls_tests.jl
@@ -40,6 +40,40 @@ function _tls_server_config(; handshake_timeout_ns::Int64 = 0)
     )
 end
 
+function _tls_connect(
+        network::AbstractString,
+        address::AbstractString,
+        config::TL.Config = TL.Config();
+        timeout_ns::Integer = Int64(0),
+        deadline_ns::Integer = Int64(0),
+        local_addr::Union{Nothing, NC.SocketEndpoint} = nothing,
+        fallback_delay_ns::Integer = Int64(300_000_000),
+        resolver::ND.AbstractResolver = ND.DEFAULT_RESOLVER,
+        policy::ND.ResolverPolicy = ND.ResolverPolicy(),
+    )::TL.Conn
+    return TL.connect(
+        network,
+        address;
+        timeout_ns = timeout_ns,
+        deadline_ns = deadline_ns,
+        local_addr = local_addr,
+        fallback_delay_ns = fallback_delay_ns,
+        resolver = resolver,
+        policy = policy,
+        server_name = config.server_name,
+        verify_peer = config.verify_peer,
+        client_auth = config.client_auth,
+        cert_file = config.cert_file,
+        key_file = config.key_file,
+        ca_file = config.ca_file,
+        client_ca_file = config.client_ca_file,
+        alpn_protocols = copy(config.alpn_protocols),
+        handshake_timeout_ns = config.handshake_timeout_ns,
+        min_version = config.min_version,
+        max_version = config.max_version,
+    )
+end
+
 if !(Sys.isapple() || Sys.islinux())
     @testset "TLS (macOS/Linux only)" begin
         @test true
@@ -137,7 +171,7 @@ else
                             return err
                         end
                     end)
-                    request_client = TL.connect("tcp", "127.0.0.1:$(Int(request_addr.port))", TL.Config(
+                    request_client = _tls_connect("tcp", "127.0.0.1:$(Int(request_addr.port))", TL.Config(
                         verify_peer = false,
                         server_name = "localhost",
                     ))
@@ -172,7 +206,7 @@ else
                 client_cfg = TL.Config(verify_peer = false, server_name = "localhost", handshake_timeout_ns = 10_000_000_000)
                 connect_err = nothing
                 try
-                    client = TL.connect("tcp", "127.0.0.1:$(Int(laddr.port))", client_cfg)
+                    client = _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", client_cfg)
                 catch ex
                     connect_err = ex
                 end
@@ -249,7 +283,7 @@ else
                     server_name = "localhost",
                     alpn_protocols = ["h2", "http/1.1"],
                 )
-                client = TL.connect("tcp", "127.0.0.1:$(Int(laddr.port))", client_cfg)
+                client = _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", client_cfg)
                 @test _tls_wait_task_done(accept_task, 2.0) != :timed_out
                 server = fetch(accept_task)
                 @test TL.connection_state(client).alpn_protocol == "h2"
@@ -281,8 +315,8 @@ else
                     return conns
                 end)
                 client_cfg = TL.Config(verify_peer = false, server_name = "localhost")
-                client1 = TL.connect("tcp", "127.0.0.1:$(Int(laddr.port))", client_cfg)
-                client2 = TL.connect("tcp", "127.0.0.1:$(Int(laddr.port))", client_cfg)
+                client1 = _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", client_cfg)
+                client2 = _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", client_cfg)
                 @test client1.ssl_ctx != C_NULL
                 @test client1.ssl_ctx == client2.ssl_ctx
                 @test _tls_wait_task_done(accept_task, 2.0) != :timed_out
@@ -344,7 +378,7 @@ else
                     server_name = "localhost",
                     handshake_timeout_ns = 10_000_000_000,
                 )
-                client = TL.connect("tcp", "127.0.0.1:$(Int(laddr.port))", client_cfg)
+                client = _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", client_cfg)
                 payload = UInt8[0x61, 0x62, 0x63, 0x64]
                 @test write(client, payload) == 4
                 recv_buf = Vector{UInt8}(undef, 4)
@@ -380,7 +414,7 @@ else
                     TL.close!(conn)
                     return nothing
                 end)
-                client = TL.connect("tcp", "127.0.0.1:$(Int(laddr.port))", TL.Config(
+                client = _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", TL.Config(
                     verify_peer = false,
                     server_name = "localhost",
                 ))
@@ -406,7 +440,7 @@ else
                     TL.handshake!(conn)
                     return conn
                 end)
-                client = TL.connect("tcp", "127.0.0.1:$(Int(laddr.port))", TL.Config(
+                client = _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", TL.Config(
                     verify_peer = false,
                     server_name = "localhost",
                 ))
@@ -491,7 +525,7 @@ else
                     handshake_timeout_ns = 10_000_000_000,
                 )
                 connect_result = try
-                    TL.connect("tcp", "127.0.0.1:$(Int(laddr.port))", client_cfg)
+                    _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", client_cfg)
                 catch ex
                     ex
                 end
@@ -534,7 +568,7 @@ else
                     handshake_timeout_ns = 10_000_000_000,
                 )
                 bad_connect_err = try
-                    TL.connect("tcp", "127.0.0.1:$(Int(laddr.port))", bad_client_cfg)
+                    _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", bad_client_cfg)
                     nothing
                 catch ex
                     ex
@@ -573,7 +607,7 @@ else
                 )
                 connect_err = nothing
                 try
-                    client = TL.connect("tcp", "127.0.0.1:$(Int(laddr.port))", client_cfg)
+                    client = _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", client_cfg)
                 catch ex
                     connect_err = ex
                 end
@@ -695,7 +729,17 @@ else
                 )
                 started_ns = time_ns()
                 err = try
-                    TL.connect_with_resolver(host_resolver, "tcp", "127.0.0.1:$(Int(laddr.port))", cfg)
+                    _tls_connect(
+                        "tcp",
+                        "127.0.0.1:$(Int(laddr.port))",
+                        cfg;
+                        timeout_ns = host_resolver.timeout_ns,
+                        deadline_ns = host_resolver.deadline_ns,
+                        local_addr = host_resolver.local_addr,
+                        fallback_delay_ns = host_resolver.fallback_delay_ns,
+                        resolver = host_resolver.resolver,
+                        policy = host_resolver.policy,
+                    )
                     nothing
                 catch ex
                     ex
@@ -726,7 +770,7 @@ else
                     TL.handshake!(conn)
                     return conn
                 end)
-                client = TL.connect("tcp", "127.0.0.1:$(Int(laddr.port))", TL.Config(
+                client = _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", TL.Config(
                     verify_peer = false,
                     server_name = "localhost",
                 ))
@@ -758,7 +802,7 @@ else
                     TL.close!(conn)
                     return nothing
                 end)
-                client = TL.connect("tcp", "127.0.0.1:$(Int(laddr.port))", TL.Config(
+                client = _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", TL.Config(
                     verify_peer = false,
                     server_name = "localhost",
                 ))
@@ -806,7 +850,7 @@ else
                     TL.handshake!(conn)
                     return conn
                 end)
-                client = TL.connect("tcp", "127.0.0.1:$(Int(laddr.port))", TL.Config(
+                client = _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", TL.Config(
                     verify_peer = false,
                     server_name = "localhost",
                 ))


### PR DESCRIPTION
## Summary
- expand comments and docstrings across the runtime, transport, TLS, and HTTP stack
- make `TCP.connect` and `TCP.listen` the primary public entrypoints for string-address workflows
- simplify the TLS client connect surface by removing `Connector`, removing `connect_with_resolver`, and forwarding HostResolver/TLS config kwargs through `TLS.connect`

## Details
- `HostResolvers` now extends the `TCP.connect` / `TCP.listen` generics instead of presenting a separate top-level user API
- `TCP.connect(...; kwargs...)` forwards HostResolver constructor keywords directly
- `TLS.connect(...; kwargs...)` now mirrors the TCP shape and forwards HostResolver kwargs plus TLS `Config` kwargs
- removed `connect_timeout`, `Connector`, and `connect_with_resolver`
- updated downstream TLS/HTTP callers, tests, and the precompile workload to use the unified interfaces

## Testing
- `julia --startup-file=no --project=/Users/jacob.quinn/.julia/dev/Reseau -e 'include("/Users/jacob.quinn/.julia/dev/Reseau/test/host_resolvers_tests.jl")'`
- `julia --startup-file=no --project=/Users/jacob.quinn/.julia/dev/Reseau -e 'include("/Users/jacob.quinn/.julia/dev/Reseau/test/tls_tests.jl")'`
- `julia --startup-file=no --project=/Users/jacob.quinn/.julia/dev/Reseau -e 'using Pkg; Pkg.test()'`
