### PR TITLE
eventloops: Add poller-backed sleep APIs

### DIFF
--- a/src/1_eventloops.jl
+++ b/src/1_eventloops.jl
@@ -52,21 +52,27 @@ mutable struct PollWaiter
 end
 
 """
-    SleepState
+    TimerState
 
-One-shot task sleep state managed by the poller.
+Poller-managed timer state shared by raw one-shot sleeps and future
+resettable/repeating timers.
 
-Unlike fd deadlines, a sleep does not belong to a descriptor registration. It is
-just a latched `PollWaiter` plus a sequence word so stale heap entries can be
-discarded if the sleep is canceled or the state is ever reused.
+Unlike fd deadlines, timers do not belong to descriptor registrations. The
+state is a latched `PollWaiter` plus timer metadata:
+- `deadline_ns`: currently armed monotonic deadline, or `0` when disarmed
+- `interval_ns`: repeat interval in nanoseconds, or `0` for one-shot timers
+- `seq`: generation counter used to reject stale heap entries after rearm/close
+- `closed`: suppresses future fire/rearm after shutdown or explicit close
 """
-mutable struct SleepState
+mutable struct TimerState
+    lock::ReentrantLock
     waiter::PollWaiter
+    @atomic deadline_ns::Int64
+    @atomic interval_ns::Int64
     @atomic seq::UInt64
-    @atomic fired::Bool
-    @atomic canceled::Bool
-    function SleepState()
-        return new(PollWaiter(), UInt64(1), false, false)
+    @atomic closed::Bool
+    function TimerState(deadline_ns::Int64 = Int64(0), interval_ns::Int64 = Int64(0))
+        return new(ReentrantLock(), PollWaiter(), deadline_ns, interval_ns, UInt64(0), false)
     end
 end
 
@@ -252,17 +258,16 @@ struct DeadlineEntry
 end
 
 """
-    SleepEntry
+    TimerEntry
 
-One scheduled one-shot sleep in the poller min-heap.
+One scheduled timer wakeup in the poller min-heap.
 
-The sequence number mirrors `DeadlineEntry`'s stale-entry strategy: if a sleep
-state is canceled, completed, or ever reused, old heap entries are ignored when
-they rise to the top.
+The sequence number mirrors `DeadlineEntry`'s stale-entry strategy: if a timer
+is rearmed or closed, old heap entries are ignored when they rise to the top.
 """
-struct SleepEntry
+struct TimerEntry
     deadline_ns::Int64
-    sleepstate::SleepState
+    timer::TimerState
     seq::UInt64
 end
 
@@ -285,7 +290,7 @@ mutable struct Poller
     registrations::Dict{Cint, Registration}
     registrations_by_token::Dict{UInt64, Registration}
     deadline_heap::Vector{DeadlineEntry}
-    sleep_heap::Vector{SleepEntry}
+    timer_heap::Vector{TimerEntry}
     shutdown_event::Base.Threads.Event
     kq::Cint
     wake_ident::UInt
@@ -302,7 +307,7 @@ function Poller()
         Dict{Cint, Registration}(),
         Dict{UInt64, Registration}(),
         DeadlineEntry[],
-        SleepEntry[],
+        TimerEntry[],
         Base.Threads.Event(),
         Cint(-1),
         UInt(1),
@@ -355,7 +360,7 @@ end
 
 function deadline_fire! end
 
-@inline function _sleep_less(a::SleepEntry, b::SleepEntry)::Bool
+@inline function _timer_less(a::TimerEntry, b::TimerEntry)::Bool
     if a.deadline_ns != b.deadline_ns
         return a.deadline_ns < b.deadline_ns
     end
@@ -389,7 +394,7 @@ function _deadline_swap!(heap::Vector{DeadlineEntry}, i::Int, j::Int)
     return nothing
 end
 
-function _sleep_swap!(heap::Vector{SleepEntry}, i::Int, j::Int)
+function _timer_swap!(heap::Vector{TimerEntry}, i::Int, j::Int)
     heap[i], heap[j] = heap[j], heap[i]
     return nothing
 end
@@ -404,11 +409,11 @@ function _deadline_sift_up!(heap::Vector{DeadlineEntry}, i::Int)
     return nothing
 end
 
-function _sleep_sift_up!(heap::Vector{SleepEntry}, i::Int)
+function _timer_sift_up!(heap::Vector{TimerEntry}, i::Int)
     while i > 1
         parent = _heap_parent_index(i)
-        _sleep_less(heap[i], heap[parent]) || break
-        _sleep_swap!(heap, i, parent)
+        _timer_less(heap[i], heap[parent]) || break
+        _timer_swap!(heap, i, parent)
         i = parent
     end
     return nothing
@@ -431,18 +436,18 @@ function _deadline_sift_down!(heap::Vector{DeadlineEntry}, i::Int)
     return nothing
 end
 
-function _sleep_sift_down!(heap::Vector{SleepEntry}, i::Int)
+function _timer_sift_down!(heap::Vector{TimerEntry}, i::Int)
     len = length(heap)
     while true
         left = _heap_left_index(i)
         left > len && break
         smallest = left
         right = _heap_right_index(i)
-        if right <= len && _sleep_less(heap[right], heap[left])
+        if right <= len && _timer_less(heap[right], heap[left])
             smallest = right
         end
-        _sleep_less(heap[smallest], heap[i]) || break
-        _sleep_swap!(heap, i, smallest)
+        _timer_less(heap[smallest], heap[i]) || break
+        _timer_swap!(heap, i, smallest)
         i = smallest
     end
     return nothing
@@ -455,10 +460,10 @@ function _deadline_push_locked!(state::Poller, entry::DeadlineEntry)
     return nothing
 end
 
-function _sleep_push_locked!(state::Poller, entry::SleepEntry)
-    heap = state.sleep_heap
+function _timer_push_locked!(state::Poller, entry::TimerEntry)
+    heap = state.timer_heap
     push!(heap, entry)
-    _sleep_sift_up!(heap, length(heap))
+    _timer_sift_up!(heap, length(heap))
     return nothing
 end
 
@@ -474,14 +479,14 @@ function _deadline_pop_locked!(state::Poller)::DeadlineEntry
     return entry
 end
 
-function _sleep_pop_locked!(state::Poller)::SleepEntry
-    heap = state.sleep_heap
-    isempty(heap) && throw(ArgumentError("sleep heap is empty"))
+function _timer_pop_locked!(state::Poller)::TimerEntry
+    heap = state.timer_heap
+    isempty(heap) && throw(ArgumentError("timer heap is empty"))
     entry = heap[1]
     last = pop!(heap)
     if !isempty(heap)
         heap[1] = last
-        _sleep_sift_down!(heap, 1)
+        _timer_sift_down!(heap, 1)
     end
     return entry
 end
@@ -502,19 +507,18 @@ function _discard_stale_deadlines_locked!(state::Poller)
     return nothing
 end
 
-@inline function _sleep_entry_live(entry::SleepEntry)::Bool
-    sleepstate = entry.sleepstate
-    (@atomic :acquire sleepstate.seq) == entry.seq || return false
-    (@atomic :acquire sleepstate.fired) && return false
-    (@atomic :acquire sleepstate.canceled) && return false
+@inline function _timer_entry_live(entry::TimerEntry)::Bool
+    timer = entry.timer
+    (@atomic :acquire timer.seq) == entry.seq || return false
+    (@atomic :acquire timer.closed) && return false
     return true
 end
 
-function _discard_stale_sleeps_locked!(state::Poller)
-    while !isempty(state.sleep_heap)
-        entry = state.sleep_heap[1]
-        _sleep_entry_live(entry) && return nothing
-        _ = _sleep_pop_locked!(state)
+function _discard_stale_timers_locked!(state::Poller)
+    while !isempty(state.timer_heap)
+        entry = state.timer_heap[1]
+        _timer_entry_live(entry) && return nothing
+        _ = _timer_pop_locked!(state)
     end
     return nothing
 end
@@ -525,10 +529,10 @@ function _deadline_peek_locked(state::Poller)
     return state.deadline_heap[1]
 end
 
-function _sleep_peek_locked(state::Poller)
-    _discard_stale_sleeps_locked!(state)
-    isempty(state.sleep_heap) && return nothing
-    return state.sleep_heap[1]
+function _timer_peek_locked(state::Poller)
+    _discard_stale_timers_locked!(state)
+    isempty(state.timer_heap) && return nothing
+    return state.timer_heap[1]
 end
 
 @inline function _maybe_wake_for_earlier_deadline!(state::Poller, new_earliest::Int64)
@@ -608,30 +612,52 @@ function schedule_deadlines!(
 end
 
 """
-    schedule_sleep!(sleepstate, deadline_ns)
+    schedule_timer!(timer, deadline_ns)
 
-Publish one one-shot sleep wakeup into the poller heap.
+Publish one timer wakeup into the poller heap.
 
 `deadline_ns` is an absolute monotonic `time_ns()`-style timestamp.
+Returns `true` if the timer was armed and `false` if the poller was already
+stopped.
 """
-function schedule_sleep!(sleepstate::SleepState, deadline_ns::Int64)
-    isassigned(POLLER) || return nothing
-    state = POLLER[]
-    (@atomic :acquire state.running) || return nothing
+function schedule_timer!(timer::TimerState, deadline_ns::Int64)::Bool
+    state = init!()
+    (@atomic :acquire state.running) || return false
     new_earliest = Int64(0)
-    seq = @atomic :acquire sleepstate.seq
-    @atomic :release sleepstate.fired = false
-    @atomic :release sleepstate.canceled = false
+    entry = nothing
+    armed = false
+    lock(timer.lock)
+    try
+        (@atomic :acquire timer.closed) && return false
+        @atomic :release timer.deadline_ns = deadline_ns
+        seq = @atomic timer.seq += UInt64(1)
+        entry = TimerEntry(deadline_ns, timer, seq)
+    finally
+        unlock(timer.lock)
+    end
     lock(state.lock)
     try
-        entry = SleepEntry(deadline_ns, sleepstate, seq)
-        _sleep_push_locked!(state, entry)
-        new_earliest = entry.deadline_ns
+        if @atomic :acquire state.running
+            _timer_push_locked!(state, entry::TimerEntry)
+            new_earliest = entry.deadline_ns
+            armed = true
+        end
     finally
         unlock(state.lock)
     end
+    if !armed
+        lock(timer.lock)
+        try
+            if (@atomic :acquire timer.seq) == (entry::TimerEntry).seq && !(@atomic :acquire timer.closed)
+                @atomic :release timer.deadline_ns = Int64(0)
+            end
+        finally
+            unlock(timer.lock)
+        end
+        return false
+    end
     _maybe_wake_for_earlier_deadline!(state, new_earliest)
-    return nothing
+    return true
 end
 
 """
@@ -650,15 +676,15 @@ function _poll_delay_ns(state::Poller)::Int64
     lock(state.lock)
     try
         deadline_entry = _deadline_peek_locked(state)
-        sleep_entry = _sleep_peek_locked(state)
+        timer_entry = _timer_peek_locked(state)
         fd_deadline_ns = deadline_entry === nothing ? Int64(0) : deadline_entry.deadline_ns
-        sleep_deadline_ns = sleep_entry === nothing ? Int64(0) : sleep_entry.deadline_ns
+        timer_deadline_ns = timer_entry === nothing ? Int64(0) : timer_entry.deadline_ns
         if fd_deadline_ns == 0
-            deadline_ns = sleep_deadline_ns
-        elseif sleep_deadline_ns == 0
+            deadline_ns = timer_deadline_ns
+        elseif timer_deadline_ns == 0
             deadline_ns = fd_deadline_ns
         else
-            deadline_ns = min(fd_deadline_ns, sleep_deadline_ns)
+            deadline_ns = min(fd_deadline_ns, timer_deadline_ns)
         end
         @atomic :release state.poll_until_ns = deadline_ns
     finally
@@ -699,34 +725,47 @@ function _drain_expired_deadlines!(state::Poller, now_ns::Int64)
     return nothing
 end
 
-function _cancel_sleep!(sleepstate::SleepState)
-    @atomic :release sleepstate.canceled = true
-    pollnotify!(sleepstate.waiter)
+function _close_timer!(timer::TimerState)
+    lock(timer.lock)
+    try
+        (@atomic :acquire timer.closed) && return nothing
+        @atomic :release timer.closed = true
+        @atomic :release timer.deadline_ns = Int64(0)
+        _ = @atomic timer.seq += UInt64(1)
+    finally
+        unlock(timer.lock)
+    end
+    pollnotify!(timer.waiter)
     return nothing
 end
 
-function _sleep_fire!(sleepstate::SleepState, seq::UInt64)
-    (@atomic :acquire sleepstate.seq) == seq || return nothing
-    (@atomic :acquire sleepstate.canceled) && return nothing
-    @atomic :release sleepstate.fired = true
-    pollnotify!(sleepstate.waiter)
+function _timer_fire!(timer::TimerState, seq::UInt64)
+    lock(timer.lock)
+    try
+        (@atomic :acquire timer.closed) && return nothing
+        (@atomic :acquire timer.seq) == seq || return nothing
+        @atomic :release timer.deadline_ns = Int64(0)
+    finally
+        unlock(timer.lock)
+    end
+    pollnotify!(timer.waiter)
     return nothing
 end
 
-function _drain_expired_sleeps!(state::Poller, now_ns::Int64)
-    expired = SleepEntry[]
+function _drain_expired_timers!(state::Poller, now_ns::Int64)
+    expired = TimerEntry[]
     lock(state.lock)
     try
         while true
-            entry = _sleep_peek_locked(state)
+            entry = _timer_peek_locked(state)
             (entry === nothing || entry.deadline_ns > now_ns) && break
-            push!(expired, _sleep_pop_locked!(state))
+            push!(expired, _timer_pop_locked!(state))
         end
     finally
         unlock(state.lock)
     end
     for entry in expired
-        _sleep_fire!(entry.sleepstate, entry.seq)
+        _timer_fire!(entry.timer, entry.seq)
     end
     return nothing
 end
@@ -1008,13 +1047,13 @@ end
 
 function _notify_all_waiters!(state::Poller)
     registrations = Registration[]
-    sleeps = SleepState[]
+    timers = TimerState[]
     lock(state.lock)
     try
         append!(registrations, values(state.registrations))
-        _discard_stale_sleeps_locked!(state)
-        for entry in state.sleep_heap
-            push!(sleeps, entry.sleepstate)
+        _discard_stale_timers_locked!(state)
+        for entry in state.timer_heap
+            push!(timers, entry.timer)
         end
     finally
         unlock(state.lock)
@@ -1022,8 +1061,8 @@ function _notify_all_waiters!(state::Poller)
     for registration in registrations
         _notify_registration!(registration, PollMode.READWRITE)
     end
-    for sleepstate in sleeps
-        _cancel_sleep!(sleepstate)
+    for timer in timers
+        _close_timer!(timer)
     end
     return nothing
 end
@@ -1034,7 +1073,7 @@ function _poller_thread_main!(state::Poller)
         errno = _backend_poll_once!(state, delay_ns)
         @atomic :release state.poll_until_ns = Int64(0)
         _drain_expired_deadlines!(state, Int64(time_ns()))
-        _drain_expired_sleeps!(state, Int64(time_ns()))
+        _drain_expired_timers!(state, Int64(time_ns()))
         errno == Int32(0) && continue
         if errno == Int32(Base.Libc.EINTR)
             continue
@@ -1057,12 +1096,12 @@ function sleep_until_ns(deadline_ns::Integer)
     target_ns <= Int64(time_ns()) && return nothing
     state = init!()
     (@atomic :acquire state.running) || return nothing
-    sleepstate = SleepState()
-    schedule_sleep!(sleepstate, target_ns)
+    timer = TimerState(target_ns, Int64(0))
+    schedule_timer!(timer, target_ns) || return nothing
     while true
-        pollwait!(sleepstate.waiter)
-        (@atomic :acquire sleepstate.fired) && return nothing
-        (@atomic :acquire sleepstate.canceled) && return nothing
+        pollwait!(timer.waiter)
+        (@atomic :acquire timer.closed) && return nothing
+        (@atomic :acquire timer.deadline_ns) == 0 && return nothing
     end
 end
 

--- a/src/1_eventloops.jl
+++ b/src/1_eventloops.jl
@@ -26,6 +26,11 @@ using EnumX
     READWRITE = 0x03
 end
 
+@enumx TimeEntryKind::UInt8 begin
+    DEADLINE = 0x01
+    TIMER = 0x02
+end
+
 @enumx PollWaiterState::UInt8 begin
     EMPTY = 0x00
     WAITING = 0x01
@@ -233,42 +238,27 @@ function Registration(
 end
 
 """
-    DeadlineEntry
+    TimeEntry
 
-One scheduled deadline observation in the poller min-heap.
+One scheduled time event in the poller min-heap.
 
-The heap stores immutable snapshots: `(deadline_ns, mode, rseq, wseq)` capture
-the descriptor state at the moment the entry was scheduled. When an entry later
-reaches the top of the heap, `IOPoll.deadline_fire!` compares the saved
-sequence numbers against the current `PollState` to decide whether the timeout
-is still live or whether the entry became stale because the deadline was reset,
-cleared, or the descriptor was closed/re-registered.
+`TimeEntryKind.DEADLINE` entries are immutable snapshots of descriptor timeout
+state. `mode`, `primary_seq`, and `secondary_seq` capture the read/write
+deadline generation at the moment the entry was scheduled, and `pollstate`
+points at the descriptor-local state that will eventually consume the timeout.
 
-If read and write deadlines are equal, we intentionally store a single
-`READWRITE` entry. That is the same optimization Go applies with
-`netpollDeadline`: it reduces heap pressure while keeping the timeout semantics
-identical.
+`TimeEntryKind.TIMER` entries are object-owned timer wakeups. `primary_seq`
+stores the timer generation captured when the entry was armed, and `timer`
+points at the `TimerState` that will eventually be notified.
 """
-struct DeadlineEntry
+struct TimeEntry
     deadline_ns::Int64
-    pollstate::PollState
+    kind::TimeEntryKind.T
+    pollstate::Union{Nothing, PollState}
+    timer::Union{Nothing, TimerState}
     mode::PollMode.T
-    rseq::UInt64
-    wseq::UInt64
-end
-
-"""
-    TimerEntry
-
-One scheduled timer wakeup in the poller min-heap.
-
-The sequence number mirrors `DeadlineEntry`'s stale-entry strategy: if a timer
-is rearmed or closed, old heap entries are ignored when they rise to the top.
-"""
-struct TimerEntry
-    deadline_ns::Int64
-    timer::TimerState
-    seq::UInt64
+    primary_seq::UInt64
+    secondary_seq::UInt64
 end
 
 """
@@ -279,8 +269,8 @@ updates can run adjacent to syscalls where spin waiting would be wasteful.
 
 Notable fields:
 - `registrations`/`registrations_by_token` let us validate that an event or
-  deadline still belongs to the current occupant of an fd slot
-- `deadline_heap` is the min-heap that drives finite backend poll timeouts
+  time entry still belongs to the current occupant of an fd slot
+- `time_heap` is the min-heap that drives finite backend poll timeouts
 - `poll_until_ns` records the deadline currently being slept toward so that a
   newly earlier deadline can call `_backend_wake!`, just like Go uses
   `netpollBreak()` to shorten a blocking poll
@@ -289,8 +279,7 @@ mutable struct Poller
     lock::ReentrantLock
     registrations::Dict{Cint, Registration}
     registrations_by_token::Dict{UInt64, Registration}
-    deadline_heap::Vector{DeadlineEntry}
-    timer_heap::Vector{TimerEntry}
+    time_heap::Vector{TimeEntry}
     shutdown_event::Base.Threads.Event
     kq::Cint
     wake_ident::UInt
@@ -306,8 +295,7 @@ function Poller()
         ReentrantLock(),
         Dict{Cint, Registration}(),
         Dict{UInt64, Registration}(),
-        DeadlineEntry[],
-        TimerEntry[],
+        TimeEntry[],
         Base.Threads.Event(),
         Cint(-1),
         UInt(1),
@@ -360,21 +348,22 @@ end
 
 function deadline_fire! end
 
-@inline function _timer_less(a::TimerEntry, b::TimerEntry)::Bool
+@inline function _time_less(a::TimeEntry, b::TimeEntry)::Bool
     if a.deadline_ns != b.deadline_ns
         return a.deadline_ns < b.deadline_ns
     end
-    return a.seq < b.seq
-end
-
-@inline function _deadline_less(a::DeadlineEntry, b::DeadlineEntry)::Bool
-    if a.deadline_ns != b.deadline_ns
-        return a.deadline_ns < b.deadline_ns
+    if a.kind != b.kind
+        return UInt8(a.kind) < UInt8(b.kind)
     end
-    if a.pollstate.token != b.pollstate.token
-        return a.pollstate.token < b.pollstate.token
+    if a.kind == TimeEntryKind.DEADLINE
+        apd = a.pollstate::PollState
+        bpd = b.pollstate::PollState
+        if apd.token != bpd.token
+            return apd.token < bpd.token
+        end
+        return UInt8(a.mode) < UInt8(b.mode)
     end
-    return UInt8(a.mode) < UInt8(b.mode)
+    return a.primary_seq < b.primary_seq
 end
 
 @inline function _heap_parent_index(i::Int)::Int
@@ -389,104 +378,53 @@ end
     return (i << 1) + 1
 end
 
-function _deadline_swap!(heap::Vector{DeadlineEntry}, i::Int, j::Int)
+function _time_swap!(heap::Vector{TimeEntry}, i::Int, j::Int)
     heap[i], heap[j] = heap[j], heap[i]
     return nothing
 end
 
-function _timer_swap!(heap::Vector{TimerEntry}, i::Int, j::Int)
-    heap[i], heap[j] = heap[j], heap[i]
-    return nothing
-end
-
-function _deadline_sift_up!(heap::Vector{DeadlineEntry}, i::Int)
+function _time_sift_up!(heap::Vector{TimeEntry}, i::Int)
     while i > 1
         parent = _heap_parent_index(i)
-        _deadline_less(heap[i], heap[parent]) || break
-        _deadline_swap!(heap, i, parent)
+        _time_less(heap[i], heap[parent]) || break
+        _time_swap!(heap, i, parent)
         i = parent
     end
     return nothing
 end
 
-function _timer_sift_up!(heap::Vector{TimerEntry}, i::Int)
-    while i > 1
-        parent = _heap_parent_index(i)
-        _timer_less(heap[i], heap[parent]) || break
-        _timer_swap!(heap, i, parent)
-        i = parent
-    end
-    return nothing
-end
-
-function _deadline_sift_down!(heap::Vector{DeadlineEntry}, i::Int)
+function _time_sift_down!(heap::Vector{TimeEntry}, i::Int)
     len = length(heap)
     while true
         left = _heap_left_index(i)
         left > len && break
         smallest = left
         right = _heap_right_index(i)
-        if right <= len && _deadline_less(heap[right], heap[left])
+        if right <= len && _time_less(heap[right], heap[left])
             smallest = right
         end
-        _deadline_less(heap[smallest], heap[i]) || break
-        _deadline_swap!(heap, i, smallest)
+        _time_less(heap[smallest], heap[i]) || break
+        _time_swap!(heap, i, smallest)
         i = smallest
     end
     return nothing
 end
 
-function _timer_sift_down!(heap::Vector{TimerEntry}, i::Int)
-    len = length(heap)
-    while true
-        left = _heap_left_index(i)
-        left > len && break
-        smallest = left
-        right = _heap_right_index(i)
-        if right <= len && _timer_less(heap[right], heap[left])
-            smallest = right
-        end
-        _timer_less(heap[smallest], heap[i]) || break
-        _timer_swap!(heap, i, smallest)
-        i = smallest
-    end
-    return nothing
-end
-
-function _deadline_push_locked!(state::Poller, entry::DeadlineEntry)
-    heap = state.deadline_heap
+function _time_push_locked!(state::Poller, entry::TimeEntry)
+    heap = state.time_heap
     push!(heap, entry)
-    _deadline_sift_up!(heap, length(heap))
+    _time_sift_up!(heap, length(heap))
     return nothing
 end
 
-function _timer_push_locked!(state::Poller, entry::TimerEntry)
-    heap = state.timer_heap
-    push!(heap, entry)
-    _timer_sift_up!(heap, length(heap))
-    return nothing
-end
-
-function _deadline_pop_locked!(state::Poller)::DeadlineEntry
-    heap = state.deadline_heap
-    isempty(heap) && throw(ArgumentError("deadline heap is empty"))
+function _time_pop_locked!(state::Poller)::TimeEntry
+    heap = state.time_heap
+    isempty(heap) && throw(ArgumentError("time heap is empty"))
     entry = heap[1]
     last = pop!(heap)
     if !isempty(heap)
         heap[1] = last
-        _deadline_sift_down!(heap, 1)
-    end
-    return entry
-end
-
-function _timer_pop_locked!(state::Poller)::TimerEntry
-    heap = state.timer_heap
-    isempty(heap) && throw(ArgumentError("timer heap is empty"))
-    entry = heap[1]
-    last = pop!(heap)
-    if !isempty(heap)
-        heap[1] = last
-        _timer_sift_down!(heap, 1)
+        _time_sift_down!(heap, 1)
     end
     return entry
 end
@@ -496,46 +434,35 @@ end
     return current !== nothing && current.fd == pd.sysfd && current.pollstate === pd
 end
 
-function _discard_stale_deadlines_locked!(state::Poller)
-    while !isempty(state.deadline_heap)
-        entry = state.deadline_heap[1]
+@inline function _entry_live_locked(state::Poller, entry::TimeEntry)::Bool
+    if entry.kind == TimeEntryKind.DEADLINE
+        pd = entry.pollstate::PollState
         # Descriptors are reused aggressively by the OS, so liveness must check
         # both the fd and the monotonically increasing token.
-        _registration_active_locked(state, entry.pollstate) && return nothing
-        _ = _deadline_pop_locked!(state)
+        return _registration_active_locked(state, pd)
     end
-    return nothing
-end
-
-@inline function _timer_entry_live(entry::TimerEntry)::Bool
-    timer = entry.timer
-    (@atomic :acquire timer.seq) == entry.seq || return false
+    timer = entry.timer::TimerState
+    (@atomic :acquire timer.seq) == entry.primary_seq || return false
     (@atomic :acquire timer.closed) && return false
     return true
 end
 
-function _discard_stale_timers_locked!(state::Poller)
-    while !isempty(state.timer_heap)
-        entry = state.timer_heap[1]
-        _timer_entry_live(entry) && return nothing
-        _ = _timer_pop_locked!(state)
+function _discard_stale_time_entries_locked!(state::Poller)
+    while !isempty(state.time_heap)
+        entry = state.time_heap[1]
+        _entry_live_locked(state, entry) && return nothing
+        _ = _time_pop_locked!(state)
     end
     return nothing
 end
 
-function _deadline_peek_locked(state::Poller)
-    _discard_stale_deadlines_locked!(state)
-    isempty(state.deadline_heap) && return nothing
-    return state.deadline_heap[1]
+function _time_peek_locked(state::Poller)
+    _discard_stale_time_entries_locked!(state)
+    isempty(state.time_heap) && return nothing
+    return state.time_heap[1]
 end
 
-function _timer_peek_locked(state::Poller)
-    _discard_stale_timers_locked!(state)
-    isempty(state.timer_heap) && return nothing
-    return state.timer_heap[1]
-end
-
-@inline function _maybe_wake_for_earlier_deadline!(state::Poller, new_earliest::Int64)
+@inline function _maybe_wake_for_earlier_time!(state::Poller, new_earliest::Int64)
     new_earliest > 0 || return nothing
     poll_until_ns = @atomic :acquire state.poll_until_ns
     if poll_until_ns == 0 || new_earliest < poll_until_ns
@@ -545,23 +472,37 @@ end
     return nothing
 end
 
+@inline function _deadline_entry(
+        deadline_ns::Int64,
+        pd::PollState,
+        mode::PollMode.T,
+        rseq::UInt64,
+        wseq::UInt64,
+    )::TimeEntry
+    return TimeEntry(deadline_ns, TimeEntryKind.DEADLINE, pd, nothing, mode, rseq, wseq)
+end
+
+@inline function _timer_entry(deadline_ns::Int64, timer::TimerState, seq::UInt64)::TimeEntry
+    return TimeEntry(deadline_ns, TimeEntryKind.TIMER, nothing, timer, PollMode.READ, seq, UInt64(0))
+end
+
 function _build_deadline_entries(
         pd::PollState,
         rd_ns::Int64,
         wd_ns::Int64,
         rseq::UInt64,
         wseq::UInt64,
-    )::Vector{DeadlineEntry}
-    entries = DeadlineEntry[]
+    )::Vector{TimeEntry}
+    entries = TimeEntry[]
     # Match Go's combined read/write deadline fast path when both deadlines are
     # identical. Distinct deadlines stay as separate heap entries because they
     # can expire independently.
     if rd_ns > 0 && wd_ns > 0 && rd_ns == wd_ns
-        push!(entries, DeadlineEntry(rd_ns, pd, PollMode.READWRITE, rseq, wseq))
+        push!(entries, _deadline_entry(rd_ns, pd, PollMode.READWRITE, rseq, wseq))
         return entries
     end
-    rd_ns > 0 && push!(entries, DeadlineEntry(rd_ns, pd, PollMode.READ, rseq, UInt64(0)))
-    wd_ns > 0 && push!(entries, DeadlineEntry(wd_ns, pd, PollMode.WRITE, UInt64(0), wseq))
+    rd_ns > 0 && push!(entries, _deadline_entry(rd_ns, pd, PollMode.READ, rseq, UInt64(0)))
+    wd_ns > 0 && push!(entries, _deadline_entry(wd_ns, pd, PollMode.WRITE, UInt64(0), wseq))
     return entries
 end
 
@@ -596,7 +537,7 @@ function schedule_deadlines!(
     try
         _registration_active_locked(state, pd) || return nothing
         for entry in _build_deadline_entries(pd, rd_ns, wd_ns, rseq, wseq)
-            _deadline_push_locked!(state, entry)
+            _time_push_locked!(state, entry)
             if new_earliest == 0 || entry.deadline_ns < new_earliest
                 new_earliest = entry.deadline_ns
             end
@@ -607,7 +548,7 @@ function schedule_deadlines!(
     # This is the local equivalent of Go's `netpollBreak()`: once the poller
     # has committed to a sleep horizon, a newly earlier wakeup must actively
     # wake it so the blocking syscall can be retried with a shorter timeout.
-    _maybe_wake_for_earlier_deadline!(state, new_earliest)
+    _maybe_wake_for_earlier_time!(state, new_earliest)
     return nothing
 end
 
@@ -631,14 +572,14 @@ function schedule_timer!(timer::TimerState, deadline_ns::Int64)::Bool
         (@atomic :acquire timer.closed) && return false
         @atomic :release timer.deadline_ns = deadline_ns
         seq = @atomic timer.seq += UInt64(1)
-        entry = TimerEntry(deadline_ns, timer, seq)
+        entry = _timer_entry(deadline_ns, timer, seq)
     finally
         unlock(timer.lock)
     end
     lock(state.lock)
     try
         if @atomic :acquire state.running
-            _timer_push_locked!(state, entry::TimerEntry)
+            _time_push_locked!(state, entry::TimeEntry)
             new_earliest = entry.deadline_ns
             armed = true
         end
@@ -648,7 +589,7 @@ function schedule_timer!(timer::TimerState, deadline_ns::Int64)::Bool
     if !armed
         lock(timer.lock)
         try
-            if (@atomic :acquire timer.seq) == (entry::TimerEntry).seq && !(@atomic :acquire timer.closed)
+            if (@atomic :acquire timer.seq) == (entry::TimeEntry).primary_seq && !(@atomic :acquire timer.closed)
                 @atomic :release timer.deadline_ns = Int64(0)
             end
         finally
@@ -656,7 +597,7 @@ function schedule_timer!(timer::TimerState, deadline_ns::Int64)::Bool
         end
         return false
     end
-    _maybe_wake_for_earlier_deadline!(state, new_earliest)
+    _maybe_wake_for_earlier_time!(state, new_earliest)
     return true
 end
 
@@ -666,8 +607,8 @@ end
 Compute the timeout for the next backend poll call.
 
 Returns:
-- `-1` when no deadlines are pending and the backend may block indefinitely
-- `0` when at least one deadline is already due and the backend should poll
+- `-1` when no time entries are pending and the backend may block indefinitely
+- `0` when at least one time entry is already due and the backend should poll
   without blocking
 - a positive nanosecond timeout otherwise
 """
@@ -675,17 +616,8 @@ function _poll_delay_ns(state::Poller)::Int64
     deadline_ns = Int64(0)
     lock(state.lock)
     try
-        deadline_entry = _deadline_peek_locked(state)
-        timer_entry = _timer_peek_locked(state)
-        fd_deadline_ns = deadline_entry === nothing ? Int64(0) : deadline_entry.deadline_ns
-        timer_deadline_ns = timer_entry === nothing ? Int64(0) : timer_entry.deadline_ns
-        if fd_deadline_ns == 0
-            deadline_ns = timer_deadline_ns
-        elseif timer_deadline_ns == 0
-            deadline_ns = fd_deadline_ns
-        else
-            deadline_ns = min(fd_deadline_ns, timer_deadline_ns)
-        end
+        entry = _time_peek_locked(state)
+        deadline_ns = entry === nothing ? Int64(0) : entry.deadline_ns
         @atomic :release state.poll_until_ns = deadline_ns
     finally
         unlock(state.lock)
@@ -695,34 +627,6 @@ function _poll_delay_ns(state::Poller)::Int64
     remaining_ns = deadline_ns - now_ns
     remaining_ns <= 0 && return Int64(0)
     return remaining_ns
-end
-
-"""
-    _drain_expired_deadlines!(state, now_ns)
-
-Remove all expired deadline entries from the heap and dispatch them to
-`deadline_fire!`.
-
-The heap lock is not held across `deadline_fire!` calls. That keeps the critical
-section small and avoids lock-ordering problems with descriptor-local locks in
-`IOPoll`.
-"""
-function _drain_expired_deadlines!(state::Poller, now_ns::Int64)
-    expired = DeadlineEntry[]
-    lock(state.lock)
-    try
-        while true
-            entry = _deadline_peek_locked(state)
-            (entry === nothing || entry.deadline_ns > now_ns) && break
-            push!(expired, _deadline_pop_locked!(state))
-        end
-    finally
-        unlock(state.lock)
-    end
-    for entry in expired
-        deadline_fire!(entry.pollstate, entry.mode, entry.rseq, entry.wseq)
-    end
-    return nothing
 end
 
 function _close_timer!(timer::TimerState)
@@ -752,20 +656,44 @@ function _timer_fire!(timer::TimerState, seq::UInt64)
     return nothing
 end
 
-function _drain_expired_timers!(state::Poller, now_ns::Int64)
-    expired = TimerEntry[]
+@inline function _fire_time_entry!(entry::TimeEntry)
+    if entry.kind == TimeEntryKind.DEADLINE
+        deadline_fire!(
+            entry.pollstate::PollState,
+            entry.mode,
+            entry.primary_seq,
+            entry.secondary_seq,
+        )
+    else
+        _timer_fire!(entry.timer::TimerState, entry.primary_seq)
+    end
+    return nothing
+end
+
+"""
+    _drain_expired_time_entries!(state, now_ns)
+
+Remove all expired time entries from the heap and dispatch them to their
+deadline or timer fire path.
+
+The heap lock is not held across fire callbacks. That keeps the critical
+section small and avoids lock-ordering problems with descriptor-local locks in
+`IOPoll`.
+"""
+function _drain_expired_time_entries!(state::Poller, now_ns::Int64)
+    expired = TimeEntry[]
     lock(state.lock)
     try
         while true
-            entry = _timer_peek_locked(state)
+            entry = _time_peek_locked(state)
             (entry === nothing || entry.deadline_ns > now_ns) && break
-            push!(expired, _timer_pop_locked!(state))
+            push!(expired, _time_pop_locked!(state))
         end
     finally
         unlock(state.lock)
     end
     for entry in expired
-        _timer_fire!(entry.timer, entry.seq)
+        _fire_time_entry!(entry)
     end
     return nothing
 end
@@ -1051,9 +979,10 @@ function _notify_all_waiters!(state::Poller)
     lock(state.lock)
     try
         append!(registrations, values(state.registrations))
-        _discard_stale_timers_locked!(state)
-        for entry in state.timer_heap
-            push!(timers, entry.timer)
+        _discard_stale_time_entries_locked!(state)
+        for entry in state.time_heap
+            entry.kind == TimeEntryKind.TIMER || continue
+            push!(timers, entry.timer::TimerState)
         end
     finally
         unlock(state.lock)
@@ -1072,8 +1001,7 @@ function _poller_thread_main!(state::Poller)
         delay_ns = _poll_delay_ns(state)
         errno = _backend_poll_once!(state, delay_ns)
         @atomic :release state.poll_until_ns = Int64(0)
-        _drain_expired_deadlines!(state, Int64(time_ns()))
-        _drain_expired_timers!(state, Int64(time_ns()))
+        _drain_expired_time_entries!(state, Int64(time_ns()))
         errno == Int32(0) && continue
         if errno == Int32(Base.Libc.EINTR)
             continue

--- a/src/1_eventloops.jl
+++ b/src/1_eventloops.jl
@@ -106,7 +106,7 @@ function pollwait!(waiter::PollWaiter)::PollWakeReason.T
         # Fast path: transition directly from EMPTY -> WAITING and park.
         state, ok = @atomicreplace(waiter.state, PollWaiterState.EMPTY => PollWaiterState.WAITING)
         if ok
-            _ = wait()::PollWakeReason.T
+            wait()
         else
             state == PollWaiterState.NOTIFIED || throw(ArgumentError("concurrent wait on PollWaiter"))
         end
@@ -118,7 +118,7 @@ function pollwait!(waiter::PollWaiter)::PollWakeReason.T
             ok && return @atomic :acquire waiter.reason
             state == PollWaiterState.EMPTY && return @atomic :acquire waiter.reason
             state == PollWaiterState.WAITING || throw(ArgumentError("invalid PollWaiter state"))
-            _ = wait()::PollWakeReason.T
+            wait()
         end
     finally
         waiter.task = nothing
@@ -161,7 +161,7 @@ function pollnotify!(waiter::PollWaiter, reason::PollWakeReason.T = PollWakeReas
             task = waiter.task
             task isa Task || throw(ArgumentError("invalid PollWaiter task state"))
             # `schedule(task)` is the low-level dual of the `wait()` above.
-            schedule(task, reason)
+            schedule(task)
             return true
         end
         state == PollWaiterState.EMPTY || throw(ArgumentError("invalid PollWaiter state"))

--- a/src/1_eventloops.jl
+++ b/src/1_eventloops.jl
@@ -52,6 +52,25 @@ mutable struct PollWaiter
 end
 
 """
+    SleepState
+
+One-shot task sleep state managed by the poller.
+
+Unlike fd deadlines, a sleep does not belong to a descriptor registration. It is
+just a latched `PollWaiter` plus a sequence word so stale heap entries can be
+discarded if the sleep is canceled or the state is ever reused.
+"""
+mutable struct SleepState
+    waiter::PollWaiter
+    @atomic seq::UInt64
+    @atomic fired::Bool
+    @atomic canceled::Bool
+    function SleepState()
+        return new(PollWaiter(), UInt64(1), false, false)
+    end
+end
+
+"""
     pollwait!(waiter)
 
 Park the current Julia task until the waiter is notified.
@@ -233,6 +252,21 @@ struct DeadlineEntry
 end
 
 """
+    SleepEntry
+
+One scheduled one-shot sleep in the poller min-heap.
+
+The sequence number mirrors `DeadlineEntry`'s stale-entry strategy: if a sleep
+state is canceled, completed, or ever reused, old heap entries are ignored when
+they rise to the top.
+"""
+struct SleepEntry
+    deadline_ns::Int64
+    sleepstate::SleepState
+    seq::UInt64
+end
+
+"""
     Poller
 
 Global event loop subsystem state. `lock` is a regular mutex because registration
@@ -251,6 +285,7 @@ mutable struct Poller
     registrations::Dict{Cint, Registration}
     registrations_by_token::Dict{UInt64, Registration}
     deadline_heap::Vector{DeadlineEntry}
+    sleep_heap::Vector{SleepEntry}
     shutdown_event::Base.Threads.Event
     kq::Cint
     wake_ident::UInt
@@ -267,6 +302,7 @@ function Poller()
         Dict{Cint, Registration}(),
         Dict{UInt64, Registration}(),
         DeadlineEntry[],
+        SleepEntry[],
         Base.Threads.Event(),
         Cint(-1),
         UInt(1),
@@ -319,6 +355,13 @@ end
 
 function deadline_fire! end
 
+@inline function _sleep_less(a::SleepEntry, b::SleepEntry)::Bool
+    if a.deadline_ns != b.deadline_ns
+        return a.deadline_ns < b.deadline_ns
+    end
+    return a.seq < b.seq
+end
+
 @inline function _deadline_less(a::DeadlineEntry, b::DeadlineEntry)::Bool
     if a.deadline_ns != b.deadline_ns
         return a.deadline_ns < b.deadline_ns
@@ -346,11 +389,26 @@ function _deadline_swap!(heap::Vector{DeadlineEntry}, i::Int, j::Int)
     return nothing
 end
 
+function _sleep_swap!(heap::Vector{SleepEntry}, i::Int, j::Int)
+    heap[i], heap[j] = heap[j], heap[i]
+    return nothing
+end
+
 function _deadline_sift_up!(heap::Vector{DeadlineEntry}, i::Int)
     while i > 1
         parent = _heap_parent_index(i)
         _deadline_less(heap[i], heap[parent]) || break
         _deadline_swap!(heap, i, parent)
+        i = parent
+    end
+    return nothing
+end
+
+function _sleep_sift_up!(heap::Vector{SleepEntry}, i::Int)
+    while i > 1
+        parent = _heap_parent_index(i)
+        _sleep_less(heap[i], heap[parent]) || break
+        _sleep_swap!(heap, i, parent)
         i = parent
     end
     return nothing
@@ -373,10 +431,34 @@ function _deadline_sift_down!(heap::Vector{DeadlineEntry}, i::Int)
     return nothing
 end
 
+function _sleep_sift_down!(heap::Vector{SleepEntry}, i::Int)
+    len = length(heap)
+    while true
+        left = _heap_left_index(i)
+        left > len && break
+        smallest = left
+        right = _heap_right_index(i)
+        if right <= len && _sleep_less(heap[right], heap[left])
+            smallest = right
+        end
+        _sleep_less(heap[smallest], heap[i]) || break
+        _sleep_swap!(heap, i, smallest)
+        i = smallest
+    end
+    return nothing
+end
+
 function _deadline_push_locked!(state::Poller, entry::DeadlineEntry)
     heap = state.deadline_heap
     push!(heap, entry)
     _deadline_sift_up!(heap, length(heap))
+    return nothing
+end
+
+function _sleep_push_locked!(state::Poller, entry::SleepEntry)
+    heap = state.sleep_heap
+    push!(heap, entry)
+    _sleep_sift_up!(heap, length(heap))
     return nothing
 end
 
@@ -388,6 +470,18 @@ function _deadline_pop_locked!(state::Poller)::DeadlineEntry
     if !isempty(heap)
         heap[1] = last
         _deadline_sift_down!(heap, 1)
+    end
+    return entry
+end
+
+function _sleep_pop_locked!(state::Poller)::SleepEntry
+    heap = state.sleep_heap
+    isempty(heap) && throw(ArgumentError("sleep heap is empty"))
+    entry = heap[1]
+    last = pop!(heap)
+    if !isempty(heap)
+        heap[1] = last
+        _sleep_sift_down!(heap, 1)
     end
     return entry
 end
@@ -408,10 +502,43 @@ function _discard_stale_deadlines_locked!(state::Poller)
     return nothing
 end
 
+@inline function _sleep_entry_live(entry::SleepEntry)::Bool
+    sleepstate = entry.sleepstate
+    (@atomic :acquire sleepstate.seq) == entry.seq || return false
+    (@atomic :acquire sleepstate.fired) && return false
+    (@atomic :acquire sleepstate.canceled) && return false
+    return true
+end
+
+function _discard_stale_sleeps_locked!(state::Poller)
+    while !isempty(state.sleep_heap)
+        entry = state.sleep_heap[1]
+        _sleep_entry_live(entry) && return nothing
+        _ = _sleep_pop_locked!(state)
+    end
+    return nothing
+end
+
 function _deadline_peek_locked(state::Poller)
     _discard_stale_deadlines_locked!(state)
     isempty(state.deadline_heap) && return nothing
     return state.deadline_heap[1]
+end
+
+function _sleep_peek_locked(state::Poller)
+    _discard_stale_sleeps_locked!(state)
+    isempty(state.sleep_heap) && return nothing
+    return state.sleep_heap[1]
+end
+
+@inline function _maybe_wake_for_earlier_deadline!(state::Poller, new_earliest::Int64)
+    new_earliest > 0 || return nothing
+    poll_until_ns = @atomic :acquire state.poll_until_ns
+    if poll_until_ns == 0 || new_earliest < poll_until_ns
+        errno = _backend_wake!(state)
+        errno == Int32(0) || _throw_errno("event loop wake", errno)
+    end
+    return nothing
 end
 
 function _build_deadline_entries(
@@ -473,17 +600,37 @@ function schedule_deadlines!(
     finally
         unlock(state.lock)
     end
-    if new_earliest > 0
-        poll_until_ns = @atomic :acquire state.poll_until_ns
-        # This is the local equivalent of Go's `netpollBreak()`: once the
-        # poller has committed to a sleep horizon, a newly earlier deadline must
-        # actively wake it so the blocking syscall can be retried with a
-        # shorter timeout.
-        if poll_until_ns == 0 || new_earliest < poll_until_ns
-            errno = _backend_wake!(state)
-            errno == Int32(0) || _throw_errno("event loop wake", errno)
-        end
+    # This is the local equivalent of Go's `netpollBreak()`: once the poller
+    # has committed to a sleep horizon, a newly earlier wakeup must actively
+    # wake it so the blocking syscall can be retried with a shorter timeout.
+    _maybe_wake_for_earlier_deadline!(state, new_earliest)
+    return nothing
+end
+
+"""
+    schedule_sleep!(sleepstate, deadline_ns)
+
+Publish one one-shot sleep wakeup into the poller heap.
+
+`deadline_ns` is an absolute monotonic `time_ns()`-style timestamp.
+"""
+function schedule_sleep!(sleepstate::SleepState, deadline_ns::Int64)
+    isassigned(POLLER) || return nothing
+    state = POLLER[]
+    (@atomic :acquire state.running) || return nothing
+    new_earliest = Int64(0)
+    seq = @atomic :acquire sleepstate.seq
+    @atomic :release sleepstate.fired = false
+    @atomic :release sleepstate.canceled = false
+    lock(state.lock)
+    try
+        entry = SleepEntry(deadline_ns, sleepstate, seq)
+        _sleep_push_locked!(state, entry)
+        new_earliest = entry.deadline_ns
+    finally
+        unlock(state.lock)
     end
+    _maybe_wake_for_earlier_deadline!(state, new_earliest)
     return nothing
 end
 
@@ -502,8 +649,17 @@ function _poll_delay_ns(state::Poller)::Int64
     deadline_ns = Int64(0)
     lock(state.lock)
     try
-        entry = _deadline_peek_locked(state)
-        deadline_ns = entry === nothing ? Int64(0) : entry.deadline_ns
+        deadline_entry = _deadline_peek_locked(state)
+        sleep_entry = _sleep_peek_locked(state)
+        fd_deadline_ns = deadline_entry === nothing ? Int64(0) : deadline_entry.deadline_ns
+        sleep_deadline_ns = sleep_entry === nothing ? Int64(0) : sleep_entry.deadline_ns
+        if fd_deadline_ns == 0
+            deadline_ns = sleep_deadline_ns
+        elseif sleep_deadline_ns == 0
+            deadline_ns = fd_deadline_ns
+        else
+            deadline_ns = min(fd_deadline_ns, sleep_deadline_ns)
+        end
         @atomic :release state.poll_until_ns = deadline_ns
     finally
         unlock(state.lock)
@@ -539,6 +695,38 @@ function _drain_expired_deadlines!(state::Poller, now_ns::Int64)
     end
     for entry in expired
         deadline_fire!(entry.pollstate, entry.mode, entry.rseq, entry.wseq)
+    end
+    return nothing
+end
+
+function _cancel_sleep!(sleepstate::SleepState)
+    @atomic :release sleepstate.canceled = true
+    pollnotify!(sleepstate.waiter)
+    return nothing
+end
+
+function _sleep_fire!(sleepstate::SleepState, seq::UInt64)
+    (@atomic :acquire sleepstate.seq) == seq || return nothing
+    (@atomic :acquire sleepstate.canceled) && return nothing
+    @atomic :release sleepstate.fired = true
+    pollnotify!(sleepstate.waiter)
+    return nothing
+end
+
+function _drain_expired_sleeps!(state::Poller, now_ns::Int64)
+    expired = SleepEntry[]
+    lock(state.lock)
+    try
+        while true
+            entry = _sleep_peek_locked(state)
+            (entry === nothing || entry.deadline_ns > now_ns) && break
+            push!(expired, _sleep_pop_locked!(state))
+        end
+    finally
+        unlock(state.lock)
+    end
+    for entry in expired
+        _sleep_fire!(entry.sleepstate, entry.seq)
     end
     return nothing
 end
@@ -820,14 +1008,22 @@ end
 
 function _notify_all_waiters!(state::Poller)
     registrations = Registration[]
+    sleeps = SleepState[]
     lock(state.lock)
     try
         append!(registrations, values(state.registrations))
+        _discard_stale_sleeps_locked!(state)
+        for entry in state.sleep_heap
+            push!(sleeps, entry.sleepstate)
+        end
     finally
         unlock(state.lock)
     end
     for registration in registrations
         _notify_registration!(registration, PollMode.READWRITE)
+    end
+    for sleepstate in sleeps
+        _cancel_sleep!(sleepstate)
     end
     return nothing
 end
@@ -838,6 +1034,7 @@ function _poller_thread_main!(state::Poller)
         errno = _backend_poll_once!(state, delay_ns)
         @atomic :release state.poll_until_ns = Int64(0)
         _drain_expired_deadlines!(state, Int64(time_ns()))
+        _drain_expired_sleeps!(state, Int64(time_ns()))
         errno == Int32(0) && continue
         if errno == Int32(Base.Libc.EINTR)
             continue
@@ -847,6 +1044,69 @@ function _poller_thread_main!(state::Poller)
     end
     notify(state.shutdown_event)
     return nothing
+end
+
+"""
+    sleep_until_ns(deadline_ns)
+
+Block the current Julia task until the monotonic `time_ns()` deadline is
+reached, or until the poller is shut down.
+"""
+function sleep_until_ns(deadline_ns::Integer)
+    target_ns = Int64(deadline_ns)
+    target_ns <= Int64(time_ns()) && return nothing
+    state = init!()
+    (@atomic :acquire state.running) || return nothing
+    sleepstate = SleepState()
+    schedule_sleep!(sleepstate, target_ns)
+    while true
+        pollwait!(sleepstate.waiter)
+        (@atomic :acquire sleepstate.fired) && return nothing
+        (@atomic :acquire sleepstate.canceled) && return nothing
+    end
+end
+
+"""
+    sleep_ns(delay_ns)
+
+Block the current Julia task for `delay_ns` nanoseconds using the poller-owned
+sleep heap.
+"""
+function sleep_ns(delay_ns::Integer)
+    delay = Int64(delay_ns)
+    delay <= 0 && return nothing
+    return sleep_until_ns(Int64(time_ns()) + delay)
+end
+
+"""
+    sleep(seconds)
+
+Block the current Julia task for `seconds` wall-clock seconds using the
+poller-owned sleep heap.
+"""
+function sleep(sec::Real)
+    sec >= 0 || throw(ArgumentError("cannot sleep for $sec seconds"))
+    return sleep_ns(ceil(Int64, sec * 1.0e9))
+end
+
+"""
+    timedwait(testcb, timeout_s; pollint=0.1)
+
+Poll `testcb()` until it returns `true` or `timeout_s` seconds elapse.
+"""
+function timedwait(testcb, timeout_s::Real; pollint::Real = 0.1)
+    pollint >= 1.0e-3 || throw(ArgumentError("pollint must be ≥ 1 millisecond"))
+    start_ns = Int64(time_ns())
+    timeout_ns = ceil(Int64, timeout_s * 1.0e9)
+    testcb() && return :ok
+    step_ns = ceil(Int64, pollint * 1.0e9)
+    while true
+        elapsed_ns = Int64(time_ns()) - start_ns
+        elapsed_ns > timeout_ns && return :timed_out
+        remaining_ns = timeout_ns - elapsed_ns
+        sleep_ns(min(step_ns, remaining_ns))
+        testcb() && return :ok
+    end
 end
 
 function _poller_thread_entry(arg::Ptr{Cvoid})::Ptr{Cvoid}

--- a/src/1_eventloops.jl
+++ b/src/1_eventloops.jl
@@ -37,6 +37,11 @@ end
     NOTIFIED = 0x02
 end
 
+@enumx PollWakeReason::UInt8 begin
+    READY = 0x01
+    CANCELED = 0x02
+end
+
 """
     PollWaiter
 
@@ -50,9 +55,10 @@ read waiter slot and one write waiter slot per descriptor.
 """
 mutable struct PollWaiter
     @atomic state::PollWaiterState.T
+    @atomic reason::PollWakeReason.T
     task::Union{Nothing, Task}
     function PollWaiter()
-        return new(PollWaiterState.EMPTY, nothing)
+        return new(PollWaiterState.EMPTY, PollWakeReason.READY, nothing)
     end
 end
 
@@ -87,12 +93,12 @@ end
 Park the current Julia task until the waiter is notified.
 Concurrent waits on the same `PollWaiter` are forbidden.
 
-Returns `nothing`.
+Returns the `PollWakeReason` that woke the waiter.
 
 Throws `ArgumentError` if two tasks try to wait on the same waiter
 simultaneously, or if the waiter state machine is observed in an invalid state.
 """
-function pollwait!(waiter::PollWaiter)
+function pollwait!(waiter::PollWaiter)::PollWakeReason.T
     task = current_task()
     task.sticky && (task.sticky = false)
     waiter.task = task
@@ -100,7 +106,7 @@ function pollwait!(waiter::PollWaiter)
         # Fast path: transition directly from EMPTY -> WAITING and park.
         state, ok = @atomicreplace(waiter.state, PollWaiterState.EMPTY => PollWaiterState.WAITING)
         if ok
-            wait()
+            _ = wait()::PollWakeReason.T
         else
             state == PollWaiterState.NOTIFIED || throw(ArgumentError("concurrent wait on PollWaiter"))
         end
@@ -109,10 +115,10 @@ function pollwait!(waiter::PollWaiter)
             # we loop until the NOTIFIED token is consumed or a clean EMPTY
             # state is observed.
             state, ok = @atomicreplace(waiter.state, PollWaiterState.NOTIFIED => PollWaiterState.EMPTY)
-            ok && return nothing
-            state == PollWaiterState.EMPTY && return nothing
+            ok && return @atomic :acquire waiter.reason
+            state == PollWaiterState.EMPTY && return @atomic :acquire waiter.reason
             state == PollWaiterState.WAITING || throw(ArgumentError("invalid PollWaiter state"))
-            wait()
+            _ = wait()::PollWakeReason.T
         end
     finally
         waiter.task = nothing
@@ -120,31 +126,47 @@ function pollwait!(waiter::PollWaiter)
 end
 
 """
-    pollnotify!(waiter)
+    pollnotify!(waiter, reason=PollWakeReason.READY)
 
 Mark waiter as notified and wake the waiter task if it has already parked.
 Returns `true` if a parked waiter was woken and `false` if the waiter was
-already notified or had not yet parked.
+already notified or had not yet parked. `PollWakeReason.READY` dominates a
+pending `PollWakeReason.CANCELED`, which matches Go's "ready beats cancel"
+behavior once readiness has already been latched.
 
 Throws `ArgumentError` if the waiter state machine is observed in an invalid
 state.
 """
-function pollnotify!(waiter::PollWaiter)::Bool
+@inline function _merge_wake_reason(
+        current::PollWakeReason.T,
+        incoming::PollWakeReason.T,
+    )::PollWakeReason.T
+    return current == PollWakeReason.READY ? current : incoming
+end
+
+function pollnotify!(waiter::PollWaiter, reason::PollWakeReason.T = PollWakeReason.READY)::Bool
     state = @atomic :acquire waiter.state
-    while state != PollWaiterState.NOTIFIED
+    while true
+        if state == PollWaiterState.NOTIFIED
+            current = @atomic :acquire waiter.reason
+            merged = _merge_wake_reason(current, reason)
+            merged == current && return false
+            @atomic :release waiter.reason = merged
+            return false
+        end
         state, ok = @atomicreplace(waiter.state, state => PollWaiterState.NOTIFIED)
         ok || continue
+        @atomic :release waiter.reason = reason
         if state == PollWaiterState.WAITING
             task = waiter.task
             task isa Task || throw(ArgumentError("invalid PollWaiter task state"))
             # `schedule(task)` is the low-level dual of the `wait()` above.
-            schedule(task)
+            schedule(task, reason)
             return true
         end
         state == PollWaiterState.EMPTY || throw(ArgumentError("invalid PollWaiter state"))
         return false
     end
-    return false
 end
 
 """
@@ -639,7 +661,7 @@ function _close_timer!(timer::TimerState)
     finally
         unlock(timer.lock)
     end
-    pollnotify!(timer.waiter)
+    pollnotify!(timer.waiter, PollWakeReason.CANCELED)
     return nothing
 end
 
@@ -652,7 +674,7 @@ function _timer_fire!(timer::TimerState, seq::UInt64)
     finally
         unlock(timer.lock)
     end
-    pollnotify!(timer.waiter)
+    pollnotify!(timer.waiter, PollWakeReason.READY)
     return nothing
 end
 
@@ -725,12 +747,16 @@ function current_registration(pd::PollState)
     end
 end
 
-function _notify_registration!(registration::Registration, mode::PollMode.T)
+function _notify_registration!(
+        registration::Registration,
+        mode::PollMode.T,
+        reason::PollWakeReason.T = PollWakeReason.READY,
+    )
     if _mode_has_read(mode) && _mode_has_read(registration.mode)
-        pollnotify!(registration.read_waiter)
+        pollnotify!(registration.read_waiter, reason)
     end
     if _mode_has_write(mode) && _mode_has_write(registration.mode)
-        pollnotify!(registration.write_waiter)
+        pollnotify!(registration.write_waiter, reason)
     end
     return nothing
 end
@@ -835,7 +861,7 @@ function shutdown!()
         unlock(state.lock)
     end
     for registration in registrations
-        _notify_registration!(registration, PollMode.READWRITE)
+        _notify_registration!(registration, PollMode.READWRITE, PollWakeReason.CANCELED)
     end
     if stop_requested
         wake_errno = _backend_wake!(state)
@@ -919,7 +945,7 @@ function deregister!(fd::Integer)
     finally
         unlock(state.lock)
     end
-    registration === nothing || _notify_registration!(registration::Registration, PollMode.READWRITE)
+    registration === nothing || _notify_registration!(registration::Registration, PollMode.READWRITE, PollWakeReason.CANCELED)
     errno == Int32(0) || _throw_errno("event loop deregister", errno)
     return nothing
 end
@@ -969,7 +995,7 @@ function _dispatch_ready_event!(state::Poller, event::PollEvent)
     finally
         unlock(state.lock)
     end
-    _notify_registration!(registration::Registration, event.mode)
+    _notify_registration!(registration::Registration, event.mode, PollWakeReason.READY)
     return nothing
 end
 
@@ -988,7 +1014,7 @@ function _notify_all_waiters!(state::Poller)
         unlock(state.lock)
     end
     for registration in registrations
-        _notify_registration!(registration, PollMode.READWRITE)
+        _notify_registration!(registration, PollMode.READWRITE, PollWakeReason.CANCELED)
     end
     for timer in timers
         _close_timer!(timer)
@@ -1027,7 +1053,8 @@ function sleep_until_ns(deadline_ns::Integer)
     timer = TimerState(target_ns, Int64(0))
     schedule_timer!(timer, target_ns) || return nothing
     while true
-        pollwait!(timer.waiter)
+        reason = pollwait!(timer.waiter)
+        reason == PollWakeReason.READY && return nothing
         (@atomic :acquire timer.closed) && return nothing
         (@atomic :acquire timer.deadline_ns) == 0 && return nothing
     end

--- a/src/3_internal_poll.jl
+++ b/src/3_internal_poll.jl
@@ -437,7 +437,7 @@ function _wake_waiters!(pd::PollState, mode::PollOp.T)
     elseif mode == PollOp.WRITE
         event_mode = EventLoops.PollMode.WRITE
     end
-    EventLoops._notify_registration!(registration, event_mode)
+    EventLoops._notify_registration!(registration, event_mode, EventLoops.PollWakeReason.CANCELED)
     return nothing
 end
 
@@ -685,7 +685,8 @@ function prepare_write!(pd::PollState, is_file::Bool = false)
 end
 
 """
-Block until read readiness, then re-check for close/timeout/not-pollable errors.
+Block until read readiness, retrying internally if a canceled wake becomes
+stale before the waiter task resumes.
 
 Returns `nothing`.
 
@@ -696,28 +697,37 @@ Throws:
 - `NotPollableError` if the backend reports a permanent readiness error
 """
 function wait_read!(pd::PollState, is_file::Bool = false)
-    _convert_poll_error!(_check_error(pd, PollOp.READ), is_file)
-    pollable(pd) || throw(ArgumentError("waiting for unsupported file type"))
-    registration = _poll_registration(pd)
-    EventLoops.arm_waiter!(registration, EventLoops.PollMode.READ)
-    EventLoops.pollwait!(registration.read_waiter)
-    _convert_poll_error!(_check_error(pd, PollOp.READ), is_file)
-    return nothing
+    while true
+        _convert_poll_error!(_check_error(pd, PollOp.READ), is_file)
+        pollable(pd) || throw(ArgumentError("waiting for unsupported file type"))
+        registration = _poll_registration(pd)
+        EventLoops.arm_waiter!(registration, EventLoops.PollMode.READ)
+        reason = EventLoops.pollwait!(registration.read_waiter)
+        reason == EventLoops.PollWakeReason.READY && return nothing
+        err = _check_error(pd, PollOp.READ)
+        err == _POLL_NO_ERROR && continue
+        _convert_poll_error!(err, is_file)
+    end
 end
 
 """
-Block until write readiness, then re-check for close/timeout/not-pollable errors.
+Block until write readiness, retrying internally if a canceled wake becomes
+stale before the waiter task resumes.
 
 Returns `nothing`.
 """
 function wait_write!(pd::PollState, is_file::Bool = false)
-    _convert_poll_error!(_check_error(pd, PollOp.WRITE), is_file)
-    pollable(pd) || throw(ArgumentError("waiting for unsupported file type"))
-    registration = _poll_registration(pd)
-    EventLoops.arm_waiter!(registration, EventLoops.PollMode.WRITE)
-    EventLoops.pollwait!(registration.write_waiter)
-    _convert_poll_error!(_check_error(pd, PollOp.WRITE), is_file)
-    return nothing
+    while true
+        _convert_poll_error!(_check_error(pd, PollOp.WRITE), is_file)
+        pollable(pd) || throw(ArgumentError("waiting for unsupported file type"))
+        registration = _poll_registration(pd)
+        EventLoops.arm_waiter!(registration, EventLoops.PollMode.WRITE)
+        reason = EventLoops.pollwait!(registration.write_waiter)
+        reason == EventLoops.PollWakeReason.READY && return nothing
+        err = _check_error(pd, PollOp.WRITE)
+        err == _POLL_NO_ERROR && continue
+        _convert_poll_error!(err, is_file)
+    end
 end
 
 """

--- a/src/7_5_http2_server.jl
+++ b/src/7_5_http2_server.jl
@@ -7,6 +7,7 @@ export shutdown_h2_server!
 using ..Reseau.TCP
 using ..Reseau.HostResolvers
 using ..Reseau.IOPoll
+using ..Reseau.EventLoops
 
 """
     H2Server
@@ -440,6 +441,6 @@ function shutdown_h2_server!(server::H2Server; force::Bool = true)
     finally
         unlock(server.lock)
     end
-    task === nothing || timedwait(() -> istaskdone(task::Task), 3.0; pollint = 0.001)
+    task === nothing || EventLoops.timedwait(() -> istaskdone(task::Task), 3.0; pollint = 0.001)
     return nothing
 end

--- a/src/7_7_http_server.jl
+++ b/src/7_7_http_server.jl
@@ -9,6 +9,7 @@ export shutdown!
 using ..Reseau.TCP
 using ..Reseau.HostResolvers
 using ..Reseau.IOPoll
+using ..Reseau.EventLoops
 
 """
     Server
@@ -355,7 +356,7 @@ function _close_listener_with_timeout!(listener::TCP.Listener; timeout_s::Float6
         end
         return nothing
     end)
-    _ = timedwait(() -> istaskdone(task), timeout_s; pollint = 0.001)
+    _ = EventLoops.timedwait(() -> istaskdone(task), timeout_s; pollint = 0.001)
     return nothing
 end
 
@@ -367,7 +368,7 @@ function _force_close_conn_with_timeout!(conn::TCP.Conn; timeout_s::Float64 = 1.
         end
         return nothing
     end)
-    _ = timedwait(() -> istaskdone(task), timeout_s; pollint = 0.001)
+    _ = EventLoops.timedwait(() -> istaskdone(task), timeout_s; pollint = 0.001)
     return nothing
 end
 
@@ -394,7 +395,7 @@ function shutdown!(server::Server; force::Bool = false, timeout_s::Float64 = 5.0
         unlock(server.lock)
     end
     if task !== nothing
-        _ = timedwait(() -> istaskdone(task::Task), timeout_s; pollint = 0.001)
+        _ = EventLoops.timedwait(() -> istaskdone(task::Task), timeout_s; pollint = 0.001)
     end
     conns = TCP.Conn[]
     tasks = Task[]
@@ -417,7 +418,7 @@ function shutdown!(server::Server; force::Bool = false, timeout_s::Float64 = 5.0
     for task_item in tasks
         remaining = deadline - time()
         remaining <= 0 && break
-        _ = timedwait(() -> istaskdone(task_item), remaining; pollint = 0.001)
+        _ = EventLoops.timedwait(() -> istaskdone(task_item), remaining; pollint = 0.001)
     end
     return nothing
 end

--- a/src/8_precompile_workload.jl
+++ b/src/8_precompile_workload.jl
@@ -325,7 +325,7 @@ function _pc_run_tls_workload!()
             min_version = client_cfg.min_version,
             max_version = client_cfg.max_version,
         )
-        status = timedwait(() -> istaskdone(accept_task), 2.0; pollint = 0.001)
+        status = EL.timedwait(() -> istaskdone(accept_task), 2.0; pollint = 0.001)
         status == :timed_out && throw(ArgumentError("TLS precompile workload timed out during accept"))
         server = fetch(accept_task)
         payload = UInt8[0x54, 0x4c, 0x53]
@@ -428,7 +428,7 @@ function _pc_run_http_transport_workload!()
         body_buf = Vector{UInt8}(undef, 2)
         read_n = HT.body_read!(response.body, body_buf)
         read_n == 2 || throw(ArgumentError("HTTP transport precompile workload expected two-byte response body"))
-        status = timedwait(() -> istaskdone(server_task::Task), 2.0; pollint = 0.001)
+        status = EL.timedwait(() -> istaskdone(server_task::Task), 2.0; pollint = 0.001)
         status == :timed_out && throw(ArgumentError("HTTP transport precompile workload timed out waiting for server task"))
         accepted = fetch(server_task::Task)
     finally
@@ -482,7 +482,7 @@ function _pc_run_http_client_workload!()
         body_buf = Vector{UInt8}(undef, 2)
         read_n = HT.body_read!(response.body, body_buf)
         read_n == 2 || throw(ArgumentError("HTTP client precompile workload expected two-byte response body"))
-        status = timedwait(() -> istaskdone(server_task::Task), 2.0; pollint = 0.001)
+        status = EL.timedwait(() -> istaskdone(server_task::Task), 2.0; pollint = 0.001)
         status == :timed_out && throw(ArgumentError("HTTP client precompile workload timed out waiting for server task"))
         fetch(server_task::Task)
     finally
@@ -517,7 +517,7 @@ function _pc_run_http_server_workload!()
             try
                 address = HT.server_addr(server)
             catch
-                sleep(0.01)
+                EL.sleep(0.01)
             end
         end
         address === nothing && throw(ArgumentError("HTTP server precompile workload timed out waiting for address"))
@@ -535,7 +535,7 @@ function _pc_run_http_server_workload!()
             client === nothing || close(client.transport)
         catch
         end
-        status = timedwait(() -> istaskdone(task), 2.0; pollint = 0.001)
+        status = EL.timedwait(() -> istaskdone(task), 2.0; pollint = 0.001)
         status == :timed_out || fetch(task)
     end
     return nothing
@@ -620,7 +620,7 @@ function _pc_run_http2_client_workload!()
         request = HT.Request("GET", "/ready"; host = address, body = HT.EmptyBody(), content_length = 0)
         response = HT.h2_roundtrip!(conn::HT.H2Connection, request)
         response.status_code == 200 || throw(ArgumentError("HTTP/2 client precompile workload expected status 200"))
-        status = timedwait(() -> istaskdone(server_task::Task), 2.0; pollint = 0.001)
+        status = EL.timedwait(() -> istaskdone(server_task::Task), 2.0; pollint = 0.001)
         status == :timed_out && throw(ArgumentError("HTTP/2 client precompile workload timed out waiting for server task"))
         fetch(server_task::Task)
     finally
@@ -655,7 +655,7 @@ function _pc_run_http2_server_workload!()
             try
                 address = HT.h2_server_addr(server)
             catch
-                sleep(0.01)
+                EL.sleep(0.01)
             end
         end
         address === nothing && throw(ArgumentError("HTTP/2 server precompile workload timed out waiting for address"))
@@ -672,7 +672,7 @@ function _pc_run_http2_server_workload!()
             HT.shutdown_h2_server!(server)
         catch
         end
-        _ = timedwait(() -> istaskdone(task), 2.0; pollint = 0.001)
+        _ = EL.timedwait(() -> istaskdone(task), 2.0; pollint = 0.001)
     end
     return nothing
 end
@@ -702,7 +702,7 @@ function _pc_run_http_unified_workload!()
             try
                 h1_address = HT.server_addr(h1_server)
             catch
-                sleep(0.01)
+                EL.sleep(0.01)
             end
         end
         h1_address === nothing && throw(ArgumentError("HTTP unified precompile workload timed out waiting for h1 address"))
@@ -722,7 +722,7 @@ function _pc_run_http_unified_workload!()
             try
                 h2_address = HT.h2_server_addr(h2_server::HT.H2Server)
             catch
-                sleep(0.01)
+                EL.sleep(0.01)
             end
         end
         h2_address === nothing && throw(ArgumentError("HTTP unified precompile workload timed out waiting for h2 address"))
@@ -737,7 +737,7 @@ function _pc_run_http_unified_workload!()
             HT.shutdown!(h1_server; force = true)
         catch
         end
-        _ = timedwait(() -> istaskdone(h1_task), 2.0; pollint = 0.001)
+        _ = EL.timedwait(() -> istaskdone(h1_task), 2.0; pollint = 0.001)
         try
             h2_client === nothing || close(h2_client::HT.Client)
         catch
@@ -749,7 +749,7 @@ function _pc_run_http_unified_workload!()
             end
         end
         if h2_task !== nothing
-            _ = timedwait(() -> istaskdone(h2_task::Task), 2.0; pollint = 0.001)
+            _ = EL.timedwait(() -> istaskdone(h2_task::Task), 2.0; pollint = 0.001)
         end
     end
     return nothing

--- a/test/eventloops_tests.jl
+++ b/test/eventloops_tests.jl
@@ -2,6 +2,7 @@ using Test
 using Reseau
 
 const NP = Reseau.EventLoops
+const EL = Reseau.EventLoops
 
 function _el_socketpair_stream()
     fds = Vector{Cint}(undef, 2)
@@ -42,6 +43,23 @@ if !(Sys.isapple() || Sys.islinux())
 else
     @testset "EventLoops kqueue phase 1" begin
         NP.shutdown!()
+        @testset "poller-backed sleep/timedwait" begin
+            t0 = time_ns()
+            EL.sleep(0.03)
+            elapsed_ns = time_ns() - t0
+            @test elapsed_ns >= 15_000_000
+            @test EL.timedwait(() -> false, 0.05; pollint = 0.001) == :timed_out
+            wake_ch = Channel{Nothing}(1)
+            wake_task = errormonitor(Threads.@spawn begin
+                EL.sleep(0.03)
+                put!(wake_ch, nothing)
+                return nothing
+            end)
+            status = EL.timedwait(() -> isready(wake_ch), 2.0; pollint = 0.001)
+            @test status != :timed_out
+            status == :timed_out || take!(wake_ch)
+            wait(wake_task)
+        end
         @testset "backend delay semantics" begin
             state = NP.Poller()
             errno = NP._backend_init!(state)

--- a/test/eventloops_tests.jl
+++ b/test/eventloops_tests.jl
@@ -60,6 +60,17 @@ else
             status == :timed_out || take!(wake_ch)
             wait(wake_task)
         end
+        @testset "pollwait wake reason precedence" begin
+            waiter = NP.PollWaiter()
+            @test !NP.pollnotify!(waiter, NP.PollWakeReason.CANCELED)
+            @test !NP.pollnotify!(waiter, NP.PollWakeReason.READY)
+            @test NP.pollwait!(waiter) == NP.PollWakeReason.READY
+
+            waiter = NP.PollWaiter()
+            @test !NP.pollnotify!(waiter, NP.PollWakeReason.READY)
+            @test !NP.pollnotify!(waiter, NP.PollWakeReason.CANCELED)
+            @test NP.pollwait!(waiter) == NP.PollWakeReason.READY
+        end
         @testset "backend delay semantics" begin
             state = NP.Poller()
             errno = NP._backend_init!(state)

--- a/test/internal_poll_tests.jl
+++ b/test/internal_poll_tests.jl
@@ -110,8 +110,8 @@ else
             combined = EL._build_deadline_entries(registration.pollstate, Int64(10), Int64(10), UInt64(3), UInt64(5))
             @test length(combined) == 1
             @test combined[1].mode == EL.PollMode.READWRITE
-            @test combined[1].rseq == UInt64(3)
-            @test combined[1].wseq == UInt64(5)
+            @test combined[1].primary_seq == UInt64(3)
+            @test combined[1].secondary_seq == UInt64(5)
             split = EL._build_deadline_entries(registration.pollstate, Int64(10), Int64(11), UInt64(3), UInt64(5))
             @test length(split) == 2
             @test split[1].mode == EL.PollMode.READ
@@ -129,7 +129,7 @@ else
                 IP.set_deadline!(ipfd, future_deadline)
                 lock(state.lock)
                 try
-                    entries = filter(x -> x.pollstate.token == ipfd.pd.token, state.deadline_heap)
+                    entries = filter(x -> x.kind == EL.TimeEntryKind.DEADLINE && (x.pollstate::EL.PollState).token == ipfd.pd.token, state.time_heap)
                     @test length(entries) == 1
                     @test entries[1].mode == EL.PollMode.READWRITE
                 finally

--- a/test/internal_poll_tests.jl
+++ b/test/internal_poll_tests.jl
@@ -44,10 +44,10 @@ else
                     n = IP.read!(ipfd, buf)
                     return n, buf[1]
                 end)
-                pre = timedwait(() -> istaskdone(read_task), 0.05; pollint = 0.001)
+                pre = EL.timedwait(() -> istaskdone(read_task), 0.05; pollint = 0.001)
                 @test pre == :timed_out
                 _ip_write_byte(fd1, 0x61)
-                status = timedwait(() -> istaskdone(read_task), 2.0; pollint = 0.001)
+                status = EL.timedwait(() -> istaskdone(read_task), 2.0; pollint = 0.001)
                 @test status != :timed_out
                 if status != :timed_out
                     n, b = fetch(read_task)
@@ -93,7 +93,7 @@ else
                 IP.init!(ipfd)
                 IP.set_read_deadline!(ipfd, time_ns() + 20_000_000)
                 IP.set_read_deadline!(ipfd, time_ns() + 5_000_000_000)
-                sleep(0.06)
+                EL.sleep(0.06)
                 _ip_write_byte(fd1, 0x63)
                 buf = Vector{UInt8}(undef, 1)
                 n = IP.read!(ipfd, buf)
@@ -136,7 +136,7 @@ else
                     unlock(state.lock)
                 end
                 IP.set_deadline!(ipfd, Int64(time_ns()) + Int64(30_000_000))
-                sleep(0.06)
+                EL.sleep(0.06)
                 @test IP._check_error(ipfd.pd, IP.PollOp.READ) == Int32(2)
                 @test IP._check_error(ipfd.pd, IP.PollOp.WRITE) == Int32(2)
                 IP.set_deadline!(ipfd, Int64(0))
@@ -164,10 +164,10 @@ else
                         return err
                     end
                 end)
-                pre = timedwait(() -> istaskdone(read_task), 0.05; pollint = 0.001)
+                pre = EL.timedwait(() -> istaskdone(read_task), 0.05; pollint = 0.001)
                 @test pre == :timed_out
                 IP.close!(ipfd)
-                status = timedwait(() -> istaskdone(read_task), 2.0; pollint = 0.001)
+                status = EL.timedwait(() -> istaskdone(read_task), 2.0; pollint = 0.001)
                 @test status != :timed_out
                 if status != :timed_out
                     err = fetch(read_task)
@@ -207,10 +207,10 @@ else
                     IP.wait_canceled!(ipfd.pd, IP.PollOp.READ)
                     return :ok
                 end)
-                pre = timedwait(() -> istaskdone(wait_task), 0.05; pollint = 0.001)
+                pre = EL.timedwait(() -> istaskdone(wait_task), 0.05; pollint = 0.001)
                 @test pre == :timed_out
                 _ip_write_byte(fd1, 0x71)
-                status = timedwait(() -> istaskdone(wait_task), 2.0; pollint = 0.001)
+                status = EL.timedwait(() -> istaskdone(wait_task), 2.0; pollint = 0.001)
                 @test status != :timed_out
                 if status != :timed_out
                     @test fetch(wait_task) == :ok
@@ -228,12 +228,12 @@ else
             mu = IP.FDLock()
             @test IP._fdlock_rwlock!(mu, true, true)
             waiters = [errormonitor(Threads.@spawn IP._fdlock_rwlock!(mu, true, true)) for _ in 1:32]
-            pre = timedwait(() -> all(istaskdone, waiters), 0.05; pollint = 0.001)
+            pre = EL.timedwait(() -> all(istaskdone, waiters), 0.05; pollint = 0.001)
             @test pre == :timed_out
             @test IP._fdlock_incref_and_close!(mu)
             _ = IP._fdlock_rwunlock!(mu, true)
             for waiter in waiters
-                status = timedwait(() -> istaskdone(waiter), 2.0; pollint = 0.001)
+                status = EL.timedwait(() -> istaskdone(waiter), 2.0; pollint = 0.001)
                 @test status != :timed_out
                 if status != :timed_out
                     @test fetch(waiter) == false

--- a/test/internal_poll_tests.jl
+++ b/test/internal_poll_tests.jl
@@ -105,6 +105,38 @@ else
                 EL.shutdown!()
             end
         end
+        @testset "wait_read retries stale canceled wake internally" begin
+            fd0, fd1 = _ip_socketpair_stream()
+            ipfd = IP.FD(fd0)
+            wait_task = nothing
+            fd0 = Cint(-1)
+            try
+                IP._set_nonblocking!(ipfd.sysfd)
+                IP.init!(ipfd)
+                IP.set_read_deadline!(ipfd, time_ns() + 20_000_000)
+                wait_task = errormonitor(Threads.@spawn begin
+                    IP.wait_read!(ipfd.pd, ipfd.is_file)
+                    return :ok
+                end)
+                pre = EL.timedwait(() -> istaskdone(wait_task), 0.01; pollint = 0.001)
+                @test pre == :timed_out
+                IP.set_read_deadline!(ipfd, time_ns() + 5_000_000_000)
+                EL.sleep(0.06)
+                stale = EL.timedwait(() -> istaskdone(wait_task), 0.02; pollint = 0.001)
+                @test stale == :timed_out
+                _ip_write_byte(fd1, 0x64)
+                status = EL.timedwait(() -> istaskdone(wait_task), 2.0; pollint = 0.001)
+                @test status != :timed_out
+                status == :timed_out || @test fetch(wait_task) == :ok
+            finally
+                if wait_task isa Task && !istaskdone(wait_task)
+                    IP.close!(ipfd)
+                end
+                ipfd.sysfd >= 0 && IP.close!(ipfd)
+                _ip_close_fd(fd1)
+                EL.shutdown!()
+            end
+        end
         @testset "combined deadline entry normalization" begin
             registration = EL.Registration(Cint(7), UInt64(11), EL.PollMode.READWRITE, EL.PollWaiter(), EL.PollWaiter(), false)
             combined = EL._build_deadline_entries(registration.pollstate, Int64(10), Int64(10), UInt64(3), UInt64(5))

--- a/test/internal_poll_tests.jl
+++ b/test/internal_poll_tests.jl
@@ -113,15 +113,15 @@ else
             try
                 IP._set_nonblocking!(ipfd.sysfd)
                 IP.init!(ipfd)
-                IP.set_read_deadline!(ipfd, time_ns() + 20_000_000)
+                IP.set_read_deadline!(ipfd, time_ns() + 100_000_000)
                 wait_task = errormonitor(Threads.@spawn begin
                     IP.wait_read!(ipfd.pd, ipfd.is_file)
                     return :ok
                 end)
-                pre = EL.timedwait(() -> istaskdone(wait_task), 0.01; pollint = 0.001)
+                pre = EL.timedwait(() -> istaskdone(wait_task), 0.05; pollint = 0.001)
                 @test pre == :timed_out
                 IP.set_read_deadline!(ipfd, time_ns() + 5_000_000_000)
-                EL.sleep(0.06)
+                EL.sleep(0.12)
                 stale = EL.timedwait(() -> istaskdone(wait_task), 0.02; pollint = 0.001)
                 @test stale == :timed_out
                 _ip_write_byte(fd1, 0x64)

--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -7,7 +7,7 @@ const IP = Reseau.IOPoll
 const SO = Reseau.SocketOps
 
 function _nc_wait_task_done(task::Task, timeout_s::Float64 = 2.0)
-    return timedwait(() -> istaskdone(task), timeout_s; pollint = 0.001)
+    return EL.timedwait(() -> istaskdone(task), timeout_s; pollint = 0.001)
 end
 
 function _read_exact!(conn::NC.Conn, buf::Vector{UInt8})::Int

--- a/test/tls_tests.jl
+++ b/test/tls_tests.jl
@@ -11,7 +11,7 @@ const _TLS_CERT_PATH = joinpath(@__DIR__, "resources", "unittests.crt")
 const _TLS_KEY_PATH = joinpath(@__DIR__, "resources", "unittests.key")
 
 function _tls_wait_task_done(task::Task, timeout_s::Float64 = 2.0)
-    return timedwait(() -> istaskdone(task), timeout_s; pollint = 0.001)
+    return EL.timedwait(() -> istaskdone(task), timeout_s; pollint = 0.001)
 end
 
 function _tls_close_quiet!(x)
@@ -633,7 +633,7 @@ else
                 laddr = NC.addr(listener)::NC.SocketAddrV4
                 accept_task = errormonitor(Threads.@spawn begin
                     conn = NC.accept!(listener)
-                    sleep(1.0)
+                    EL.sleep(1.0)
                     return conn
                 end)
                 client_tcp = ND.connect("tcp", "127.0.0.1:$(Int(laddr.port))")
@@ -676,7 +676,7 @@ else
                 laddr = NC.addr(listener)::NC.SocketAddrV4
                 accept_task = errormonitor(Threads.@spawn begin
                     conn = NC.accept!(listener)
-                    sleep(1.0)
+                    EL.sleep(1.0)
                     return conn
                 end)
                 client_tcp = ND.connect("tcp", "127.0.0.1:$(Int(laddr.port))")
@@ -717,7 +717,7 @@ else
                 laddr = NC.addr(listener)::NC.SocketAddrV4
                 accept_task = errormonitor(Threads.@spawn begin
                     conn = NC.accept!(listener)
-                    sleep(1.2)
+                    EL.sleep(1.2)
                     NC.close!(conn)
                     return nothing
                 end)
@@ -798,7 +798,7 @@ else
                 hold_task = errormonitor(Threads.@spawn begin
                     conn = TL.accept!(listener)
                     TL.handshake!(conn)
-                    sleep(1.5)
+                    EL.sleep(1.5)
                     TL.close!(conn)
                     return nothing
                 end)


### PR DESCRIPTION
## Summary
- add raw `EventLoops.sleep_until_ns`, `sleep_ns`, `sleep`, and `timedwait`
- hard-cut the internal sleep path over to unified `TimerState`/`TimerEntry` so one-shot sleeps and future repeating timers share the same poller-owned state model
- merge descriptor deadlines and timer wakeups onto a single `TimeEntry` heap so the poller uses one set of heap, peek, drain, and wake-delay machinery
- distinguish `READY` versus `CANCELED` waiter wakes and retry `wait_read!` / `wait_write!` internally on stale canceled wakes to better match Go's poll semantics

## Testing
- `JULIA_TEST_FAILFAST=1 julia --project=. -e 'using Pkg; Pkg.test()'`

This pull request was written with the assistance of generative AI.
