### PR TITLE
Add pure-Julia HTTP websocket support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,8 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 NetworkOptions = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 OpenSSL_jll = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
@@ -25,9 +27,7 @@ julia = "1.11"
 [extras]
 JuliaC = "acedd4c2-ced6-4a15-accc-2607eb759ba2"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Libdl", "Random", "SHA", "JuliaC"]
+test = ["Test", "Libdl", "JuliaC"]

--- a/src/7_6_http_websocket_codec.jl
+++ b/src/7_6_http_websocket_codec.jl
@@ -1,0 +1,690 @@
+using Base64
+using EnumX
+using Random
+using SHA
+
+@enumx WsOpcode::UInt8 begin
+    CONTINUATION = 0x00
+    TEXT = 0x01
+    BINARY = 0x02
+    CLOSE = 0x08
+    PING = 0x09
+    PONG = 0x0a
+end
+
+ws_is_data_frame(opcode::UInt8)::Bool = return opcode <= 0x07
+ws_is_data_frame(opcode::WsOpcode.T)::Bool = return ws_is_data_frame(UInt8(opcode))
+ws_is_control_frame(opcode::UInt8)::Bool = return opcode >= 0x08
+ws_is_control_frame(opcode::WsOpcode.T)::Bool = return ws_is_control_frame(UInt8(opcode))
+
+const WS_MAX_PAYLOAD_LENGTH = UInt64(0x7fffffffffffffff)
+const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+struct WebSocketProtocolError <: Exception
+    message::String
+end
+
+struct WebSocketInvalidPayloadError <: Exception
+    message::String
+end
+
+struct WebSocketCallbackError <: Exception
+    message::String
+end
+
+function Base.showerror(io::IO, err::WebSocketProtocolError)
+    print(io, err.message)
+    return nothing
+end
+
+function Base.showerror(io::IO, err::WebSocketInvalidPayloadError)
+    print(io, err.message)
+    return nothing
+end
+
+function Base.showerror(io::IO, err::WebSocketCallbackError)
+    print(io, err.message)
+    return nothing
+end
+
+mutable struct WsFrame{P <: AbstractVector{UInt8}}
+    fin::Bool
+    rsv::NTuple{3, Bool}
+    opcode::UInt8
+    masked::Bool
+    masking_key::NTuple{4, UInt8}
+    payload_length::UInt64
+    payload::P
+end
+
+function WsFrame(;
+        opcode::UInt8 = UInt8(WsOpcode.TEXT),
+        payload::P = UInt8[],
+        fin::Bool = true,
+        masked::Bool = false,
+        masking_key::NTuple{4, UInt8} = (0x00, 0x00, 0x00, 0x00),
+        rsv::NTuple{3, Bool} = (false, false, false),
+    ) where {P <: AbstractVector{UInt8}}
+    return WsFrame{P}(fin, rsv, opcode, masked, masking_key, UInt64(length(payload)), payload)
+end
+
+function ws_encode_frame(frame::WsFrame)::Memory{UInt8}
+    header_size = 2
+    if frame.payload_length >= 65536
+        header_size += 8
+    elseif frame.payload_length >= 126
+        header_size += 2
+    end
+    frame.masked && (header_size += 4)
+    total_size = header_size + Int(frame.payload_length)
+    buf = Memory{UInt8}(undef, total_size)
+    pos = 1
+    b1 = frame.opcode & 0x0f
+    frame.fin && (b1 |= 0x80)
+    frame.rsv[1] && (b1 |= 0x40)
+    frame.rsv[2] && (b1 |= 0x20)
+    frame.rsv[3] && (b1 |= 0x10)
+    buf[pos] = b1
+    pos += 1
+    b2 = UInt8(0)
+    frame.masked && (b2 |= 0x80)
+    if frame.payload_length < 126
+        b2 |= UInt8(frame.payload_length)
+        buf[pos] = b2
+        pos += 1
+    elseif frame.payload_length <= 0xffff
+        b2 |= 126
+        buf[pos] = b2
+        pos += 1
+        buf[pos] = UInt8((frame.payload_length >> 8) & 0xff)
+        buf[pos + 1] = UInt8(frame.payload_length & 0xff)
+        pos += 2
+    else
+        b2 |= 127
+        buf[pos] = b2
+        pos += 1
+        for i in 7:-1:0
+            buf[pos] = UInt8((frame.payload_length >> (8 * i)) & 0xff)
+            pos += 1
+        end
+    end
+    if frame.masked
+        buf[pos] = frame.masking_key[1]
+        buf[pos + 1] = frame.masking_key[2]
+        buf[pos + 2] = frame.masking_key[3]
+        buf[pos + 3] = frame.masking_key[4]
+        pos += 4
+    end
+    if !isempty(frame.payload)
+        if frame.masked
+            for i in 1:Int(frame.payload_length)
+                buf[pos] = frame.payload[i] ⊻ frame.masking_key[((i - 1) % 4) + 1]
+                pos += 1
+            end
+        else
+            copyto!(buf, pos, frame.payload, 1, Int(frame.payload_length))
+        end
+    end
+    return buf
+end
+
+function ws_frame_encoded_size(frame::WsFrame)::UInt64
+    size = UInt64(2)
+    if frame.payload_length >= 65536
+        size += 8
+    elseif frame.payload_length >= 126
+        size += 2
+    end
+    frame.masked && (size += 4)
+    return size + frame.payload_length
+end
+
+struct WsDecodedFrame
+    fin::Bool
+    rsv::NTuple{3, Bool}
+    opcode::UInt8
+    masked::Bool
+    masking_key::NTuple{4, UInt8}
+    payload_length::UInt64
+    payload::Vector{UInt8}
+end
+
+@enumx WsDecoderState::UInt8 begin
+    OPCODE_BYTE = 0
+    LENGTH_BYTE = 1
+    EXTENDED_LENGTH = 2
+    MASKING_KEY = 3
+    PAYLOAD = 4
+    DONE = 5
+end
+
+mutable struct WsDecoder{FF, FP, UD}
+    state::WsDecoderState.T
+    state_bytes_processed::UInt64
+    fin::Bool
+    rsv::NTuple{3, Bool}
+    opcode::UInt8
+    masked::Bool
+    masking_key::NTuple{4, UInt8}
+    payload_length::UInt64
+    extended_length_size::Int
+    length_cache::Vector{UInt8}
+    key_cache::Vector{UInt8}
+    payload_buf::Vector{UInt8}
+    expecting_continuation::Bool
+    fragment_opcode::UInt8
+    text_fragment_payload::Vector{UInt8}
+    on_frame::FF
+    on_payload::FP
+    user_data::UD
+end
+
+@inline function _ws_callback_success(result)::Bool
+    result === nothing && return true
+    result isa Bool && return result
+    return false
+end
+
+function ws_decoder_new(; on_frame = nothing, on_payload = nothing, user_data = nothing)::WsDecoder
+    return WsDecoder(
+        WsDecoderState.OPCODE_BYTE,
+        UInt64(0),
+        false,
+        (false, false, false),
+        UInt8(0),
+        false,
+        (0x00, 0x00, 0x00, 0x00),
+        UInt64(0),
+        0,
+        UInt8[],
+        UInt8[],
+        UInt8[],
+        false,
+        UInt8(0),
+        UInt8[],
+        on_frame,
+        on_payload,
+        user_data,
+    )
+end
+
+function _ws_decoder_reset!(dec::WsDecoder)::Nothing
+    dec.state = WsDecoderState.OPCODE_BYTE
+    dec.state_bytes_processed = UInt64(0)
+    dec.fin = false
+    dec.rsv = (false, false, false)
+    dec.opcode = UInt8(0)
+    dec.masked = false
+    dec.masking_key = (0x00, 0x00, 0x00, 0x00)
+    dec.payload_length = UInt64(0)
+    dec.extended_length_size = 0
+    empty!(dec.length_cache)
+    empty!(dec.key_cache)
+    empty!(dec.payload_buf)
+    return nothing
+end
+
+@inline function _ws_throw_protocol_error(message::AbstractString)
+    throw(WebSocketProtocolError(String(message)))
+end
+
+@inline function _ws_throw_invalid_payload(message::AbstractString)
+    throw(WebSocketInvalidPayloadError(String(message)))
+end
+
+function _ws_decoder_invoke_payload_callback(dec::WsDecoder, payload::Vector{UInt8})::Nothing
+    dec.on_payload === nothing && return nothing
+    isempty(payload) && return nothing
+    if applicable(dec.on_payload, payload, dec.user_data)
+        _ws_callback_success(dec.on_payload(payload, dec.user_data)) || throw(WebSocketCallbackError("websocket payload callback failed"))
+        return nothing
+    end
+    _ws_callback_success(dec.on_payload(payload)) || throw(WebSocketCallbackError("websocket payload callback failed"))
+    return nothing
+end
+
+function ws_decoder_process!(dec::WsDecoder, data::AbstractVector{UInt8}; on_frame_header = nothing)::Vector{WsDecodedFrame}
+    frames = WsDecodedFrame[]
+    pos = firstindex(data)
+    while pos <= lastindex(data)
+        if dec.state == WsDecoderState.OPCODE_BYTE
+            b = data[pos]
+            pos += 1
+            dec.fin = (b & 0x80) != 0
+            dec.rsv = ((b & 0x40) != 0, (b & 0x20) != 0, (b & 0x10) != 0)
+            dec.opcode = b & 0x0f
+            dec.opcode in (0x00, 0x01, 0x02, 0x08, 0x09, 0x0a) || _ws_throw_protocol_error("invalid websocket opcode")
+            is_control = ws_is_control_frame(dec.opcode)
+            is_control && !dec.fin && _ws_throw_protocol_error("control frames must not be fragmented")
+            if !is_control
+                if dec.opcode == UInt8(WsOpcode.CONTINUATION)
+                    (!dec.expecting_continuation || dec.fragment_opcode == UInt8(0)) && _ws_throw_protocol_error("unexpected continuation frame")
+                else
+                    dec.expecting_continuation && _ws_throw_protocol_error("unexpected new data frame while fragmented message is open")
+                    empty!(dec.text_fragment_payload)
+                    dec.fragment_opcode = dec.fin ? UInt8(0) : dec.opcode
+                end
+                dec.expecting_continuation = !dec.fin
+            end
+            dec.state = WsDecoderState.LENGTH_BYTE
+        elseif dec.state == WsDecoderState.LENGTH_BYTE
+            b = data[pos]
+            pos += 1
+            dec.masked = (b & 0x80) != 0
+            len7 = b & 0x7f
+            ws_is_control_frame(dec.opcode) && len7 >= 126 && _ws_throw_protocol_error("control frame payload length must be <= 125")
+            if len7 < 126
+                dec.payload_length = UInt64(len7)
+                dec.extended_length_size = 0
+                on_frame_header === nothing || on_frame_header(dec.opcode, dec.fin, dec.payload_length)
+                dec.state = dec.masked ? WsDecoderState.MASKING_KEY : WsDecoderState.PAYLOAD
+                dec.state_bytes_processed = UInt64(0)
+                dec.payload_length == 0 && !dec.masked && (dec.state = WsDecoderState.DONE)
+            elseif len7 == 126
+                dec.extended_length_size = 2
+                empty!(dec.length_cache)
+                dec.state = WsDecoderState.EXTENDED_LENGTH
+                dec.state_bytes_processed = UInt64(0)
+            else
+                dec.extended_length_size = 8
+                empty!(dec.length_cache)
+                dec.state = WsDecoderState.EXTENDED_LENGTH
+                dec.state_bytes_processed = UInt64(0)
+            end
+        elseif dec.state == WsDecoderState.EXTENDED_LENGTH
+            needed = dec.extended_length_size - length(dec.length_cache)
+            available = min(needed, lastindex(data) - pos + 1)
+            append!(dec.length_cache, @view data[pos:(pos + available - 1)])
+            pos += available
+            if length(dec.length_cache) == dec.extended_length_size
+                if dec.extended_length_size == 2
+                    v = (UInt64(dec.length_cache[1]) << 8) | UInt64(dec.length_cache[2])
+                    v < 126 && _ws_throw_protocol_error("non-canonical 16-bit websocket payload length")
+                    dec.payload_length = v
+                else
+                    v = UInt64(0)
+                    for i in 1:8
+                        v = (v << 8) | UInt64(dec.length_cache[i])
+                    end
+                    (v < 65536 || v > WS_MAX_PAYLOAD_LENGTH) && _ws_throw_protocol_error("invalid 64-bit websocket payload length")
+                    dec.payload_length = v
+                end
+                on_frame_header === nothing || on_frame_header(dec.opcode, dec.fin, dec.payload_length)
+                dec.state = dec.masked ? WsDecoderState.MASKING_KEY : WsDecoderState.PAYLOAD
+                dec.state_bytes_processed = UInt64(0)
+                dec.payload_length == 0 && !dec.masked && (dec.state = WsDecoderState.DONE)
+            end
+        elseif dec.state == WsDecoderState.MASKING_KEY
+            needed = 4 - length(dec.key_cache)
+            available = min(needed, lastindex(data) - pos + 1)
+            append!(dec.key_cache, @view data[pos:(pos + available - 1)])
+            pos += available
+            if length(dec.key_cache) == 4
+                dec.masking_key = (dec.key_cache[1], dec.key_cache[2], dec.key_cache[3], dec.key_cache[4])
+                dec.state = dec.payload_length > 0 ? WsDecoderState.PAYLOAD : WsDecoderState.DONE
+                dec.state_bytes_processed = UInt64(0)
+            end
+        elseif dec.state == WsDecoderState.PAYLOAD
+            dec.payload_length > WS_MAX_PAYLOAD_LENGTH && _ws_throw_protocol_error("websocket payload length exceeds maximum")
+            payload_length_int = Int(dec.payload_length)
+            remaining = payload_length_int - length(dec.payload_buf)
+            remaining < 0 && _ws_throw_protocol_error("websocket payload length underflow")
+            available = min(remaining, lastindex(data) - pos + 1)
+            chunk = @view data[pos:(pos + available - 1)]
+            pos += available
+            if dec.masked
+                offset = length(dec.payload_buf)
+                for i in 1:available
+                    push!(dec.payload_buf, chunk[i] ⊻ dec.masking_key[((offset + i - 1) % 4) + 1])
+                end
+            else
+                append!(dec.payload_buf, chunk)
+            end
+            length(dec.payload_buf) == payload_length_int && (dec.state = WsDecoderState.DONE)
+        end
+        if dec.state == WsDecoderState.DONE
+            if dec.opcode == UInt8(WsOpcode.CLOSE)
+                ws_validate_close_payload(dec.payload_buf)
+            elseif dec.opcode == UInt8(WsOpcode.TEXT)
+                if dec.fin
+                    isvalid(String, dec.payload_buf) || _ws_throw_invalid_payload("invalid UTF-8 text frame payload")
+                else
+                    append!(dec.text_fragment_payload, dec.payload_buf)
+                end
+            elseif dec.opcode == UInt8(WsOpcode.CONTINUATION)
+                if dec.fragment_opcode == UInt8(WsOpcode.TEXT)
+                    append!(dec.text_fragment_payload, dec.payload_buf)
+                    if dec.fin
+                        isvalid(String, dec.text_fragment_payload) || begin
+                            dec.expecting_continuation = false
+                            dec.fragment_opcode = UInt8(0)
+                            empty!(dec.text_fragment_payload)
+                            _ws_throw_invalid_payload("invalid UTF-8 continuation payload")
+                        end
+                        dec.fragment_opcode = UInt8(0)
+                        empty!(dec.text_fragment_payload)
+                    end
+                elseif dec.fin
+                    dec.fragment_opcode = UInt8(0)
+                end
+            end
+            frame = WsDecodedFrame(
+                dec.fin,
+                dec.rsv,
+                dec.opcode,
+                dec.masked,
+                dec.masking_key,
+                dec.payload_length,
+                copy(dec.payload_buf),
+            )
+            _ws_decoder_invoke_payload_callback(dec, frame.payload)
+            push!(frames, frame)
+            if dec.on_frame !== nothing
+                _ws_callback_success(dec.on_frame(frame)) || throw(WebSocketCallbackError("websocket frame callback failed"))
+            end
+            _ws_decoder_reset!(dec)
+        end
+    end
+    return frames
+end
+
+const WS_CLOSE_STATUS_NORMAL = UInt16(1000)
+const WS_CLOSE_STATUS_GOING_AWAY = UInt16(1001)
+const WS_CLOSE_STATUS_PROTOCOL_ERROR = UInt16(1002)
+const WS_CLOSE_STATUS_UNSUPPORTED_DATA = UInt16(1003)
+const WS_CLOSE_STATUS_NO_STATUS = UInt16(1005)
+const WS_CLOSE_STATUS_ABNORMAL = UInt16(1006)
+const WS_CLOSE_STATUS_INVALID_PAYLOAD = UInt16(1007)
+const WS_CLOSE_STATUS_POLICY_VIOLATION = UInt16(1008)
+const WS_CLOSE_STATUS_MESSAGE_TOO_BIG = UInt16(1009)
+const WS_CLOSE_STATUS_EXTENSIONS_NEEDED = UInt16(1010)
+const WS_CLOSE_STATUS_INTERNAL_ERROR = UInt16(1011)
+
+function ws_is_valid_close_status(code::UInt16)::Bool
+    code < 1000 && return false
+    code in (1004, 1005, 1006) && return false
+    code >= 1000 && code <= 1011 && return true
+    code >= 3000 && code <= 4999 && return true
+    return false
+end
+
+function ws_encode_close_payload(status_code::UInt16, reason::AbstractVector{UInt8} = UInt8[])::Memory{UInt8}
+    buf = Memory{UInt8}(undef, 2 + length(reason))
+    buf[1] = UInt8((status_code >> 8) & 0xff)
+    buf[2] = UInt8(status_code & 0xff)
+    if !isempty(reason)
+        copyto!(buf, 3, reason, 1, length(reason))
+    end
+    return buf
+end
+
+function ws_validate_close_payload(payload::AbstractVector{UInt8})::Nothing
+    len = length(payload)
+    len == 0 && return nothing
+    len == 1 && _ws_throw_protocol_error("close payload length must be 0 or >= 2")
+    code = (UInt16(payload[1]) << 8) | UInt16(payload[2])
+    ws_is_valid_close_status(code) || _ws_throw_protocol_error("invalid websocket close status")
+    if len > 2
+        reason = @view payload[3:len]
+        isvalid(String, reason) || _ws_throw_invalid_payload("invalid websocket close reason")
+    end
+    return nothing
+end
+
+function ws_decode_close_payload(payload::AbstractVector{UInt8})::Tuple{UInt16, Vector{UInt8}}
+    length(payload) < 2 && return UInt16(0), UInt8[]
+    code = (UInt16(payload[1]) << 8) | UInt16(payload[2])
+    reason = length(payload) > 2 ? copy(@view(payload[3:end])) : UInt8[]
+    return code, reason
+end
+
+mutable struct WsConnection{UD, Dec <: WsDecoder, FBegin, FPayload, FComplete}
+    is_client::Bool
+    is_open::Bool
+    close_sent::Bool
+    close_received::Bool
+    user_data::UD
+    decoder::Dec
+    outgoing_frames::Vector{Memory{UInt8}}
+    max_incoming_payload_length::UInt64
+    incoming_message_payload_total::UInt64
+    on_incoming_frame_begin::FBegin
+    on_incoming_frame_payload::FPayload
+    on_incoming_frame_complete::FComplete
+end
+
+function ws_connection_new(;
+        is_client::Bool = true,
+        user_data = nothing,
+        max_incoming_payload_length::UInt64 = UInt64(0),
+        on_incoming_frame_begin = nothing,
+        on_incoming_frame_payload = nothing,
+        on_incoming_frame_complete = nothing,
+    )::WsConnection
+    decoder = ws_decoder_new()
+    return WsConnection(
+        is_client,
+        true,
+        false,
+        false,
+        user_data,
+        decoder,
+        Memory{UInt8}[],
+        max_incoming_payload_length,
+        UInt64(0),
+        on_incoming_frame_begin,
+        on_incoming_frame_payload,
+        on_incoming_frame_complete,
+    )
+end
+
+function ws_send_frame!(ws::WsConnection, opcode::UInt8, payload::AbstractVector{UInt8}; fin::Bool = true)::Nothing
+    ws.is_open || throw(ProtocolError("websocket connection is closed"))
+    if ws_is_control_frame(opcode)
+        !fin && throw(ArgumentError("control frames must not be fragmented"))
+        length(payload) > 125 && throw(ArgumentError("control frame payloads must be <= 125 bytes"))
+    end
+    masking_key = if ws.is_client
+        key = rand(UInt8, 4)
+        (key[1], key[2], key[3], key[4])
+    else
+        (0x00, 0x00, 0x00, 0x00)
+    end
+    frame = WsFrame(
+        opcode = opcode,
+        payload = payload,
+        fin = fin,
+        masked = ws.is_client,
+        masking_key = masking_key,
+    )
+    push!(ws.outgoing_frames, ws_encode_frame(frame))
+    return nothing
+end
+
+function ws_send_text!(ws::WsConnection, payload::AbstractVector{UInt8})::Nothing
+    ws_send_frame!(ws, UInt8(WsOpcode.TEXT), payload)
+    return nothing
+end
+
+function ws_send_binary!(ws::WsConnection, payload::AbstractVector{UInt8})::Nothing
+    ws_send_frame!(ws, UInt8(WsOpcode.BINARY), payload)
+    return nothing
+end
+
+function ws_send_ping!(ws::WsConnection, payload::AbstractVector{UInt8} = UInt8[])::Nothing
+    ws_send_frame!(ws, UInt8(WsOpcode.PING), payload)
+    return nothing
+end
+
+function ws_send_pong!(ws::WsConnection, payload::AbstractVector{UInt8} = UInt8[])::Nothing
+    ws_send_frame!(ws, UInt8(WsOpcode.PONG), payload)
+    return nothing
+end
+
+function ws_close!(ws::WsConnection; status_code::UInt16 = WS_CLOSE_STATUS_NORMAL, reason::AbstractVector{UInt8} = UInt8[])::Nothing
+    ws.close_sent && return nothing
+    ws_is_valid_close_status(status_code) || throw(ArgumentError("invalid websocket close status"))
+    isempty(reason) || isvalid(String, reason) || throw(ArgumentError("websocket close reason must be valid UTF-8"))
+    length(reason) <= 123 || throw(ArgumentError("websocket close reason must be <= 123 bytes"))
+    payload = ws_encode_close_payload(status_code, reason)
+    ws_send_frame!(ws, UInt8(WsOpcode.CLOSE), payload)
+    ws.close_sent = true
+    return nothing
+end
+
+function _ws_connection_invoke_callback(callback, args...)::Nothing
+    callback === nothing && return nothing
+    if applicable(callback, args...)
+        _ws_callback_success(callback(args...)) || throw(WebSocketCallbackError("websocket frame callback failed"))
+        return nothing
+    end
+    throw(WebSocketCallbackError("websocket frame callback arity mismatch"))
+end
+
+function ws_on_incoming_data!(ws::WsConnection, data::AbstractVector{UInt8})::Vector{WsDecodedFrame}
+    frames = if ws.max_incoming_payload_length > 0
+        incoming_total = ws.incoming_message_payload_total
+        ws_decoder_process!(
+            ws.decoder,
+            data;
+            on_frame_header = (opcode::UInt8, fin::Bool, payload_length::UInt64) -> begin
+                if ws_is_data_frame(opcode)
+                    running_total = opcode == UInt8(WsOpcode.CONTINUATION) ? incoming_total : UInt64(0)
+                    if running_total > ws.max_incoming_payload_length || payload_length > (ws.max_incoming_payload_length - running_total)
+                        _ws_throw_protocol_error("incoming websocket payload exceeds configured maximum")
+                    end
+                    incoming_total = running_total + payload_length
+                    fin && (incoming_total = UInt64(0))
+                else
+                    payload_length > ws.max_incoming_payload_length && _ws_throw_protocol_error("incoming websocket control frame exceeds configured maximum")
+                end
+                return nothing
+            end,
+        )
+    else
+        ws_decoder_process!(ws.decoder, data)
+    end
+    for (i, frame) in pairs(frames)
+        if ws.is_client
+            frame.masked && _ws_throw_protocol_error("server websocket frames must not be masked")
+        else
+            !frame.masked && _ws_throw_protocol_error("client websocket frames must be masked")
+        end
+        if ws.max_incoming_payload_length > 0
+            if ws_is_data_frame(frame.opcode)
+                running_total = frame.opcode == UInt8(WsOpcode.CONTINUATION) ? ws.incoming_message_payload_total : UInt64(0)
+                if running_total > ws.max_incoming_payload_length || frame.payload_length > (ws.max_incoming_payload_length - running_total)
+                    _ws_throw_protocol_error("incoming websocket payload exceeds configured maximum")
+                end
+                ws.incoming_message_payload_total = running_total + frame.payload_length
+            else
+                frame.payload_length > ws.max_incoming_payload_length && _ws_throw_protocol_error("incoming websocket control frame exceeds configured maximum")
+            end
+        end
+        frame_info = (payload_length = frame.payload_length, opcode = frame.opcode, fin = frame.fin)
+        _ws_connection_invoke_callback(ws.on_incoming_frame_begin, ws, frame_info, ws.user_data)
+        if !isempty(frame.payload)
+            _ws_connection_invoke_callback(ws.on_incoming_frame_payload, ws, frame_info, frame.payload, ws.user_data)
+        end
+        _ws_connection_invoke_callback(ws.on_incoming_frame_complete, ws, frame_info, 0, ws.user_data)
+        if frame.opcode == UInt8(WsOpcode.PING)
+            ws_send_pong!(ws, frame.payload)
+        end
+        if frame.opcode == UInt8(WsOpcode.CLOSE)
+            ws.close_received = true
+            if !ws.close_sent
+                ws_send_frame!(ws, UInt8(WsOpcode.CLOSE), frame.payload)
+                ws.close_sent = true
+            end
+            ws.is_open = false
+            resize!(frames, i)
+            return frames
+        end
+        if ws_is_data_frame(frame.opcode) && frame.fin
+            ws.incoming_message_payload_total = UInt64(0)
+        end
+    end
+    return frames
+end
+
+function ws_get_outgoing_data!(ws::WsConnection)::Vector{UInt8}
+    total = 0
+    for frame in ws.outgoing_frames
+        total += length(frame)
+    end
+    output = Vector{UInt8}(undef, total)
+    pos = 1
+    for frame in ws.outgoing_frames
+        n = length(frame)
+        copyto!(output, pos, frame, 1, n)
+        pos += n
+    end
+    empty!(ws.outgoing_frames)
+    return output
+end
+
+function ws_random_handshake_key()::String
+    return Base64.base64encode(rand(UInt8, 16))
+end
+
+function ws_compute_accept_key(key::AbstractString)::String
+    hash = SHA.sha1(Vector{UInt8}(codeunits(string(key, WS_GUID))))
+    return Base64.base64encode(hash)
+end
+
+@inline function _ws_header_value_has_token(value::AbstractString, token::AbstractString; case_sensitive::Bool = false)::Bool
+    for part in eachsplit(value, ',')
+        trimmed = strip(part)
+        isempty(trimmed) && continue
+        if case_sensitive
+            trimmed == token && return true
+        else
+            lowercase(trimmed) == lowercase(token) && return true
+        end
+    end
+    return false
+end
+
+@inline function _ws_headers_have_token(headers::Headers, name::AbstractString, token::AbstractString; case_sensitive::Bool = false)::Bool
+    values = get_headers(headers, name)
+    isempty(values) && return false
+    for value in values
+        _ws_header_value_has_token(value, token; case_sensitive = case_sensitive) && return true
+    end
+    return false
+end
+
+function ws_is_websocket_request(request::Request)::Bool
+    uppercase(request.method) == "GET" || return false
+    _ws_headers_have_token(request.headers, "Upgrade", "websocket"; case_sensitive = false) || return false
+    _ws_headers_have_token(request.headers, "Connection", "upgrade"; case_sensitive = false) || return false
+    get_header(request.headers, "Sec-WebSocket-Key") === nothing && return false
+    version = get_header(request.headers, "Sec-WebSocket-Version")
+    version === nothing && return false
+    strip(version) == "13" || return false
+    return true
+end
+
+function ws_get_request_sec_websocket_key(request::Request)::Union{Nothing, String}
+    key = get_header(request.headers, "Sec-WebSocket-Key")
+    key === nothing && return nothing
+    return strip(key)
+end
+
+function ws_select_subprotocol(request::Request, server_protocols::AbstractVector{<:AbstractString})::Union{Nothing, String}
+    values = get_headers(request.headers, "Sec-WebSocket-Protocol")
+    isempty(values) && return nothing
+    requested = String[]
+    for value in values
+        for part in eachsplit(value, ',')
+            trimmed = strip(part)
+            isempty(trimmed) && continue
+            push!(requested, String(trimmed))
+        end
+    end
+    for server_protocol in server_protocols
+        protocol = String(server_protocol)
+        protocol in requested && return protocol
+    end
+    return nothing
+end

--- a/src/7_6_http_websocket_codec.jl
+++ b/src/7_6_http_websocket_codec.jl
@@ -28,10 +28,6 @@ struct WebSocketInvalidPayloadError <: Exception
     message::String
 end
 
-struct WebSocketCallbackError <: Exception
-    message::String
-end
-
 function Base.showerror(io::IO, err::WebSocketProtocolError)
     print(io, err.message)
     return nothing
@@ -42,12 +38,7 @@ function Base.showerror(io::IO, err::WebSocketInvalidPayloadError)
     return nothing
 end
 
-function Base.showerror(io::IO, err::WebSocketCallbackError)
-    print(io, err.message)
-    return nothing
-end
-
-mutable struct WsFrame{P <: AbstractVector{UInt8}}
+struct WsFrame{P <: AbstractVector{UInt8}}
     fin::Bool
     rsv::NTuple{3, Bool}
     opcode::UInt8
@@ -128,27 +119,6 @@ function ws_encode_frame(frame::WsFrame)::Memory{UInt8}
     return buf
 end
 
-function ws_frame_encoded_size(frame::WsFrame)::UInt64
-    size = UInt64(2)
-    if frame.payload_length >= 65536
-        size += 8
-    elseif frame.payload_length >= 126
-        size += 2
-    end
-    frame.masked && (size += 4)
-    return size + frame.payload_length
-end
-
-struct WsDecodedFrame
-    fin::Bool
-    rsv::NTuple{3, Bool}
-    opcode::UInt8
-    masked::Bool
-    masking_key::NTuple{4, UInt8}
-    payload_length::UInt64
-    payload::Vector{UInt8}
-end
-
 @enumx WsDecoderState::UInt8 begin
     OPCODE_BYTE = 0
     LENGTH_BYTE = 1
@@ -158,9 +128,8 @@ end
     DONE = 5
 end
 
-mutable struct WsDecoder{FF, FP, UD}
+mutable struct WsDecoder
     state::WsDecoderState.T
-    state_bytes_processed::UInt64
     fin::Bool
     rsv::NTuple{3, Bool}
     opcode::UInt8
@@ -174,21 +143,11 @@ mutable struct WsDecoder{FF, FP, UD}
     expecting_continuation::Bool
     fragment_opcode::UInt8
     text_fragment_payload::Vector{UInt8}
-    on_frame::FF
-    on_payload::FP
-    user_data::UD
 end
 
-@inline function _ws_callback_success(result)::Bool
-    result === nothing && return true
-    result isa Bool && return result
-    return false
-end
-
-function ws_decoder_new(; on_frame = nothing, on_payload = nothing, user_data = nothing)::WsDecoder
+function ws_decoder_new()::WsDecoder
     return WsDecoder(
         WsDecoderState.OPCODE_BYTE,
-        UInt64(0),
         false,
         (false, false, false),
         UInt8(0),
@@ -202,15 +161,11 @@ function ws_decoder_new(; on_frame = nothing, on_payload = nothing, user_data = 
         false,
         UInt8(0),
         UInt8[],
-        on_frame,
-        on_payload,
-        user_data,
     )
 end
 
 function _ws_decoder_reset!(dec::WsDecoder)::Nothing
     dec.state = WsDecoderState.OPCODE_BYTE
-    dec.state_bytes_processed = UInt64(0)
     dec.fin = false
     dec.rsv = (false, false, false)
     dec.opcode = UInt8(0)
@@ -232,19 +187,8 @@ end
     throw(WebSocketInvalidPayloadError(String(message)))
 end
 
-function _ws_decoder_invoke_payload_callback(dec::WsDecoder, payload::Vector{UInt8})::Nothing
-    dec.on_payload === nothing && return nothing
-    isempty(payload) && return nothing
-    if applicable(dec.on_payload, payload, dec.user_data)
-        _ws_callback_success(dec.on_payload(payload, dec.user_data)) || throw(WebSocketCallbackError("websocket payload callback failed"))
-        return nothing
-    end
-    _ws_callback_success(dec.on_payload(payload)) || throw(WebSocketCallbackError("websocket payload callback failed"))
-    return nothing
-end
-
-function ws_decoder_process!(dec::WsDecoder, data::AbstractVector{UInt8}; on_frame_header = nothing)::Vector{WsDecodedFrame}
-    frames = WsDecodedFrame[]
+function ws_decoder_process!(f::Union{Nothing, Function}, dec::WsDecoder, data::AbstractVector{UInt8}; on_frame_header = nothing)::Vector{WsFrame{Vector{UInt8}}}
+    frames = WsFrame{Vector{UInt8}}[]
     pos = firstindex(data)
     while pos <= lastindex(data)
         if dec.state == WsDecoderState.OPCODE_BYTE
@@ -278,18 +222,15 @@ function ws_decoder_process!(dec::WsDecoder, data::AbstractVector{UInt8}; on_fra
                 dec.extended_length_size = 0
                 on_frame_header === nothing || on_frame_header(dec.opcode, dec.fin, dec.payload_length)
                 dec.state = dec.masked ? WsDecoderState.MASKING_KEY : WsDecoderState.PAYLOAD
-                dec.state_bytes_processed = UInt64(0)
                 dec.payload_length == 0 && !dec.masked && (dec.state = WsDecoderState.DONE)
             elseif len7 == 126
                 dec.extended_length_size = 2
                 empty!(dec.length_cache)
                 dec.state = WsDecoderState.EXTENDED_LENGTH
-                dec.state_bytes_processed = UInt64(0)
             else
                 dec.extended_length_size = 8
                 empty!(dec.length_cache)
                 dec.state = WsDecoderState.EXTENDED_LENGTH
-                dec.state_bytes_processed = UInt64(0)
             end
         elseif dec.state == WsDecoderState.EXTENDED_LENGTH
             needed = dec.extended_length_size - length(dec.length_cache)
@@ -311,7 +252,6 @@ function ws_decoder_process!(dec::WsDecoder, data::AbstractVector{UInt8}; on_fra
                 end
                 on_frame_header === nothing || on_frame_header(dec.opcode, dec.fin, dec.payload_length)
                 dec.state = dec.masked ? WsDecoderState.MASKING_KEY : WsDecoderState.PAYLOAD
-                dec.state_bytes_processed = UInt64(0)
                 dec.payload_length == 0 && !dec.masked && (dec.state = WsDecoderState.DONE)
             end
         elseif dec.state == WsDecoderState.MASKING_KEY
@@ -322,7 +262,6 @@ function ws_decoder_process!(dec::WsDecoder, data::AbstractVector{UInt8}; on_fra
             if length(dec.key_cache) == 4
                 dec.masking_key = (dec.key_cache[1], dec.key_cache[2], dec.key_cache[3], dec.key_cache[4])
                 dec.state = dec.payload_length > 0 ? WsDecoderState.PAYLOAD : WsDecoderState.DONE
-                dec.state_bytes_processed = UInt64(0)
             end
         elseif dec.state == WsDecoderState.PAYLOAD
             dec.payload_length > WS_MAX_PAYLOAD_LENGTH && _ws_throw_protocol_error("websocket payload length exceeds maximum")
@@ -368,7 +307,7 @@ function ws_decoder_process!(dec::WsDecoder, data::AbstractVector{UInt8}; on_fra
                     dec.fragment_opcode = UInt8(0)
                 end
             end
-            frame = WsDecodedFrame(
+            frame = WsFrame(
                 dec.fin,
                 dec.rsv,
                 dec.opcode,
@@ -377,28 +316,17 @@ function ws_decoder_process!(dec::WsDecoder, data::AbstractVector{UInt8}; on_fra
                 dec.payload_length,
                 copy(dec.payload_buf),
             )
-            _ws_decoder_invoke_payload_callback(dec, frame.payload)
             push!(frames, frame)
-            if dec.on_frame !== nothing
-                _ws_callback_success(dec.on_frame(frame)) || throw(WebSocketCallbackError("websocket frame callback failed"))
-            end
+            f === nothing || f(frame)
             _ws_decoder_reset!(dec)
         end
     end
     return frames
 end
 
-const WS_CLOSE_STATUS_NORMAL = UInt16(1000)
-const WS_CLOSE_STATUS_GOING_AWAY = UInt16(1001)
-const WS_CLOSE_STATUS_PROTOCOL_ERROR = UInt16(1002)
-const WS_CLOSE_STATUS_UNSUPPORTED_DATA = UInt16(1003)
-const WS_CLOSE_STATUS_NO_STATUS = UInt16(1005)
-const WS_CLOSE_STATUS_ABNORMAL = UInt16(1006)
-const WS_CLOSE_STATUS_INVALID_PAYLOAD = UInt16(1007)
-const WS_CLOSE_STATUS_POLICY_VIOLATION = UInt16(1008)
-const WS_CLOSE_STATUS_MESSAGE_TOO_BIG = UInt16(1009)
-const WS_CLOSE_STATUS_EXTENSIONS_NEEDED = UInt16(1010)
-const WS_CLOSE_STATUS_INTERNAL_ERROR = UInt16(1011)
+function ws_decoder_process!(dec::WsDecoder, data::AbstractVector{UInt8}; on_frame_header = nothing)::Vector{WsFrame{Vector{UInt8}}}
+    return ws_decoder_process!(nothing, dec, data; on_frame_header = on_frame_header)
+end
 
 function ws_is_valid_close_status(code::UInt16)::Bool
     code < 1000 && return false
@@ -438,47 +366,35 @@ function ws_decode_close_payload(payload::AbstractVector{UInt8})::Tuple{UInt16, 
     return code, reason
 end
 
-mutable struct WsConnection{UD, Dec <: WsDecoder, FBegin, FPayload, FComplete}
+mutable struct Conn
     is_client::Bool
     is_open::Bool
     close_sent::Bool
     close_received::Bool
-    user_data::UD
-    decoder::Dec
+    decoder::WsDecoder
     outgoing_frames::Vector{Memory{UInt8}}
     max_incoming_payload_length::UInt64
     incoming_message_payload_total::UInt64
-    on_incoming_frame_begin::FBegin
-    on_incoming_frame_payload::FPayload
-    on_incoming_frame_complete::FComplete
 end
 
-function ws_connection_new(;
+function Conn(;
         is_client::Bool = true,
-        user_data = nothing,
         max_incoming_payload_length::UInt64 = UInt64(0),
-        on_incoming_frame_begin = nothing,
-        on_incoming_frame_payload = nothing,
-        on_incoming_frame_complete = nothing,
-    )::WsConnection
+    )::Conn
     decoder = ws_decoder_new()
-    return WsConnection(
+    return Conn(
         is_client,
         true,
         false,
         false,
-        user_data,
         decoder,
         Memory{UInt8}[],
         max_incoming_payload_length,
         UInt64(0),
-        on_incoming_frame_begin,
-        on_incoming_frame_payload,
-        on_incoming_frame_complete,
     )
 end
 
-function ws_send_frame!(ws::WsConnection, opcode::UInt8, payload::AbstractVector{UInt8}; fin::Bool = true)::Nothing
+function ws_send_frame!(ws::Conn, opcode::UInt8, payload::AbstractVector{UInt8}; fin::Bool = true)::Nothing
     ws.is_open || throw(ProtocolError("websocket connection is closed"))
     if ws_is_control_frame(opcode)
         !fin && throw(ArgumentError("control frames must not be fragmented"))
@@ -501,27 +417,17 @@ function ws_send_frame!(ws::WsConnection, opcode::UInt8, payload::AbstractVector
     return nothing
 end
 
-function ws_send_text!(ws::WsConnection, payload::AbstractVector{UInt8})::Nothing
-    ws_send_frame!(ws, UInt8(WsOpcode.TEXT), payload)
-    return nothing
-end
-
-function ws_send_binary!(ws::WsConnection, payload::AbstractVector{UInt8})::Nothing
-    ws_send_frame!(ws, UInt8(WsOpcode.BINARY), payload)
-    return nothing
-end
-
-function ws_send_ping!(ws::WsConnection, payload::AbstractVector{UInt8} = UInt8[])::Nothing
+function ws_send_ping!(ws::Conn, payload::AbstractVector{UInt8} = UInt8[])::Nothing
     ws_send_frame!(ws, UInt8(WsOpcode.PING), payload)
     return nothing
 end
 
-function ws_send_pong!(ws::WsConnection, payload::AbstractVector{UInt8} = UInt8[])::Nothing
+function ws_send_pong!(ws::Conn, payload::AbstractVector{UInt8} = UInt8[])::Nothing
     ws_send_frame!(ws, UInt8(WsOpcode.PONG), payload)
     return nothing
 end
 
-function ws_close!(ws::WsConnection; status_code::UInt16 = WS_CLOSE_STATUS_NORMAL, reason::AbstractVector{UInt8} = UInt8[])::Nothing
+function ws_close!(ws::Conn; status_code::UInt16 = UInt16(1000), reason::AbstractVector{UInt8} = UInt8[])::Nothing
     ws.close_sent && return nothing
     ws_is_valid_close_status(status_code) || throw(ArgumentError("invalid websocket close status"))
     isempty(reason) || isvalid(String, reason) || throw(ArgumentError("websocket close reason must be valid UTF-8"))
@@ -532,19 +438,11 @@ function ws_close!(ws::WsConnection; status_code::UInt16 = WS_CLOSE_STATUS_NORMA
     return nothing
 end
 
-function _ws_connection_invoke_callback(callback, args...)::Nothing
-    callback === nothing && return nothing
-    if applicable(callback, args...)
-        _ws_callback_success(callback(args...)) || throw(WebSocketCallbackError("websocket frame callback failed"))
-        return nothing
-    end
-    throw(WebSocketCallbackError("websocket frame callback arity mismatch"))
-end
-
-function ws_on_incoming_data!(ws::WsConnection, data::AbstractVector{UInt8})::Vector{WsDecodedFrame}
+function ws_on_incoming_data!(f::Union{Nothing, Function}, ws::Conn, data::AbstractVector{UInt8})::Vector{WsFrame{Vector{UInt8}}}
     frames = if ws.max_incoming_payload_length > 0
         incoming_total = ws.incoming_message_payload_total
         ws_decoder_process!(
+            f,
             ws.decoder,
             data;
             on_frame_header = (opcode::UInt8, fin::Bool, payload_length::UInt64) -> begin
@@ -562,7 +460,7 @@ function ws_on_incoming_data!(ws::WsConnection, data::AbstractVector{UInt8})::Ve
             end,
         )
     else
-        ws_decoder_process!(ws.decoder, data)
+        ws_decoder_process!(f, ws.decoder, data)
     end
     for (i, frame) in pairs(frames)
         if ws.is_client
@@ -581,12 +479,6 @@ function ws_on_incoming_data!(ws::WsConnection, data::AbstractVector{UInt8})::Ve
                 frame.payload_length > ws.max_incoming_payload_length && _ws_throw_protocol_error("incoming websocket control frame exceeds configured maximum")
             end
         end
-        frame_info = (payload_length = frame.payload_length, opcode = frame.opcode, fin = frame.fin)
-        _ws_connection_invoke_callback(ws.on_incoming_frame_begin, ws, frame_info, ws.user_data)
-        if !isempty(frame.payload)
-            _ws_connection_invoke_callback(ws.on_incoming_frame_payload, ws, frame_info, frame.payload, ws.user_data)
-        end
-        _ws_connection_invoke_callback(ws.on_incoming_frame_complete, ws, frame_info, 0, ws.user_data)
         if frame.opcode == UInt8(WsOpcode.PING)
             ws_send_pong!(ws, frame.payload)
         end
@@ -607,7 +499,11 @@ function ws_on_incoming_data!(ws::WsConnection, data::AbstractVector{UInt8})::Ve
     return frames
 end
 
-function ws_get_outgoing_data!(ws::WsConnection)::Vector{UInt8}
+function ws_on_incoming_data!(ws::Conn, data::AbstractVector{UInt8})::Vector{WsFrame{Vector{UInt8}}}
+    return ws_on_incoming_data!(nothing, ws, data)
+end
+
+function ws_get_outgoing_data!(ws::Conn)::Vector{UInt8}
     total = 0
     for frame in ws.outgoing_frames
         total += length(frame)

--- a/src/7_6_http_websockets.jl
+++ b/src/7_6_http_websockets.jl
@@ -121,7 +121,7 @@ mutable struct WebSocket{S, C}
     codec::Conn
     maxframesize::Int
     maxfragmentation::Int
-    readchannel::Channel{Union{String, Vector{UInt8}, WebSocketError}}
+    readchannel::Channel{Union{String, Vector{UInt8}}}
     readtask::Union{Nothing, Task}
     readclosed::Bool
     writeclosed::Bool
@@ -145,7 +145,7 @@ function WebSocket(
     ) where {S, C}
     maxframesize > 0 || throw(ArgumentError("maxframesize must be > 0"))
     maxfragmentation > 0 || throw(ArgumentError("maxfragmentation must be > 0"))
-    channel = Channel{Union{String, Vector{UInt8}, WebSocketError}}(Inf)
+    channel = Channel{Union{String, Vector{UInt8}}}(Inf)
     codec = Conn(is_client = is_client)
     ws = WebSocket(
         subprotocol === nothing ? nothing : String(subprotocol),
@@ -177,12 +177,12 @@ struct _ClientHandshake
     request::Request
 end
 
-isbinary(x) = return x isa AbstractVector{UInt8}
-istext(x) = return x isa AbstractString
-opcode(x) = return isbinary(x) ? WsOpcode.BINARY : WsOpcode.TEXT
-_to_bytes(x::AbstractVector{UInt8}) = return x
-_to_bytes(x::AbstractString) = return codeunits(String(x))
-_to_bytes(x) = return codeunits(string(x))
+isbinary(x) = x isa AbstractVector{UInt8}
+istext(x) = x isa AbstractString
+opcode(x) = isbinary(x) ? WsOpcode.BINARY : WsOpcode.TEXT
+_to_bytes(x::AbstractVector{UInt8}) = x
+_to_bytes(x::AbstractString) = codeunits(String(x))
+_to_bytes(x) = codeunits(string(x))
 
 function isclosed(ws::WebSocket)::Bool
     return ws.readclosed && ws.writeclosed
@@ -215,11 +215,7 @@ function _queue_close!(ws::WebSocket, body::CloseFrameBody)::Nothing
     ws.closebody = body
     ws.readclosed = true
     if isopen(ws.readchannel)
-        try
-            put!(ws.readchannel, WebSocketError(body))
-        catch
-        end
-        close(ws.readchannel)
+        close(ws.readchannel, WebSocketError(body))
     end
     return nothing
 end
@@ -443,17 +439,13 @@ function pong(ws::WebSocket, data = UInt8[])
 end
 
 function receive(ws::WebSocket)
-    if isready(ws.readchannel)
-        msg = take!(ws.readchannel)
-        msg isa WebSocketError && throw(msg)
-        return msg
-    end
     if ws.readclosed || !isopen(ws.readchannel)
+        if isready(ws.readchannel)
+            return take!(ws.readchannel)
+        end
         throw(WebSocketError(ws.closebody === nothing ? CloseFrameBody(1006, "") : ws.closebody::CloseFrameBody))
     end
-    msg = take!(ws.readchannel)
-    msg isa WebSocketError && throw(msg)
-    return msg
+    return take!(ws.readchannel)
 end
 
 function Base.iterate(ws::WebSocket, st = nothing)

--- a/src/7_6_http_websockets.jl
+++ b/src/7_6_http_websockets.jl
@@ -1,7 +1,5 @@
 module WebSockets
 
-using Random
-
 import Base: close, iterate
 
 import ..Headers
@@ -16,7 +14,6 @@ import ..ProtocolError
 import ..TooManyRedirectsError
 import ..Client
 import ..ClientConn
-import ..Cookie
 import ..CookieJar
 import ..COOKIEJAR
 import .._ConnReader
@@ -63,9 +60,8 @@ import ..read_request
 import ..write_response!
 import ..write_request!
 import ..WsOpcode
-import ..WsDecodedFrame
-import ..WsConnection
-import ..ws_connection_new
+import ..WsFrame
+import ..Conn
 import ..ws_send_frame!
 import ..ws_send_ping!
 import ..ws_send_pong!
@@ -89,6 +85,7 @@ export send
 export receive
 export ping
 export pong
+export Conn
 export Server
 export serve!
 export listen!
@@ -117,17 +114,13 @@ function Base.showerror(io::IO, err::WebSocketError)
     return nothing
 end
 
-mutable struct WebSocket{S, C, W <: WsConnection}
-    id::String
-    host::String
-    path::String
+mutable struct WebSocket{S, C}
     subprotocol::Union{Nothing, String}
     stream::S
     close_transport!::C
-    codec::W
+    codec::Conn
     maxframesize::Int
     maxfragmentation::Int
-    is_client::Bool
     readchannel::Channel{Union{String, Vector{UInt8}, WebSocketError}}
     readtask::Union{Nothing, Task}
     readclosed::Bool
@@ -144,9 +137,7 @@ end
 
 function WebSocket(
         stream::S,
-        close_transport!::C,
-        host::AbstractString,
-        path::AbstractString;
+        close_transport!::C;
         subprotocol::Union{Nothing, AbstractString} = nothing,
         maxframesize::Integer = typemax(Int),
         maxfragmentation::Integer = DEFAULT_MAX_FRAG,
@@ -155,18 +146,14 @@ function WebSocket(
     maxframesize > 0 || throw(ArgumentError("maxframesize must be > 0"))
     maxfragmentation > 0 || throw(ArgumentError("maxfragmentation must be > 0"))
     channel = Channel{Union{String, Vector{UInt8}, WebSocketError}}(Inf)
-    codec = ws_connection_new(is_client = is_client)
+    codec = Conn(is_client = is_client)
     ws = WebSocket(
-        string(rand(UInt32); base = 58),
-        String(host),
-        String(path),
         subprotocol === nothing ? nothing : String(subprotocol),
         stream,
         close_transport!,
         codec,
         Int(maxframesize),
         Int(maxfragmentation),
-        is_client,
         channel,
         nothing,
         false,
@@ -196,10 +183,6 @@ opcode(x) = return isbinary(x) ? WsOpcode.BINARY : WsOpcode.TEXT
 _to_bytes(x::AbstractVector{UInt8}) = return x
 _to_bytes(x::AbstractString) = return codeunits(String(x))
 _to_bytes(x) = return codeunits(string(x))
-
-function getresponse(ws::WebSocket)
-    return ws.handshake_response
-end
 
 function isclosed(ws::WebSocket)::Bool
     return ws.readclosed && ws.writeclosed
@@ -285,7 +268,7 @@ function _flush_ws_output!(ws::WebSocket)::Nothing
     return nothing
 end
 
-function _process_incoming_frame!(ws::WebSocket, frame::WsDecodedFrame)::Nothing
+function _process_incoming_frame!(ws::WebSocket, frame::WsFrame)::Nothing
     frame.payload_length <= ws.maxframesize || begin
         close_body = CloseFrameBody(1009, "frame too large")
         _queue_close!(ws, close_body)
@@ -368,10 +351,7 @@ function _ws_read_loop!(ws::WebSocket; buffer_bytes::Int = DEFAULT_READ_BUFFER_B
         while true
             n = read!(ws.stream, buf)
             n == 0 && break
-            frames = ws_on_incoming_data!(ws.codec, @view buf[1:n])
-            for frame in frames
-                _process_incoming_frame!(ws, frame)
-            end
+            ws_on_incoming_data!(frame -> _process_incoming_frame!(ws, frame), ws.codec, @view buf[1:n])
             _flush_ws_output!(ws)
             ws.readclosed && break
         end
@@ -410,15 +390,6 @@ function _start_read_task!(ws::WebSocket; buffer_bytes::Int = DEFAULT_READ_BUFFE
     ws.readtask !== nothing && return nothing
     ws.readtask = errormonitor(Threads.@spawn _ws_read_loop!(ws; buffer_bytes = buffer_bytes))
     return nothing
-end
-
-function writeframe(ws::WebSocket, fin::Bool, op::WsOpcode.T, payload::AbstractVector{UInt8})::Int
-    @lock ws.sendlock begin
-        ws.writeclosed && throw(WebSocketError(CloseFrameBody(1006, "websocket is closed")))
-        ws_send_frame!(ws.codec, UInt8(op), payload; fin = fin)
-        _flush_ws_output_locked!(ws)
-    end
-    return length(payload)
 end
 
 function send(ws::WebSocket, x)
@@ -718,12 +689,9 @@ function _open_client_websocket(
                     return nothing
                 end
             end
-            host_name, _ = HostResolvers.split_host_port(current_address)
             ws = WebSocket(
                 _conn_stream(conn),
                 close_transport!,
-                host_name,
-                current_request.target;
                 subprotocol = negotiated,
                 maxframesize = maxframesize,
                 maxfragmentation = maxfragmentation,
@@ -732,10 +700,7 @@ function _open_client_websocket(
             ws.handshake_request = send_request
             ws.handshake_response = response
             if !isempty(attempt.buffered)
-                frames = ws_on_incoming_data!(ws.codec, attempt.buffered)
-                for frame in frames
-                    _process_incoming_frame!(ws, frame)
-                end
+                ws_on_incoming_data!(frame -> _process_incoming_frame!(ws, frame), ws.codec, attempt.buffered)
                 _flush_ws_output!(ws)
             end
             _start_read_task!(ws)
@@ -1035,13 +1000,9 @@ function _serve_ws_session!(server::Server, conn, request::Request, response::Re
         _close_ws_server_conn!(conn)
         return nothing
     end
-    request_host = request.host === nothing ? get_header(request.headers, "Host") : request.host
-    request_host === nothing && (request_host = "")
     ws = WebSocket(
         conn,
         close_transport!,
-        request_host::String,
-        request.target;
         subprotocol = get_header(response.headers, "Sec-WebSocket-Protocol"),
         maxframesize = server.maxframesize,
         maxfragmentation = server.maxfragmentation,

--- a/src/7_6_http_websockets.jl
+++ b/src/7_6_http_websockets.jl
@@ -619,7 +619,7 @@ function _open_client_websocket(
         connect_timeout::Real = 0,
         require_ssl_verification::Bool = true,
         kwargs...,
-    )::Tuple{WebSocket, Client, Bool}
+    )::WebSocket
     _validate_request_extra_kwargs(kwargs)
     parsed = _parse_websocket_url(url; query = query)
     req_headers = _normalize_headers_input(headers)
@@ -696,7 +696,7 @@ function _open_client_websocket(
                 _flush_ws_output!(ws)
             end
             _start_read_task!(ws)
-            return ws, req_client, owns_client
+            return ws
         end
         if !_is_redirect_status(response.status_code) || redirect_policy.max_redirects == 0
             owns_client && close(req_client)
@@ -760,7 +760,7 @@ function open(
         require_ssl_verification::Bool = true,
         kwargs...,
     )
-    ws, _, _ = _open_client_websocket(
+    ws = _open_client_websocket(
         url;
         headers = headers,
         maxframesize = maxframesize,

--- a/src/7_6_http_websockets.jl
+++ b/src/7_6_http_websockets.jl
@@ -1,0 +1,843 @@
+module WebSockets
+
+using Random
+
+import Base: close, iterate
+
+import ..Headers
+import ..HostResolvers
+import ..Request
+import ..Response
+import ..EmptyBody
+import ..ProtocolError
+import ..TooManyRedirectsError
+import ..Client
+import ..ClientConn
+import ..Cookie
+import ..CookieJar
+import ..COOKIEJAR
+import .._ConnReader
+import .._USE_TRANSPORT_PROXY
+import .._close_conn!
+import .._client_for_request
+import .._conn_reader_available
+import .._conn_stream
+import .._copy_request
+import .._copy_request_for_send
+import .._cookie_header
+import .._effective_cookiejar
+import .._host_for_sni
+import .._host_path_from_request
+import .._normalize_cookies_input
+import .._normalize_headers_input
+import .._parse_http_url
+import .._prepare_request_for_redirect
+import .._proxy_config_for_request
+import .._proxy_plan
+import .._ProxyPlanMode
+import .._ProxyTarget
+import .._read_incoming_response
+import .._redirect_policy
+import .._redirect_referer
+import .._request_deadline_ns
+import .._request_url
+import .._resolve_redirect_target
+import .._should_copy_sensitive_headers_on_redirect
+import .._store_set_cookies!
+import .._strip_sensitive_redirect_headers!
+import .._streaming_response
+import .._validate_request_extra_kwargs
+import .._apply_conn_deadline!
+import .._new_conn!
+import .._is_redirect_status
+import ..get_header
+import ..get_headers
+import ..has_header
+import ..set_header!
+import ..delete_header!
+import ..body_close!
+import ..write_request!
+import ..WsOpcode
+import ..WsDecodedFrame
+import ..WsConnection
+import ..ws_connection_new
+import ..ws_send_frame!
+import ..ws_send_ping!
+import ..ws_send_pong!
+import ..ws_close!
+import ..ws_on_incoming_data!
+import ..ws_get_outgoing_data!
+import ..ws_random_handshake_key
+import ..ws_compute_accept_key
+import ..ws_decode_close_payload
+import ..ws_is_valid_close_status
+import ..ws_select_subprotocol
+import ..ws_is_websocket_request
+import ..WebSocketProtocolError
+import ..WebSocketInvalidPayloadError
+
+export WebSocket
+export WebSocketError
+export CloseFrameBody
+export send
+export receive
+export ping
+export pong
+
+const DEFAULT_MAX_FRAG = 1024
+const DEFAULT_READ_BUFFER_BYTES = 16 * 1024
+
+struct CloseFrameBody
+    code::Int
+    reason::String
+end
+
+struct WebSocketError <: Exception
+    message::CloseFrameBody
+end
+
+isok(err::WebSocketError) = return err.message.code in (1000, 1001, 1005)
+isok(_) = return false
+
+function Base.showerror(io::IO, err::WebSocketError)
+    print(io, "websocket closed with status ", err.message.code)
+    isempty(err.message.reason) || print(io, ": ", err.message.reason)
+    return nothing
+end
+
+mutable struct WebSocket{S, C, W <: WsConnection}
+    id::String
+    host::String
+    path::String
+    subprotocol::Union{Nothing, String}
+    stream::S
+    close_transport!::C
+    codec::W
+    maxframesize::Int
+    maxfragmentation::Int
+    is_client::Bool
+    readchannel::Channel{Union{String, Vector{UInt8}, WebSocketError}}
+    readtask::Union{Nothing, Task}
+    readclosed::Bool
+    writeclosed::Bool
+    closelock::ReentrantLock
+    sendlock::ReentrantLock
+    handshake_request::Union{Nothing, Request}
+    handshake_response::Union{Nothing, Response}
+    fragment_opcode::Union{Nothing, UInt8}
+    fragment_payload::Vector{UInt8}
+    fragment_count::Int
+    closebody::Union{Nothing, CloseFrameBody}
+end
+
+function WebSocket(
+        stream::S,
+        close_transport!::C,
+        host::AbstractString,
+        path::AbstractString;
+        subprotocol::Union{Nothing, AbstractString} = nothing,
+        maxframesize::Integer = typemax(Int),
+        maxfragmentation::Integer = DEFAULT_MAX_FRAG,
+        is_client::Bool = true,
+    ) where {S, C}
+    maxframesize > 0 || throw(ArgumentError("maxframesize must be > 0"))
+    maxfragmentation > 0 || throw(ArgumentError("maxfragmentation must be > 0"))
+    channel = Channel{Union{String, Vector{UInt8}, WebSocketError}}(Inf)
+    codec = ws_connection_new(is_client = is_client)
+    ws = WebSocket(
+        string(rand(UInt32); base = 58),
+        String(host),
+        String(path),
+        subprotocol === nothing ? nothing : String(subprotocol),
+        stream,
+        close_transport!,
+        codec,
+        Int(maxframesize),
+        Int(maxfragmentation),
+        is_client,
+        channel,
+        nothing,
+        false,
+        false,
+        ReentrantLock(),
+        ReentrantLock(),
+        nothing,
+        nothing,
+        nothing,
+        UInt8[],
+        0,
+        nothing,
+    )
+    return ws
+end
+
+struct _ClientHandshake
+    conn::Union{Nothing, ClientConn}
+    response::Response
+    buffered::Vector{UInt8}
+    request::Request
+end
+
+isbinary(x) = return x isa AbstractVector{UInt8}
+istext(x) = return x isa AbstractString
+opcode(x) = return isbinary(x) ? WsOpcode.BINARY : WsOpcode.TEXT
+_to_bytes(x::AbstractVector{UInt8}) = return x
+_to_bytes(x::AbstractString) = return codeunits(String(x))
+_to_bytes(x) = return codeunits(string(x))
+
+function getresponse(ws::WebSocket)
+    return ws.handshake_response
+end
+
+function isclosed(ws::WebSocket)::Bool
+    return ws.readclosed && ws.writeclosed
+end
+
+function isupgrade(message::Request)::Bool
+    return ws_is_websocket_request(message)
+end
+
+function isupgrade(message::Response)::Bool
+    message.status_code == 101 || return false
+    _response_has_token(message.headers, "Upgrade", "websocket") || return false
+    _response_has_token(message.headers, "Connection", "upgrade") || return false
+    return true
+end
+
+function _response_has_token(headers::Headers, name::AbstractString, token::AbstractString)::Bool
+    values = get_headers(headers, name)
+    isempty(values) && return false
+    lower_token = lowercase(token)
+    for value in values
+        for part in eachsplit(value, ',')
+            lowercase(strip(part)) == lower_token && return true
+        end
+    end
+    return false
+end
+
+function _queue_close!(ws::WebSocket, body::CloseFrameBody)::Nothing
+    ws.closebody = body
+    ws.readclosed = true
+    if isopen(ws.readchannel)
+        try
+            put!(ws.readchannel, WebSocketError(body))
+        catch
+        end
+        close(ws.readchannel)
+    end
+    return nothing
+end
+
+function _close_channel!(ws::WebSocket)::Nothing
+    isopen(ws.readchannel) && close(ws.readchannel)
+    return nothing
+end
+
+function _enqueue_message!(ws::WebSocket, msg)::Nothing
+    if isopen(ws.readchannel)
+        try
+            put!(ws.readchannel, msg)
+        catch
+        end
+    end
+    return nothing
+end
+
+function _valid_close_status(code::Int)::Bool
+    code < 0 && return false
+    code > typemax(UInt16) && return false
+    return ws_is_valid_close_status(UInt16(code))
+end
+
+function _take_conn_reader_buffer!(reader::_ConnReader)::Vector{UInt8}
+    available = _conn_reader_available(reader)
+    available == 0 && return UInt8[]
+    buffered = Vector{UInt8}(undef, available)
+    copyto!(buffered, 1, reader.buf, reader.next, available)
+    reader.next = reader.stop + 1
+    return buffered
+end
+
+function _flush_ws_output_locked!(ws::WebSocket)::Nothing
+    outgoing = ws_get_outgoing_data!(ws.codec)
+    isempty(outgoing) && return nothing
+    write(ws.stream, outgoing)
+    return nothing
+end
+
+function _flush_ws_output!(ws::WebSocket)::Nothing
+    @lock ws.sendlock begin
+        _flush_ws_output_locked!(ws)
+    end
+    return nothing
+end
+
+function _process_incoming_frame!(ws::WebSocket, frame::WsDecodedFrame)::Nothing
+    frame.payload_length <= ws.maxframesize || begin
+        close_body = CloseFrameBody(1009, "frame too large")
+        _queue_close!(ws, close_body)
+        return nothing
+    end
+    op = frame.opcode
+    fin = frame.fin
+    frame_payload = copy(frame.payload)
+    if op == UInt8(WsOpcode.PING) || op == UInt8(WsOpcode.PONG)
+        return nothing
+    end
+    if op == UInt8(WsOpcode.CLOSE)
+        close_body = if length(frame_payload) >= 2
+            code, reason = ws_decode_close_payload(frame_payload)
+            _valid_close_status(Int(code)) || begin
+                _queue_close!(ws, CloseFrameBody(1002, "invalid close status code"))
+                return nothing
+            end
+            CloseFrameBody(Int(code), isempty(reason) ? "" : String(reason))
+        else
+            CloseFrameBody(1005, "")
+        end
+        ws.writeclosed = true
+        _queue_close!(ws, close_body)
+        return nothing
+    end
+    if op == UInt8(WsOpcode.CONTINUATION)
+        ws.fragment_opcode === nothing && begin
+            _queue_close!(ws, CloseFrameBody(1002, "unexpected continuation"))
+            return nothing
+        end
+        ws.fragment_count += 1
+        if ws.fragment_count > ws.maxfragmentation
+            _queue_close!(ws, CloseFrameBody(1009, "message too large"))
+            return nothing
+        end
+        append!(ws.fragment_payload, frame_payload)
+        if fin
+            msg_opcode = ws.fragment_opcode::UInt8
+            data = copy(ws.fragment_payload)
+            ws.fragment_opcode = nothing
+            empty!(ws.fragment_payload)
+            ws.fragment_count = 0
+            if msg_opcode == UInt8(WsOpcode.TEXT)
+                _enqueue_message!(ws, String(data))
+            else
+                _enqueue_message!(ws, data)
+            end
+        end
+        return nothing
+    end
+    if op == UInt8(WsOpcode.TEXT) || op == UInt8(WsOpcode.BINARY)
+        ws.fragment_opcode === nothing || begin
+            _queue_close!(ws, CloseFrameBody(1002, "unexpected new data frame"))
+            return nothing
+        end
+        if fin
+            if op == UInt8(WsOpcode.TEXT)
+                _enqueue_message!(ws, String(frame_payload))
+            else
+                _enqueue_message!(ws, frame_payload)
+            end
+            ws.fragment_count = 0
+        else
+            ws.fragment_opcode = op
+            ws.fragment_payload = frame_payload
+            ws.fragment_count = 1
+            if ws.fragment_count > ws.maxfragmentation
+                _queue_close!(ws, CloseFrameBody(1009, "message too large"))
+            end
+        end
+    end
+    return nothing
+end
+
+function _ws_read_loop!(ws::WebSocket; buffer_bytes::Int = DEFAULT_READ_BUFFER_BYTES)::Nothing
+    buffer_bytes > 0 || throw(ArgumentError("buffer_bytes must be > 0"))
+    buf = Vector{UInt8}(undef, buffer_bytes)
+    try
+        while true
+            n = read!(ws.stream, buf)
+            n == 0 && break
+            frames = ws_on_incoming_data!(ws.codec, @view buf[1:n])
+            for frame in frames
+                _process_incoming_frame!(ws, frame)
+            end
+            _flush_ws_output!(ws)
+            ws.readclosed && break
+        end
+        if !ws.readclosed
+            _queue_close!(ws, CloseFrameBody(1006, ""))
+        end
+    catch err
+        close_body = if err isa WebSocketInvalidPayloadError
+            CloseFrameBody(1007, "invalid websocket payload")
+        elseif err isa WebSocketProtocolError
+            CloseFrameBody(1002, "websocket protocol error")
+        else
+            CloseFrameBody(1006, "")
+        end
+        if !ws.readclosed
+            _queue_close!(ws, close_body)
+        end
+        if !ws.writeclosed && close_body.code != 1006
+            try
+                close(ws, close_body)
+            catch
+            end
+        end
+    finally
+        if ws.readclosed && ws.writeclosed
+            try
+                ws.close_transport!()
+            catch
+            end
+        end
+    end
+    return nothing
+end
+
+function _start_read_task!(ws::WebSocket)::Nothing
+    ws.readtask !== nothing && return nothing
+    ws.readtask = errormonitor(Threads.@spawn _ws_read_loop!(ws))
+    return nothing
+end
+
+function writeframe(ws::WebSocket, fin::Bool, op::WsOpcode.T, payload::AbstractVector{UInt8})::Int
+    @lock ws.sendlock begin
+        ws.writeclosed && throw(WebSocketError(CloseFrameBody(1006, "websocket is closed")))
+        ws_send_frame!(ws.codec, UInt8(op), payload; fin = fin)
+        _flush_ws_output_locked!(ws)
+    end
+    return length(payload)
+end
+
+function send(ws::WebSocket, x)
+    @lock ws.sendlock begin
+        ws.writeclosed && throw(WebSocketError(CloseFrameBody(1006, "websocket is closed")))
+        if !isbinary(x) && !istext(x)
+            first = true
+            total = 0
+            state = iterate(x)
+            if state === nothing
+                ws_send_frame!(ws.codec, UInt8(WsOpcode.TEXT), UInt8[]; fin = true)
+                _flush_ws_output_locked!(ws)
+                return 0
+            end
+            item, st = state
+            next_state = iterate(x, st)
+            while true
+                total += length(_to_bytes(item))
+                ws_send_frame!(ws.codec, UInt8(first ? opcode(item) : WsOpcode.CONTINUATION), _to_bytes(item); fin = next_state === nothing)
+                first = false
+                next_state === nothing && break
+                item, st = next_state
+                next_state = iterate(x, st)
+            end
+            _flush_ws_output_locked!(ws)
+            return total
+        end
+        bytes = _to_bytes(x)
+        ws_send_frame!(ws.codec, UInt8(opcode(x)), bytes; fin = true)
+        _flush_ws_output_locked!(ws)
+        return length(bytes)
+    end
+end
+
+function ping(ws::WebSocket, data = UInt8[])
+    @lock ws.sendlock begin
+        ws.writeclosed && throw(WebSocketError(CloseFrameBody(1006, "websocket is closed")))
+        ws_send_ping!(ws.codec, _to_bytes(data))
+        _flush_ws_output_locked!(ws)
+    end
+    return nothing
+end
+
+function pong(ws::WebSocket, data = UInt8[])
+    @lock ws.sendlock begin
+        ws.writeclosed && throw(WebSocketError(CloseFrameBody(1006, "websocket is closed")))
+        ws_send_pong!(ws.codec, _to_bytes(data))
+        _flush_ws_output_locked!(ws)
+    end
+    return nothing
+end
+
+function receive(ws::WebSocket)
+    if isready(ws.readchannel)
+        msg = take!(ws.readchannel)
+        msg isa WebSocketError && throw(msg)
+        return msg
+    end
+    if ws.readclosed || !isopen(ws.readchannel)
+        throw(WebSocketError(ws.closebody === nothing ? CloseFrameBody(1006, "") : ws.closebody::CloseFrameBody))
+    end
+    msg = take!(ws.readchannel)
+    msg isa WebSocketError && throw(msg)
+    return msg
+end
+
+function Base.iterate(ws::WebSocket, st = nothing)
+    isclosed(ws) && return nothing
+    try
+        return receive(ws), nothing
+    catch err
+        isok(err) && return nothing
+        rethrow(err)
+    end
+end
+
+function close(ws::WebSocket, body::Union{Nothing, CloseFrameBody} = nothing)
+    @lock ws.closelock begin
+        if !ws.writeclosed
+            ws.writeclosed = true
+            if body !== nothing
+                if !_valid_close_status(body.code)
+                    body = CloseFrameBody(1002, "invalid close status code")
+                end
+                try
+                    @lock ws.sendlock begin
+                        ws_close!(ws.codec; status_code = UInt16(body.code), reason = codeunits(body.reason))
+                        _flush_ws_output_locked!(ws)
+                    end
+                catch
+                end
+            else
+                try
+                    @lock ws.sendlock begin
+                        ws_close!(ws.codec; status_code = UInt16(1000), reason = UInt8[])
+                        _flush_ws_output_locked!(ws)
+                    end
+                catch
+                end
+            end
+        end
+    end
+    if !ws.readclosed
+        deadline = time() + 5.0
+        while time() < deadline
+            ws.readclosed && break
+            sleep(0.05)
+        end
+        ws.readclosed = true
+    end
+    try
+        ws.close_transport!()
+    catch
+    end
+    _close_channel!(ws)
+    return nothing
+end
+
+function _apply_websocket_request_headers!(
+        headers::Headers,
+        key::String;
+        subprotocols::AbstractVector{<:AbstractString} = String[],
+    )::Nothing
+    set_header!(headers, "Upgrade", "websocket")
+    set_header!(headers, "Connection", "Upgrade")
+    set_header!(headers, "Sec-WebSocket-Key", key)
+    set_header!(headers, "Sec-WebSocket-Version", "13")
+    if isempty(subprotocols)
+        delete_header!(headers, "Sec-WebSocket-Protocol")
+    else
+        set_header!(headers, "Sec-WebSocket-Protocol", join(String.(subprotocols), ", "))
+    end
+    return nothing
+end
+
+function _parse_websocket_url(url::AbstractString; query = nothing)
+    text = String(url)
+    lower = lowercase(text)
+    if startswith(lower, "ws://")
+        return _parse_http_url("http://" * text[6:end]; query = query)
+    elseif startswith(lower, "wss://")
+        return _parse_http_url("https://" * text[7:end]; query = query)
+    elseif startswith(lower, "http://") || startswith(lower, "https://")
+        return _parse_http_url(text; query = query)
+    end
+    throw(ArgumentError("websocket URL must use ws://, wss://, http://, or https://"))
+end
+
+function _normalize_websocket_redirect_location(location::AbstractString)::String
+    text = String(location)
+    lower = lowercase(text)
+    if startswith(lower, "ws://")
+        return "http://" * text[6:end]
+    elseif startswith(lower, "wss://")
+        return "https://" * text[7:end]
+    end
+    return text
+end
+
+function _validate_websocket_upgrade!(
+        response::Response,
+        expected_accept::String,
+        requested_subprotocols::AbstractVector{<:AbstractString},
+    )::Union{Nothing, String}
+    isupgrade(response) || throw(WebSocketError(CloseFrameBody(1002, "websocket handshake failed")))
+    accept = get_header(response.headers, "Sec-WebSocket-Accept")
+    accept == expected_accept || throw(WebSocketError(CloseFrameBody(1002, "websocket handshake accept mismatch")))
+    subprotocol = get_header(response.headers, "Sec-WebSocket-Protocol")
+    subprotocol === nothing && return nothing
+    normalized = strip(subprotocol)
+    isempty(normalized) && return nothing
+    if isempty(requested_subprotocols)
+        throw(WebSocketError(CloseFrameBody(1002, "unexpected websocket subprotocol in response")))
+    end
+    normalized in String.(requested_subprotocols) || throw(WebSocketError(CloseFrameBody(1002, "unrequested websocket subprotocol in response")))
+    return normalized
+end
+
+function _websocket_roundtrip!(
+        client::Client,
+        address::String,
+        request::Request;
+        secure::Bool,
+        server_name::String,
+        proxy_config,
+    )::_ClientHandshake
+    deadline_ns = _request_deadline_ns(request)
+    plan = _proxy_plan(proxy_config, secure, address)
+    conn = _new_conn!(client.transport, plan, address; secure = secure, server_name = server_name, deadline_ns = deadline_ns)
+    try
+        _apply_conn_deadline!(conn, deadline_ns)
+        request_io = conn.request_buf
+        truncate(request_io, 0)
+        seekstart(request_io)
+        wire_target = plan.mode == _ProxyPlanMode.HTTP_FORWARD ? _request_url(secure, address, request.target) : nothing
+        proxy_auth = plan.mode == _ProxyPlanMode.HTTP_FORWARD && plan.proxy !== nothing ? (plan.proxy::_ProxyTarget).authorization : nothing
+        write_request!(request_io, request; wire_target = wire_target, proxy_authorization = proxy_auth)
+        stream = _conn_stream(conn)
+        nbytes = request_io.size
+        wrote = write(stream, request_io.data, nbytes)
+        wrote == nbytes || throw(ProtocolError("transport short write"))
+        response = _read_incoming_response(conn.reader, request)
+        try
+            body_close!(response.rawbody)
+        catch
+        end
+        buffered = response.head.status_code == 101 ? _take_conn_reader_buffer!(conn.reader) : UInt8[]
+        public_response = _streaming_response(response)
+        if response.head.status_code != 101
+            _close_conn!(conn)
+            return _ClientHandshake(nothing, public_response, UInt8[], request)
+        end
+        return _ClientHandshake(conn, public_response, buffered, request)
+    catch
+        _close_conn!(conn)
+        rethrow()
+    end
+end
+
+function _open_client_websocket(
+        url::AbstractString;
+        headers = Pair{String, String}[],
+        maxframesize::Integer = typemax(Int),
+        maxfragmentation::Integer = DEFAULT_MAX_FRAG,
+        subprotocols::AbstractVector{<:AbstractString} = String[],
+        query = nothing,
+        client::Union{Nothing, Client} = nothing,
+        redirect::Bool = true,
+        redirect_limit::Union{Nothing, Integer} = nothing,
+        redirect_method = nothing,
+        forwardheaders::Bool = true,
+        cookies = true,
+        cookiejar::Union{Nothing, CookieJar} = nothing,
+        proxy = _USE_TRANSPORT_PROXY,
+        connect_timeout::Real = 0,
+        require_ssl_verification::Bool = true,
+        kwargs...,
+    )::Tuple{WebSocket, Client, Bool}
+    _validate_request_extra_kwargs(kwargs)
+    parsed = _parse_websocket_url(url; query = query)
+    req_headers = _normalize_headers_input(headers)
+    normalized_cookies = _normalize_cookies_input(cookies)
+    if parsed.authorization !== nothing && !has_header(req_headers, "Authorization")
+        set_header!(req_headers, "Authorization", parsed.authorization::String)
+    end
+    key = ws_random_handshake_key()
+    _apply_websocket_request_headers!(req_headers, key; subprotocols = subprotocols)
+    request = Request("GET", parsed.target; headers = req_headers, host = parsed.address, body = EmptyBody(), content_length = 0)
+    req_client, owns_client = _client_for_request(client; connect_timeout = connect_timeout, require_ssl_verification = require_ssl_verification)
+    client === nothing || proxy === _USE_TRANSPORT_PROXY || throw(ArgumentError("proxy override is not supported when passing an explicit Client"))
+    proxy_config = _proxy_config_for_request(req_client, proxy)
+    effective_cookiejar = _effective_cookiejar(client, cookiejar)
+    redirect_policy = _redirect_policy(
+        req_client;
+        redirect_limit = redirect ? redirect_limit : 0,
+        redirect_method = redirect_method,
+        forwardheaders = forwardheaders,
+    )
+    current_address = parsed.address
+    current_secure = parsed.secure
+    current_server_name = parsed.server_name
+    current_request = request
+    initial_address = current_address
+    for redirect_count in 0:redirect_policy.max_redirects
+        send_request = _copy_request(current_request)
+        host, path = _host_path_from_request(current_address, current_request)
+        cookie_value = _cookie_header(effective_cookiejar, normalized_cookies, current_secure, host, path)
+        cookie_value === nothing || set_header!(send_request.headers, "Cookie", cookie_value)
+        expected_accept = ws_compute_accept_key(get_header(send_request.headers, "Sec-WebSocket-Key")::String)
+        attempt = _websocket_roundtrip!(
+            req_client,
+            current_address,
+            send_request;
+            secure = current_secure,
+            server_name = current_server_name,
+            proxy_config = proxy_config,
+        )
+        _store_set_cookies!(effective_cookiejar, normalized_cookies, current_secure, host, path, attempt.response.headers)
+        response = attempt.response
+        if response.status_code == 101
+            negotiated = try
+                _validate_websocket_upgrade!(response, expected_accept, subprotocols)
+            catch
+                attempt.conn === nothing || _close_conn!(attempt.conn::ClientConn)
+                owns_client && close(req_client)
+                rethrow()
+            end
+            conn = attempt.conn
+            conn === nothing && begin
+                owns_client && close(req_client)
+                throw(ProtocolError("websocket upgrade succeeded without an active connection"))
+            end
+            close_transport! = let conn = conn::ClientConn, owned_client = owns_client, local_client = req_client
+                () -> begin
+                    _close_conn!(conn)
+                    owned_client && close(local_client)
+                    return nothing
+                end
+            end
+            host_name, _ = HostResolvers.split_host_port(current_address)
+            ws = WebSocket(
+                _conn_stream(conn),
+                close_transport!,
+                host_name,
+                current_request.target;
+                subprotocol = negotiated,
+                maxframesize = maxframesize,
+                maxfragmentation = maxfragmentation,
+                is_client = true,
+            )
+            ws.handshake_request = send_request
+            ws.handshake_response = response
+            if !isempty(attempt.buffered)
+                frames = ws_on_incoming_data!(ws.codec, attempt.buffered)
+                for frame in frames
+                    _process_incoming_frame!(ws, frame)
+                end
+                _flush_ws_output!(ws)
+            end
+            _start_read_task!(ws)
+            return ws, req_client, owns_client
+        end
+        if !_is_redirect_status(response.status_code) || redirect_policy.max_redirects == 0
+            owns_client && close(req_client)
+            throw(WebSocketError(CloseFrameBody(1002, "websocket handshake failed: status $(response.status_code)")))
+        end
+        location = get_header(response.headers, "Location")
+        (location === nothing || isempty(location::String)) && begin
+            owns_client && close(req_client)
+            throw(WebSocketError(CloseFrameBody(1002, "websocket handshake failed: status $(response.status_code)")))
+        end
+        redirect_count == redirect_policy.max_redirects && begin
+            owns_client && close(req_client)
+            throw(TooManyRedirectsError(redirect_policy.max_redirects, response))
+        end
+        previous_secure = current_secure
+        previous_address = current_address
+        previous_target = current_request.target
+        current_address, current_secure, next_target = _resolve_redirect_target(
+            current_address,
+            current_secure,
+            _normalize_websocket_redirect_location(location::String),
+            current_request.target,
+        )
+        current_server_name = _host_for_sni(current_address)
+        current_request = _prepare_request_for_redirect(current_request, response.status_code, next_target, redirect_policy)
+        key = ws_random_handshake_key()
+        _apply_websocket_request_headers!(current_request.headers, key; subprotocols = subprotocols)
+        current_request.host = current_address
+        next_ref = _redirect_referer(previous_secure, previous_address, previous_target, current_secure, get_header(current_request.headers, "Referer"))
+        if next_ref === nothing
+            delete_header!(current_request.headers, "Referer")
+        else
+            set_header!(current_request.headers, "Referer", next_ref::String)
+        end
+        if !_should_copy_sensitive_headers_on_redirect(initial_address, current_address)
+            _strip_sensitive_redirect_headers!(current_request.headers)
+            _apply_websocket_request_headers!(current_request.headers, key; subprotocols = subprotocols)
+        end
+    end
+    owns_client && close(req_client)
+    throw(ProtocolError("unexpected websocket redirect loop termination"))
+end
+
+function open(
+        url::AbstractString;
+        suppress_close_error::Bool = false,
+        headers = Pair{String, String}[],
+        maxframesize::Integer = typemax(Int),
+        maxfragmentation::Integer = DEFAULT_MAX_FRAG,
+        subprotocols::AbstractVector{<:AbstractString} = String[],
+        query = nothing,
+        client::Union{Nothing, Client} = nothing,
+        redirect::Bool = true,
+        redirect_limit::Union{Nothing, Integer} = nothing,
+        redirect_method = nothing,
+        forwardheaders::Bool = true,
+        cookies = true,
+        cookiejar::Union{Nothing, CookieJar} = nothing,
+        proxy = _USE_TRANSPORT_PROXY,
+        connect_timeout::Real = 0,
+        require_ssl_verification::Bool = true,
+        kwargs...,
+    )
+    ws, _, _ = _open_client_websocket(
+        url;
+        headers = headers,
+        maxframesize = maxframesize,
+        maxfragmentation = maxfragmentation,
+        subprotocols = subprotocols,
+        query = query,
+        client = client,
+        redirect = redirect,
+        redirect_limit = redirect_limit,
+        redirect_method = redirect_method,
+        forwardheaders = forwardheaders,
+        cookies = cookies,
+        cookiejar = cookiejar,
+        proxy = proxy,
+        connect_timeout = connect_timeout,
+        require_ssl_verification = require_ssl_verification,
+        kwargs...,
+    )
+    return ws
+end
+
+function open(
+        f::Function,
+        url::AbstractString;
+        suppress_close_error::Bool = false,
+        kwargs...,
+    )
+    ws = open(url; suppress_close_error = suppress_close_error, kwargs...)
+    try
+        return f(ws)
+    catch err
+        if err isa WebSocketError && isok(err)
+            return nothing
+        end
+        rethrow(err)
+    finally
+        if !isclosed(ws)
+            try
+                close(ws, CloseFrameBody(1000, ""))
+            catch err
+                if !(suppress_close_error && err isa WebSocketError)
+                    rethrow(err)
+                end
+            end
+        end
+    end
+end
+
+end

--- a/src/7_6_http_websockets.jl
+++ b/src/7_6_http_websockets.jl
@@ -8,6 +8,9 @@ import ..Headers
 import ..HostResolvers
 import ..Request
 import ..Response
+import ..TCP
+import ..TLS
+import ..BytesBody
 import ..EmptyBody
 import ..ProtocolError
 import ..TooManyRedirectsError
@@ -56,6 +59,8 @@ import ..has_header
 import ..set_header!
 import ..delete_header!
 import ..body_close!
+import ..read_request
+import ..write_response!
 import ..write_request!
 import ..WsOpcode
 import ..WsDecodedFrame
@@ -71,6 +76,7 @@ import ..ws_random_handshake_key
 import ..ws_compute_accept_key
 import ..ws_decode_close_payload
 import ..ws_is_valid_close_status
+import ..ws_get_request_sec_websocket_key
 import ..ws_select_subprotocol
 import ..ws_is_websocket_request
 import ..WebSocketProtocolError
@@ -83,6 +89,12 @@ export send
 export receive
 export ping
 export pong
+export Server
+export serve!
+export listen!
+export listen
+export server_addr
+export shutdown!
 
 const DEFAULT_MAX_FRAG = 1024
 const DEFAULT_READ_BUFFER_BYTES = 16 * 1024
@@ -394,9 +406,9 @@ function _ws_read_loop!(ws::WebSocket; buffer_bytes::Int = DEFAULT_READ_BUFFER_B
     return nothing
 end
 
-function _start_read_task!(ws::WebSocket)::Nothing
+function _start_read_task!(ws::WebSocket; buffer_bytes::Int = DEFAULT_READ_BUFFER_BYTES)::Nothing
     ws.readtask !== nothing && return nothing
-    ws.readtask = errormonitor(Threads.@spawn _ws_read_loop!(ws))
+    ws.readtask = errormonitor(Threads.@spawn _ws_read_loop!(ws; buffer_bytes = buffer_bytes))
     return nothing
 end
 
@@ -838,6 +850,373 @@ function open(
             end
         end
     end
+end
+
+mutable struct Server
+    network::String
+    address::String
+    handler::Function
+    tls_config::Union{Nothing, TLS.Config}
+    subprotocols::Vector{String}
+    check_origin::Union{Nothing, Function}
+    maxframesize::Int
+    maxfragmentation::Int
+    read_buffer_bytes::Int
+    lock::ReentrantLock
+    listener::Union{Nothing, TCP.Listener, TLS.Listener}
+    serve_task::Union{Nothing, Task}
+    active_tcp_conns::Set{TCP.Conn}
+    active_tls_conns::Set{TLS.Conn}
+    active_tasks::Set{Task}
+    bound_address::Union{Nothing, String}
+    @atomic shutting_down::Bool
+end
+
+function Server(;
+        network::AbstractString = "tcp",
+        address::AbstractString = "127.0.0.1:0",
+        handler::Function,
+        tls_config::Union{Nothing, TLS.Config} = nothing,
+        subprotocols::AbstractVector{<:AbstractString} = String[],
+        check_origin::Union{Nothing, Function} = nothing,
+        maxframesize::Integer = typemax(Int),
+        maxfragmentation::Integer = DEFAULT_MAX_FRAG,
+        read_buffer_bytes::Integer = DEFAULT_READ_BUFFER_BYTES,
+    )
+    maxframesize > 0 || throw(ArgumentError("maxframesize must be > 0"))
+    maxfragmentation > 0 || throw(ArgumentError("maxfragmentation must be > 0"))
+    read_buffer_bytes > 0 || throw(ArgumentError("read_buffer_bytes must be > 0"))
+    return Server(
+        String(network),
+        String(address),
+        handler,
+        tls_config,
+        String.(subprotocols),
+        check_origin,
+        Int(maxframesize),
+        Int(maxfragmentation),
+        Int(read_buffer_bytes),
+        ReentrantLock(),
+        nothing,
+        nothing,
+        Set{TCP.Conn}(),
+        Set{TLS.Conn}(),
+        Set{Task}(),
+        nothing,
+        false,
+    )
+end
+
+@inline function _server_shutting_down(server::Server)::Bool
+    return @atomic :acquire server.shutting_down
+end
+
+function server_addr(server::Server)::String
+    lock(server.lock)
+    try
+        server.bound_address === nothing && throw(ProtocolError("websocket server is not listening"))
+        return server.bound_address::String
+    finally
+        unlock(server.lock)
+    end
+end
+
+function _listener_bound_address(listener)::String
+    if listener isa TLS.Listener
+        laddr = TLS.addr(listener::TLS.Listener)
+    else
+        laddr = TCP.addr(listener::TCP.Listener)
+    end
+    if laddr isa TCP.SocketAddrV4
+        return HostResolvers.join_host_port("127.0.0.1", Int((laddr::TCP.SocketAddrV4).port))
+    end
+    return HostResolvers.join_host_port("::1", Int((laddr::TCP.SocketAddrV6).port))
+end
+
+function _track_conn!(server::Server, conn, task::Task)::Nothing
+    lock(server.lock)
+    try
+        if conn isa TCP.Conn
+            push!(server.active_tcp_conns, conn::TCP.Conn)
+        else
+            push!(server.active_tls_conns, conn::TLS.Conn)
+        end
+        push!(server.active_tasks, task)
+    finally
+        unlock(server.lock)
+    end
+    return nothing
+end
+
+function _untrack_conn!(server::Server, conn, task::Task)::Nothing
+    lock(server.lock)
+    try
+        if conn isa TCP.Conn
+            delete!(server.active_tcp_conns, conn::TCP.Conn)
+        else
+            delete!(server.active_tls_conns, conn::TLS.Conn)
+        end
+        delete!(server.active_tasks, task)
+    finally
+        unlock(server.lock)
+    end
+    return nothing
+end
+
+function _close_ws_server_conn!(conn)::Nothing
+    try
+        if conn isa TLS.Conn
+            TLS.close!(conn::TLS.Conn)
+        else
+            TCP.close!(conn::TCP.Conn)
+        end
+    catch
+    end
+    return nothing
+end
+
+function _write_ws_response!(conn, response::Response)::Nothing
+    io = IOBuffer()
+    write_response!(io, response)
+    bytes = take!(io)
+    write(conn, bytes)
+    return nothing
+end
+
+function _origin_allowed_default(request::Request)::Bool
+    origin = get_header(request.headers, "Origin")
+    origin === nothing && return true
+    parsed = try
+        _parse_http_url(origin::String)
+    catch
+        return false
+    end
+    request_host = request.host === nothing ? get_header(request.headers, "Host") : request.host
+    request_host === nothing && return false
+    origin_host, origin_port = HostResolvers.split_host_port(parsed.address)
+    if occursin(':', request_host::String)
+        req_host, req_port = HostResolvers.split_host_port(request_host::String)
+        return lowercase(origin_host) == lowercase(req_host) && origin_port == req_port
+    end
+    return lowercase(origin_host) == lowercase(request_host::String)
+end
+
+function _origin_allowed(server::Server, request::Request)::Bool
+    checker = server.check_origin
+    checker === nothing && return _origin_allowed_default(request)
+    origin = get_header(request.headers, "Origin")
+    if applicable(checker, request, origin)
+        result = checker(request, origin)
+    elseif applicable(checker, request)
+        result = checker(request)
+    else
+        throw(ArgumentError("check_origin callback must accept (request) or (request, origin)"))
+    end
+    result isa Bool || throw(ArgumentError("check_origin callback must return Bool"))
+    return result
+end
+
+function _upgrade_response(request::Request, server::Server)::Response
+    ws_is_websocket_request(request) || return Response(400; body = BytesBody(Vector{UInt8}("websocket upgrade required")), content_length = 26, headers = Headers())
+    _origin_allowed(server, request) || return Response(403; body = BytesBody(Vector{UInt8}("websocket origin rejected")), content_length = 25, headers = Headers())
+    key = ws_get_request_sec_websocket_key(request)
+    key === nothing && return Response(400; body = BytesBody(Vector{UInt8}("missing websocket key")), content_length = 21, headers = Headers())
+    headers = Headers()
+    set_header!(headers, "Upgrade", "websocket")
+    set_header!(headers, "Connection", "Upgrade")
+    set_header!(headers, "Sec-WebSocket-Accept", ws_compute_accept_key(key::String))
+    selected = isempty(server.subprotocols) ? nothing : ws_select_subprotocol(request, server.subprotocols)
+    selected === nothing || set_header!(headers, "Sec-WebSocket-Protocol", selected::String)
+    return Response(101; headers = headers, body = EmptyBody(), content_length = 0, request = request)
+end
+
+function _serve_ws_session!(server::Server, conn, request::Request, response::Response)::Nothing
+    close_transport! = () -> begin
+        _close_ws_server_conn!(conn)
+        return nothing
+    end
+    request_host = request.host === nothing ? get_header(request.headers, "Host") : request.host
+    request_host === nothing && (request_host = "")
+    ws = WebSocket(
+        conn,
+        close_transport!,
+        request_host::String,
+        request.target;
+        subprotocol = get_header(response.headers, "Sec-WebSocket-Protocol"),
+        maxframesize = server.maxframesize,
+        maxfragmentation = server.maxfragmentation,
+        is_client = false,
+    )
+    ws.handshake_request = request
+    ws.handshake_response = response
+    _start_read_task!(ws; buffer_bytes = server.read_buffer_bytes)
+    try
+        server.handler(ws)
+    catch err
+        if !isclosed(ws)
+            if err isa WebSocketError
+                close(ws, (err::WebSocketError).message)
+            else
+                close(ws, CloseFrameBody(1011, "unexpected server websocket error"))
+            end
+        end
+        isok(err) || rethrow(err)
+    finally
+        if !isclosed(ws)
+            try
+                close(ws, CloseFrameBody(1000, ""))
+            catch
+            end
+        end
+    end
+    return nothing
+end
+
+function _serve_ws_conn!(server::Server, conn)::Nothing
+    task = current_task()
+    _track_conn!(server, conn, task)
+    try
+        request = read_request(_ConnReader(conn))
+        response = _upgrade_response(request, server)
+        _write_ws_response!(conn, response)
+        response.status_code == 101 || return nothing
+        _serve_ws_session!(server, conn, request, response)
+    finally
+        _close_ws_server_conn!(conn)
+        _untrack_conn!(server, conn, task)
+    end
+    return nothing
+end
+
+function serve!(server::Server, listener)::Server
+    _server_shutting_down(server) && throw(ProtocolError("websocket server is shutting down"))
+    lock(server.lock)
+    try
+        server.listener = listener
+        server.bound_address = _listener_bound_address(listener)
+    finally
+        unlock(server.lock)
+    end
+    while !_server_shutting_down(server)
+        conn = try
+            if listener isa TLS.Listener
+                TLS.accept!(listener::TLS.Listener)
+            else
+                TCP.accept!(listener::TCP.Listener)
+            end
+        catch err
+            _server_shutting_down(server) && return server
+            err isa EOFError && return server
+            rethrow(err)
+        end
+        errormonitor(Threads.@spawn _serve_ws_conn!(server, conn))
+    end
+    return server
+end
+
+function _listen_ws(server::Server)
+    listener = server.tls_config === nothing ?
+        TCP.listen(server.network, server.address; backlog = 128) :
+        TLS.listen(server.network, server.address, server.tls_config::TLS.Config; backlog = 128)
+    try
+        serve!(server, listener)
+    finally
+        try
+            if listener isa TLS.Listener
+                TLS.close!(listener::TLS.Listener)
+            else
+                TCP.close!(listener::TCP.Listener)
+            end
+        catch
+        end
+    end
+    return server
+end
+
+function shutdown!(server::Server; force::Bool = false)::Nothing
+    @atomic :release server.shutting_down = true
+    listener = nothing
+    lock(server.lock)
+    try
+        listener = server.listener
+        server.listener = nothing
+    finally
+        unlock(server.lock)
+    end
+    if listener !== nothing
+        try
+            if listener isa TLS.Listener
+                TLS.close!(listener::TLS.Listener)
+            else
+                TCP.close!(listener::TCP.Listener)
+            end
+        catch
+        end
+    end
+    if force
+        lock(server.lock)
+        try
+            for conn in server.active_tcp_conns
+                _close_ws_server_conn!(conn)
+            end
+            for conn in server.active_tls_conns
+                _close_ws_server_conn!(conn)
+            end
+        finally
+            unlock(server.lock)
+        end
+    end
+    return nothing
+end
+
+function Base.close(server::Server)
+    shutdown!(server; force = true)
+    return nothing
+end
+
+function Base.wait(server::Server)
+    lock(server.lock)
+    try
+        server.serve_task === nothing && return nothing
+        wait(server.serve_task::Task)
+    finally
+        unlock(server.lock)
+    end
+    return nothing
+end
+
+function listen!(
+        handler::Function,
+        host::AbstractString = "127.0.0.1",
+        port::Integer = 8080;
+        tls_config::Union{Nothing, TLS.Config} = nothing,
+        subprotocols::AbstractVector{<:AbstractString} = String[],
+        check_origin::Union{Nothing, Function} = nothing,
+        maxframesize::Integer = typemax(Int),
+        maxfragmentation::Integer = DEFAULT_MAX_FRAG,
+        read_buffer_bytes::Integer = DEFAULT_READ_BUFFER_BYTES,
+    )::Server
+    server = Server(
+        network = "tcp",
+        address = HostResolvers.join_host_port(host, Int(port)),
+        handler = handler,
+        tls_config = tls_config,
+        subprotocols = subprotocols,
+        check_origin = check_origin,
+        maxframesize = maxframesize,
+        maxfragmentation = maxfragmentation,
+        read_buffer_bytes = read_buffer_bytes,
+    )
+    server.serve_task = errormonitor(Threads.@spawn _listen_ws(server))
+    return server
+end
+
+serve!(handler::Function, host::AbstractString = "127.0.0.1", port::Integer = 8080; kwargs...) = listen!(handler, host, port; kwargs...)
+
+function listen(handler::Function, host::AbstractString = "127.0.0.1", port::Integer = 8080; kwargs...)
+    server = listen!(handler, host, port; kwargs...)
+    wait(server)
+    return server
 end
 
 end

--- a/src/7_6_http_websockets.jl
+++ b/src/7_6_http_websockets.jl
@@ -809,10 +809,10 @@ function open(
     end
 end
 
-mutable struct Server
+mutable struct Server{F}
     network::String
     address::String
-    handler::Function
+    handler::F
     tls_config::Union{Nothing, TLS.Config}
     subprotocols::Vector{String}
     check_origin::Union{Nothing, Function}
@@ -832,14 +832,14 @@ end
 function Server(;
         network::AbstractString = "tcp",
         address::AbstractString = "127.0.0.1:0",
-        handler::Function,
+        handler::F,
         tls_config::Union{Nothing, TLS.Config} = nothing,
         subprotocols::AbstractVector{<:AbstractString} = String[],
         check_origin::Union{Nothing, Function} = nothing,
         maxframesize::Integer = typemax(Int),
         maxfragmentation::Integer = DEFAULT_MAX_FRAG,
         read_buffer_bytes::Integer = DEFAULT_READ_BUFFER_BYTES,
-    )
+    ) where {F}
     maxframesize > 0 || throw(ArgumentError("maxframesize must be > 0"))
     maxfragmentation > 0 || throw(ArgumentError("maxfragmentation must be > 0"))
     read_buffer_bytes > 0 || throw(ArgumentError("read_buffer_bytes must be > 0"))

--- a/src/7_http.jl
+++ b/src/7_http.jl
@@ -34,6 +34,7 @@ include("7_6_http_request_bodies.jl")
 include("7_6_http_client.jl")
 include("7_6_http_stream.jl")
 include("7_6_http_sse.jl")
+include("7_6_http_websocket_codec.jl")
 include("7_7_http_server.jl")
 
 end

--- a/src/7_http.jl
+++ b/src/7_http.jl
@@ -35,6 +35,7 @@ include("7_6_http_client.jl")
 include("7_6_http_stream.jl")
 include("7_6_http_sse.jl")
 include("7_6_http_websocket_codec.jl")
+include("7_6_http_websockets.jl")
 include("7_7_http_server.jl")
 
 end

--- a/test/http_websocket_autobahn.jl
+++ b/test/http_websocket_autobahn.jl
@@ -1,0 +1,33 @@
+using Test
+using Reseau
+
+const W = Reseau.HTTP.WebSockets
+
+const _AUTOBAHN_DIR = joinpath(@__DIR__, "websockets")
+
+function _have_docker_autobahn_image()::Bool
+    success(`which docker`) || return false
+    return success(`docker image inspect crossbario/autobahn-testsuite`)
+end
+
+if Int === Int64 && !Sys.iswindows() && get(ENV, "RESEAU_RUN_WEBSOCKET_AUTOBAHN", "") == "1"
+    _have_docker_autobahn_image() || @warn "Autobahn image not found; skipping websocket interoperability harness"
+    if _have_docker_autobahn_image()
+        @testset "HTTP.WebSockets Autobahn Server Harness" begin
+            server = W.listen!("127.0.0.1", 9002) do ws
+                for msg in ws
+                    W.send(ws, msg)
+                end
+            end
+            try
+                cmd = Cmd(
+                    `docker run --rm --add-host=host.docker.internal:host-gateway -v "$_AUTOBAHN_DIR/config:/config" -v "$_AUTOBAHN_DIR/reports:/reports" crossbario/autobahn-testsuite wstest -m fuzzingclient -s /config/fuzzingclient.json`;
+                    dir = _AUTOBAHN_DIR,
+                )
+                @test success(cmd)
+            finally
+                close(server)
+            end
+        end
+    end
+end

--- a/test/http_websocket_client_tests.jl
+++ b/test/http_websocket_client_tests.jl
@@ -109,10 +109,10 @@ function _write_ws_frame!(conn, opcode::UInt8, payload::AbstractVector{UInt8}; f
     return nothing
 end
 
-function _read_ws_frames(conn, ws::HT.WsConnection)
+function _read_ws_frames(conn, ws::W.Conn)
     buf = Vector{UInt8}(undef, 8192)
     n = read!(conn, buf)
-    n == 0 && return HT.WsDecodedFrame[]
+    n == 0 && return HT.WsFrame{Vector{UInt8}}[]
     return HT.ws_on_incoming_data!(ws, @view buf[1:n])
 end
 
@@ -126,7 +126,7 @@ end
             @test W.isupgrade(request)
             _accept_ws_request!(conn, request)
             _write_ws_frame!(conn, UInt8(HT.WsOpcode.TEXT), Vector{UInt8}("hello"))
-            server_ws = HT.ws_connection_new(is_client = false)
+            server_ws = W.Conn(is_client = false)
             frames = _read_ws_frames(conn, server_ws)
             @test length(frames) == 1
             @test frames[1].opcode == UInt8(HT.WsOpcode.TEXT)
@@ -161,7 +161,7 @@ end
             request = _read_ws_request(conn)
             _accept_ws_request!(conn, request)
             _write_ws_frame!(conn, UInt8(HT.WsOpcode.TEXT), Vector{UInt8}("secure"))
-            server_ws = HT.ws_connection_new(is_client = false)
+            server_ws = W.Conn(is_client = false)
             HT.ws_close!(server_ws; status_code = UInt16(1000), reason = UInt8[])
             write(conn, HT.ws_get_outgoing_data!(server_ws))
         end
@@ -183,7 +183,7 @@ end
             request = _read_ws_request(conn)
             @test HT.ws_select_subprotocol(request, ["chat", "superchat"]) == "chat"
             _accept_ws_request!(conn, request; subprotocol = "chat")
-            server_ws = HT.ws_connection_new(is_client = false)
+            server_ws = W.Conn(is_client = false)
             HT.ws_close!(server_ws; status_code = UInt16(1000), reason = UInt8[])
             write(conn, HT.ws_get_outgoing_data!(server_ws))
         end
@@ -207,7 +207,7 @@ end
             request = _read_ws_request(conn)
             @test HT.get_header(request.headers, "Cookie") == "session=abc"
             _accept_ws_request!(conn, request)
-            server_ws = HT.ws_connection_new(is_client = false)
+            server_ws = W.Conn(is_client = false)
             HT.ws_close!(server_ws; status_code = UInt16(1000), reason = UInt8[])
             write(conn, HT.ws_get_outgoing_data!(server_ws))
         end

--- a/test/http_websocket_client_tests.jl
+++ b/test/http_websocket_client_tests.jl
@@ -1,0 +1,230 @@
+using Test
+using Reseau
+
+const HT = Reseau.HTTP
+const W = Reseau.HTTP.WebSockets
+const NC = Reseau.TCP
+const TL = Reseau.TLS
+const ND = Reseau.HostResolvers
+
+const _TLS_CERT_PATH = joinpath(@__DIR__, "resources", "unittests.crt")
+const _TLS_KEY_PATH = joinpath(@__DIR__, "resources", "unittests.key")
+
+function _write_response_all!(conn, response::HT.Response)
+    io = IOBuffer()
+    HT.write_response!(io, response)
+    write(conn, take!(io))
+    return nothing
+end
+
+function _listener_address(listener)::String
+    if listener isa TL.Listener
+        laddr = TL.addr(listener)::NC.SocketAddrV4
+        return ND.join_host_port("127.0.0.1", Int(laddr.port))
+    end
+    laddr = NC.addr(listener)::NC.SocketAddrV4
+    return ND.join_host_port("127.0.0.1", Int(laddr.port))
+end
+
+function _ws_server(serve_one::Function; secure::Bool = false)
+    listener = if secure
+        TL.listen(
+            "tcp",
+            "127.0.0.1:0",
+            TL.Config(verify_peer = false, cert_file = _TLS_CERT_PATH, key_file = _TLS_KEY_PATH),
+        )
+    else
+        NC.listen("tcp", "127.0.0.1:0")
+    end
+    address = _listener_address(listener)
+    task = errormonitor(Threads.@spawn begin
+        try
+            conn = secure ? TL.accept!(listener) : NC.accept!(listener)
+            serve_one(conn)
+        finally
+            @isdefined(conn) && _close_quiet!(conn)
+        end
+    end)
+    return listener, task, address
+end
+
+function _wait_task_ok(task::Task)
+    try
+        wait(task)
+    catch err
+        err isa Reseau.IOPoll.NetClosingError && return nothing
+        err isa EOFError && return nothing
+        rethrow(err)
+    end
+    return nothing
+end
+
+function _close_quiet!(x::Task)
+    try
+        _wait_task_ok(x)
+    catch
+    end
+    return nothing
+end
+
+function _close_quiet!(x)
+    x === nothing && return nothing
+    try
+        if x isa TL.Listener
+            TL.close!(x)
+        elseif x isa NC.Listener
+            NC.close!(x)
+        elseif x isa TL.Conn
+            TL.close!(x)
+        elseif x isa NC.Conn
+            NC.close!(x)
+        end
+    catch
+    end
+    return nothing
+end
+
+function _read_ws_request(conn)
+    reader = HT._ConnReader(conn)
+    request = HT.read_request(reader)
+    return request
+end
+
+function _accept_ws_request!(conn, request::HT.Request; subprotocol::Union{Nothing, String} = nothing)
+    headers = HT.Headers()
+    HT.set_header!(headers, "Upgrade", "websocket")
+    HT.set_header!(headers, "Connection", "Upgrade")
+    key = HT.ws_get_request_sec_websocket_key(request)
+    key === nothing && error("missing websocket key")
+    HT.set_header!(headers, "Sec-WebSocket-Accept", HT.ws_compute_accept_key(key))
+    subprotocol === nothing || HT.set_header!(headers, "Sec-WebSocket-Protocol", subprotocol)
+    _write_response_all!(conn, HT.Response(101; headers = headers, body = HT.EmptyBody(), content_length = 0))
+    return nothing
+end
+
+function _write_ws_frame!(conn, opcode::UInt8, payload::AbstractVector{UInt8}; fin::Bool = true, masked::Bool = false)
+    frame = HT.WsFrame(opcode = opcode, payload = payload, fin = fin, masked = masked, masking_key = (0x01, 0x02, 0x03, 0x04))
+    encoded = HT.ws_encode_frame(frame)
+    write(conn, encoded, length(encoded))
+    return nothing
+end
+
+function _read_ws_frames(conn, ws::HT.WsConnection)
+    buf = Vector{UInt8}(undef, 8192)
+    n = read!(conn, buf)
+    n == 0 && return HT.WsDecodedFrame[]
+    return HT.ws_on_incoming_data!(ws, @view buf[1:n])
+end
+
+@testset "HTTP.WebSockets client open over ws" begin
+    listener = nothing
+    task = nothing
+    ws = nothing
+    try
+        listener, task, address = _ws_server() do conn
+            request = _read_ws_request(conn)
+            @test W.isupgrade(request)
+            _accept_ws_request!(conn, request)
+            _write_ws_frame!(conn, UInt8(HT.WsOpcode.TEXT), Vector{UInt8}("hello"))
+            server_ws = HT.ws_connection_new(is_client = false)
+            frames = _read_ws_frames(conn, server_ws)
+            @test length(frames) == 1
+            @test frames[1].opcode == UInt8(HT.WsOpcode.TEXT)
+            @test frames[1].payload == Vector{UInt8}("pong")
+            HT.ws_close!(server_ws; status_code = UInt16(1000), reason = UInt8[])
+            write(conn, HT.ws_get_outgoing_data!(server_ws))
+        end
+        ws = W.open("ws://$address/chat")
+        @test W.receive(ws) == "hello"
+        W.send(ws, "pong")
+        err = try
+            W.receive(ws)
+            nothing
+        catch ex
+            ex
+        end
+        @test err isa W.WebSocketError
+        @test W.isok(err)
+    finally
+        ws === nothing || try close(ws) catch end
+        _close_quiet!(listener)
+        _close_quiet!(task)
+    end
+end
+
+@testset "HTTP.WebSockets client open over wss" begin
+    listener = nothing
+    task = nothing
+    ws = nothing
+    try
+        listener, task, address = _ws_server(; secure = true) do conn
+            request = _read_ws_request(conn)
+            _accept_ws_request!(conn, request)
+            _write_ws_frame!(conn, UInt8(HT.WsOpcode.TEXT), Vector{UInt8}("secure"))
+            server_ws = HT.ws_connection_new(is_client = false)
+            HT.ws_close!(server_ws; status_code = UInt16(1000), reason = UInt8[])
+            write(conn, HT.ws_get_outgoing_data!(server_ws))
+        end
+        ws = W.open("wss://$address/secure"; require_ssl_verification = false)
+        @test W.receive(ws) == "secure"
+    finally
+        ws === nothing || try close(ws) catch end
+        _close_quiet!(listener)
+        _close_quiet!(task)
+    end
+end
+
+@testset "HTTP.WebSockets client subprotocol negotiation" begin
+    listener = nothing
+    task = nothing
+    ws = nothing
+    try
+        listener, task, address = _ws_server() do conn
+            request = _read_ws_request(conn)
+            @test HT.ws_select_subprotocol(request, ["chat", "superchat"]) == "chat"
+            _accept_ws_request!(conn, request; subprotocol = "chat")
+            server_ws = HT.ws_connection_new(is_client = false)
+            HT.ws_close!(server_ws; status_code = UInt16(1000), reason = UInt8[])
+            write(conn, HT.ws_get_outgoing_data!(server_ws))
+        end
+        ws = W.open("ws://$address/subproto"; subprotocols = ["chat", "superchat"])
+        @test ws.subprotocol == "chat"
+    finally
+        ws === nothing || try close(ws) catch end
+        _close_quiet!(listener)
+        _close_quiet!(task)
+    end
+end
+
+@testset "HTTP.WebSockets client redirects and cookies" begin
+    redirect_listener = nothing
+    redirect_task = nothing
+    target_listener = nothing
+    target_task = nothing
+    ws = nothing
+    try
+        target_listener, target_task, target_address = _ws_server() do conn
+            request = _read_ws_request(conn)
+            @test HT.get_header(request.headers, "Cookie") == "session=abc"
+            _accept_ws_request!(conn, request)
+            server_ws = HT.ws_connection_new(is_client = false)
+            HT.ws_close!(server_ws; status_code = UInt16(1000), reason = UInt8[])
+            write(conn, HT.ws_get_outgoing_data!(server_ws))
+        end
+        redirect_listener, redirect_task, redirect_address = _ws_server() do conn
+            request = _read_ws_request(conn)
+            headers = HT.Headers()
+            HT.set_header!(headers, "Location", "ws://$target_address/final")
+            HT.set_header!(headers, "Set-Cookie", "session=abc; Path=/")
+            _write_response_all!(conn, HT.Response(302; headers = headers, body = HT.EmptyBody(), content_length = 0))
+        end
+        ws = W.open("ws://$redirect_address/start"; cookiejar = HT.CookieJar())
+        @test ws.handshake_response.status_code == 101
+    finally
+        ws === nothing || try close(ws) catch end
+        _close_quiet!(redirect_listener)
+        _close_quiet!(redirect_task)
+        _close_quiet!(target_listener)
+        _close_quiet!(target_task)
+    end
+end

--- a/test/http_websocket_codec_tests.jl
+++ b/test/http_websocket_codec_tests.jl
@@ -4,6 +4,7 @@ using Test
 using Reseau
 
 const HT = Reseau.HTTP
+const W = HT.WebSockets
 
 @testset "HTTP websocket opcode helpers" begin
     @test UInt8(HT.WsOpcode.CONTINUATION) == 0x00
@@ -39,7 +40,7 @@ end
     masked_encoded = HT.ws_encode_frame(masked)
     @test (masked_encoded[2] & 0x80) != 0
     @test collect(masked_encoded[3:6]) == UInt8[0x37, 0xfa, 0x21, 0x3d]
-    @test HT.ws_frame_encoded_size(masked) == UInt64(8)
+    @test length(masked_encoded) == 8
 end
 
 @testset "HTTP websocket decoder" begin
@@ -93,9 +94,9 @@ end
 end
 
 @testset "HTTP websocket connection state machine" begin
-    ws = HT.ws_connection_new(is_client = false)
-    HT.ws_send_text!(ws, Vector{UInt8}("A"))
-    HT.ws_send_binary!(ws, UInt8[0x42])
+    ws = W.Conn(is_client = false)
+    HT.ws_send_frame!(ws, UInt8(HT.WsOpcode.TEXT), Vector{UInt8}("A"))
+    HT.ws_send_frame!(ws, UInt8(HT.WsOpcode.BINARY), UInt8[0x42])
     outgoing = HT.ws_get_outgoing_data!(ws)
     @test isempty(ws.outgoing_frames)
     frames = HT.ws_decoder_process!(HT.ws_decoder_new(), outgoing)
@@ -103,7 +104,7 @@ end
     @test frames[1].opcode == UInt8(HT.WsOpcode.TEXT)
     @test frames[2].opcode == UInt8(HT.WsOpcode.BINARY)
 
-    server_ws = HT.ws_connection_new(is_client = false)
+    server_ws = W.Conn(is_client = false)
     ping_frame = HT.WsFrame(
         opcode = UInt8(HT.WsOpcode.PING),
         payload = Vector{UInt8}("ok"),
@@ -121,7 +122,7 @@ end
     @test pong_frames[1].opcode == UInt8(HT.WsOpcode.PONG)
     @test pong_frames[1].payload == Vector{UInt8}("ok")
 
-    close_ws = HT.ws_connection_new(is_client = false)
+    close_ws = W.Conn(is_client = false)
     close_frame = HT.WsFrame(
         opcode = UInt8(HT.WsOpcode.CLOSE),
         payload = HT.ws_encode_close_payload(UInt16(1000)),
@@ -136,12 +137,12 @@ end
     @test close_ws.close_sent
     @test !close_ws.is_open
 
-    @test_throws HT.WebSocketProtocolError HT.ws_on_incoming_data!(HT.ws_connection_new(is_client = false), HT.ws_encode_frame(HT.WsFrame(opcode = UInt8(HT.WsOpcode.TEXT), payload = UInt8[0x41], fin = true)))
-    @test_throws HT.WebSocketProtocolError HT.ws_on_incoming_data!(HT.ws_connection_new(is_client = true), HT.ws_encode_frame(HT.WsFrame(opcode = UInt8(HT.WsOpcode.TEXT), payload = UInt8[0x41], fin = true, masked = true, masking_key = (0x01, 0x02, 0x03, 0x04))))
+    @test_throws HT.WebSocketProtocolError HT.ws_on_incoming_data!(W.Conn(is_client = false), HT.ws_encode_frame(HT.WsFrame(opcode = UInt8(HT.WsOpcode.TEXT), payload = UInt8[0x41], fin = true)))
+    @test_throws HT.WebSocketProtocolError HT.ws_on_incoming_data!(W.Conn(is_client = true), HT.ws_encode_frame(HT.WsFrame(opcode = UInt8(HT.WsOpcode.TEXT), payload = UInt8[0x41], fin = true, masked = true, masking_key = (0x01, 0x02, 0x03, 0x04))))
 end
 
 @testset "HTTP websocket payload limits" begin
-    ws = HT.ws_connection_new(is_client = false, max_incoming_payload_length = UInt64(4))
+    ws = W.Conn(is_client = false, max_incoming_payload_length = UInt64(4))
     frame = HT.WsFrame(
         opcode = UInt8(HT.WsOpcode.TEXT),
         payload = Vector{UInt8}("hello"),

--- a/test/http_websocket_codec_tests.jl
+++ b/test/http_websocket_codec_tests.jl
@@ -1,0 +1,182 @@
+using Base64
+using Test
+
+using Reseau
+
+const HT = Reseau.HTTP
+
+@testset "HTTP websocket opcode helpers" begin
+    @test UInt8(HT.WsOpcode.CONTINUATION) == 0x00
+    @test UInt8(HT.WsOpcode.TEXT) == 0x01
+    @test UInt8(HT.WsOpcode.BINARY) == 0x02
+    @test UInt8(HT.WsOpcode.CLOSE) == 0x08
+    @test UInt8(HT.WsOpcode.PING) == 0x09
+    @test UInt8(HT.WsOpcode.PONG) == 0x0a
+    @test HT.ws_is_data_frame(UInt8(0x01))
+    @test HT.ws_is_data_frame(HT.WsOpcode.BINARY)
+    @test !HT.ws_is_data_frame(UInt8(0x09))
+    @test HT.ws_is_control_frame(UInt8(0x08))
+    @test HT.ws_is_control_frame(HT.WsOpcode.PONG)
+    @test !HT.ws_is_control_frame(UInt8(0x01))
+end
+
+@testset "HTTP websocket frame encoder" begin
+    payload = Vector{UInt8}("Hello")
+    frame = HT.WsFrame(opcode = UInt8(HT.WsOpcode.TEXT), payload = payload, fin = true)
+    encoded = HT.ws_encode_frame(frame)
+    @test length(encoded) == 7
+    @test encoded[1] == 0x81
+    @test encoded[2] == 0x05
+    @test collect(encoded[3:end]) == payload
+
+    masked = HT.WsFrame(
+        opcode = UInt8(HT.WsOpcode.TEXT),
+        payload = Vector{UInt8}("Hi"),
+        fin = true,
+        masked = true,
+        masking_key = (0x37, 0xfa, 0x21, 0x3d),
+    )
+    masked_encoded = HT.ws_encode_frame(masked)
+    @test (masked_encoded[2] & 0x80) != 0
+    @test collect(masked_encoded[3:6]) == UInt8[0x37, 0xfa, 0x21, 0x3d]
+    @test HT.ws_frame_encoded_size(masked) == UInt64(8)
+end
+
+@testset "HTTP websocket decoder" begin
+    decoder = HT.ws_decoder_new()
+    payload = Vector{UInt8}("Hello")
+    frames = HT.ws_decoder_process!(decoder, UInt8[0x81, 0x05, payload...])
+    @test length(frames) == 1
+    @test frames[1].opcode == UInt8(HT.WsOpcode.TEXT)
+    @test frames[1].payload == payload
+
+    decoder = HT.ws_decoder_new()
+    key = UInt8[0x37, 0xfa, 0x21, 0x3d]
+    plain = Vector{UInt8}("Hi")
+    masked = UInt8[plain[1] ⊻ key[1], plain[2] ⊻ key[2]]
+    frames = HT.ws_decoder_process!(decoder, UInt8[0x81, 0x82, key..., masked...])
+    @test length(frames) == 1
+    @test frames[1].masked
+    @test frames[1].payload == plain
+
+    decoder = HT.ws_decoder_new()
+    first_frames = HT.ws_decoder_process!(decoder, UInt8[0x01, 0x03, UInt8('H'), UInt8('e'), UInt8('l')])
+    @test length(first_frames) == 1
+    @test !first_frames[1].fin
+    second_frames = HT.ws_decoder_process!(decoder, UInt8[0x80, 0x02, UInt8('l'), UInt8('o')])
+    @test length(second_frames) == 1
+    @test second_frames[1].opcode == UInt8(HT.WsOpcode.CONTINUATION)
+
+    decoder = HT.ws_decoder_new()
+    @test_throws HT.WebSocketProtocolError HT.ws_decoder_process!(decoder, UInt8[0x09, 0x00])
+
+    decoder = HT.ws_decoder_new()
+    @test_throws HT.WebSocketInvalidPayloadError HT.ws_decoder_process!(decoder, UInt8[0x81, 0x02, 0xc3, 0x28])
+
+    decoder = HT.ws_decoder_new()
+    @test_throws HT.WebSocketProtocolError HT.ws_decoder_process!(decoder, UInt8[0x88, 0x01, 0x00])
+end
+
+@testset "HTTP websocket close payload helpers" begin
+    @test HT.ws_is_valid_close_status(UInt16(1000))
+    @test HT.ws_is_valid_close_status(UInt16(1001))
+    @test !HT.ws_is_valid_close_status(UInt16(1005))
+    @test !HT.ws_is_valid_close_status(UInt16(999))
+
+    payload = HT.ws_encode_close_payload(UInt16(1000), Vector{UInt8}("bye"))
+    code, reason = HT.ws_decode_close_payload(payload)
+    @test code == UInt16(1000)
+    @test reason == Vector{UInt8}("bye")
+    @test HT.ws_validate_close_payload(payload) === nothing
+    @test_throws HT.WebSocketProtocolError HT.ws_validate_close_payload(UInt8[0x03])
+    @test_throws HT.WebSocketInvalidPayloadError HT.ws_validate_close_payload(UInt8[0x03, 0xe8, 0xc3, 0x28])
+end
+
+@testset "HTTP websocket connection state machine" begin
+    ws = HT.ws_connection_new(is_client = false)
+    HT.ws_send_text!(ws, Vector{UInt8}("A"))
+    HT.ws_send_binary!(ws, UInt8[0x42])
+    outgoing = HT.ws_get_outgoing_data!(ws)
+    @test isempty(ws.outgoing_frames)
+    frames = HT.ws_decoder_process!(HT.ws_decoder_new(), outgoing)
+    @test length(frames) == 2
+    @test frames[1].opcode == UInt8(HT.WsOpcode.TEXT)
+    @test frames[2].opcode == UInt8(HT.WsOpcode.BINARY)
+
+    server_ws = HT.ws_connection_new(is_client = false)
+    ping_frame = HT.WsFrame(
+        opcode = UInt8(HT.WsOpcode.PING),
+        payload = Vector{UInt8}("ok"),
+        fin = true,
+        masked = true,
+        masking_key = (0x01, 0x02, 0x03, 0x04),
+    )
+    incoming = HT.ws_encode_frame(ping_frame)
+    frames = HT.ws_on_incoming_data!(server_ws, incoming)
+    @test length(frames) == 1
+    @test frames[1].opcode == UInt8(HT.WsOpcode.PING)
+    pong_wire = HT.ws_get_outgoing_data!(server_ws)
+    pong_frames = HT.ws_decoder_process!(HT.ws_decoder_new(), pong_wire)
+    @test length(pong_frames) == 1
+    @test pong_frames[1].opcode == UInt8(HT.WsOpcode.PONG)
+    @test pong_frames[1].payload == Vector{UInt8}("ok")
+
+    close_ws = HT.ws_connection_new(is_client = false)
+    close_frame = HT.WsFrame(
+        opcode = UInt8(HT.WsOpcode.CLOSE),
+        payload = HT.ws_encode_close_payload(UInt16(1000)),
+        fin = true,
+        masked = true,
+        masking_key = (0x01, 0x02, 0x03, 0x04),
+    )
+    close_frames = HT.ws_on_incoming_data!(close_ws, HT.ws_encode_frame(close_frame))
+    @test length(close_frames) == 1
+    @test close_frames[1].opcode == UInt8(HT.WsOpcode.CLOSE)
+    @test close_ws.close_received
+    @test close_ws.close_sent
+    @test !close_ws.is_open
+
+    @test_throws HT.WebSocketProtocolError HT.ws_on_incoming_data!(HT.ws_connection_new(is_client = false), HT.ws_encode_frame(HT.WsFrame(opcode = UInt8(HT.WsOpcode.TEXT), payload = UInt8[0x41], fin = true)))
+    @test_throws HT.WebSocketProtocolError HT.ws_on_incoming_data!(HT.ws_connection_new(is_client = true), HT.ws_encode_frame(HT.WsFrame(opcode = UInt8(HT.WsOpcode.TEXT), payload = UInt8[0x41], fin = true, masked = true, masking_key = (0x01, 0x02, 0x03, 0x04))))
+end
+
+@testset "HTTP websocket payload limits" begin
+    ws = HT.ws_connection_new(is_client = false, max_incoming_payload_length = UInt64(4))
+    frame = HT.WsFrame(
+        opcode = UInt8(HT.WsOpcode.TEXT),
+        payload = Vector{UInt8}("hello"),
+        fin = true,
+        masked = true,
+        masking_key = (0x01, 0x02, 0x03, 0x04),
+    )
+    @test_throws HT.WebSocketProtocolError HT.ws_on_incoming_data!(ws, HT.ws_encode_frame(frame))
+end
+
+@testset "HTTP websocket handshake helpers" begin
+    key = HT.ws_random_handshake_key()
+    @test length(key) == 24
+    @test length(Base64.base64decode(key)) == 16
+    @test key != HT.ws_random_handshake_key()
+
+    @test HT.ws_compute_accept_key("dGhlIHNhbXBsZSBub25jZQ==") == "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+
+    headers = HT.Headers()
+    HT.set_header!(headers, "Upgrade", "websocket")
+    HT.set_header!(headers, "Connection", "keep-alive, Upgrade")
+    HT.set_header!(headers, "Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+    HT.set_header!(headers, "Sec-WebSocket-Version", "13")
+    HT.set_header!(headers, "Sec-WebSocket-Protocol", "chat, superchat")
+    request = HT.Request("GET", "/ws"; headers = headers, host = "example.com", content_length = 0)
+    @test HT.ws_is_websocket_request(request)
+    @test HT.ws_get_request_sec_websocket_key(request) == "dGhlIHNhbXBsZSBub25jZQ=="
+    @test HT.ws_select_subprotocol(request, ["superchat", "chat"]) == "superchat"
+    @test HT.ws_select_subprotocol(request, ["mqtt"]) === nothing
+
+    bad_headers = HT.Headers()
+    HT.set_header!(bad_headers, "Upgrade", "websocket")
+    HT.set_header!(bad_headers, "Connection", "x-upgrade-token")
+    HT.set_header!(bad_headers, "Sec-WebSocket-Key", "abc")
+    HT.set_header!(bad_headers, "Sec-WebSocket-Version", "13")
+    bad_request = HT.Request("GET", "/ws"; headers = bad_headers, host = "example.com", content_length = 0)
+    @test !HT.ws_is_websocket_request(bad_request)
+end

--- a/test/http_websocket_integration_tests.jl
+++ b/test/http_websocket_integration_tests.jl
@@ -1,0 +1,107 @@
+using Test
+using Reseau
+
+const HT = Reseau.HTTP
+const W = Reseau.HTTP.WebSockets
+const NC = Reseau.TCP
+const ND = Reseau.HostResolvers
+
+function _wait_ws_server_addr(server; timeout_s::Float64 = 5.0)
+    deadline = time() + timeout_s
+    while time() < deadline
+        try
+            return W.server_addr(server)
+        catch
+            sleep(0.01)
+        end
+    end
+    return W.server_addr(server)
+end
+
+function _close_ws_quiet!(x)
+    x === nothing && return nothing
+    try
+        if x isa HT.WebSockets.Server
+            close(x)
+        elseif x isa NC.Listener
+            NC.close!(x)
+        elseif x isa NC.Conn
+            NC.close!(x)
+        elseif x isa Task
+            wait(x)
+        end
+    catch
+    end
+    return nothing
+end
+
+@testset "HTTP.WebSockets multiple concurrent writers" begin
+    server = W.listen!("127.0.0.1", 0) do ws
+        send_tasks = Task[]
+        for i in 1:10
+            push!(send_tasks, errormonitor(Threads.@spawn W.send(ws, string(i))))
+        end
+        for task in send_tasks
+            wait(task)
+        end
+        @test W.receive(ws) == "ok"
+    end
+    try
+        address = _wait_ws_server_addr(server)
+        ws = W.open("ws://$address/writers")
+        try
+            received = Set{String}()
+            for _ in 1:10
+                push!(received, W.receive(ws))
+            end
+            @test received == Set(string(i) for i in 1:10)
+            W.send(ws, "ok")
+        finally
+            close(ws)
+        end
+    finally
+        close(server)
+    end
+end
+
+@testset "HTTP.WebSockets client uses forward proxy absolute-form and proxy auth" begin
+    listener = nothing
+    task = nothing
+    ws = nothing
+    try
+        listener = NC.listen("tcp", "127.0.0.1:0")
+        laddr = NC.addr(listener)::NC.SocketAddrV4
+        proxy_address = ND.join_host_port("127.0.0.1", Int(laddr.port))
+        task = errormonitor(Threads.@spawn begin
+            conn = NC.accept!(listener)
+            try
+                request = HT.read_request(HT._ConnReader(conn))
+                @test request.target == "http://example.com:80/proxied"
+                @test HT.get_header(request.headers, "Proxy-Authorization") == "Basic dXNlcjpwYXNz"
+                headers = HT.Headers()
+                HT.set_header!(headers, "Upgrade", "websocket")
+                HT.set_header!(headers, "Connection", "Upgrade")
+                key = HT.ws_get_request_sec_websocket_key(request)
+                key === nothing && error("missing websocket key")
+                HT.set_header!(headers, "Sec-WebSocket-Accept", HT.ws_compute_accept_key(key))
+                io = IOBuffer()
+                HT.write_response!(io, HT.Response(101; headers = headers, body = HT.EmptyBody(), content_length = 0))
+                write(conn, take!(io))
+                frame = HT.WsFrame(opcode = UInt8(HT.WsOpcode.TEXT), payload = Vector{UInt8}("proxied"), fin = true)
+                encoded = HT.ws_encode_frame(frame)
+                write(conn, encoded, length(encoded))
+            finally
+                try
+                    NC.close!(conn)
+                catch
+                end
+            end
+        end)
+        ws = W.open("ws://example.com/proxied"; proxy = "http://user:pass@$proxy_address")
+        @test W.receive(ws) == "proxied"
+    finally
+        ws === nothing || try close(ws) catch end
+        _close_ws_quiet!(listener)
+        _close_ws_quiet!(task)
+    end
+end

--- a/test/http_websocket_server_tests.jl
+++ b/test/http_websocket_server_tests.jl
@@ -1,0 +1,144 @@
+using Test
+using Reseau
+
+const HT = Reseau.HTTP
+const W = Reseau.HTTP.WebSockets
+const NC = Reseau.TCP
+const TL = Reseau.TLS
+const ND = Reseau.HostResolvers
+
+const _TLS_CERT_PATH = joinpath(@__DIR__, "resources", "unittests.crt")
+const _TLS_KEY_PATH = joinpath(@__DIR__, "resources", "unittests.key")
+
+function _wait_server_addr(server; timeout_s::Float64 = 5.0)
+    deadline = time() + timeout_s
+    while time() < deadline
+        try
+            return W.server_addr(server)
+        catch
+            sleep(0.01)
+        end
+    end
+    return W.server_addr(server)
+end
+
+function _raw_upgrade_response(address::String; secure::Bool = false, origin::Union{Nothing, String} = nothing)
+    conn = secure ?
+        TL.client(NC.connect(ND.HostResolver(), "tcp", address), TL.Config(server_name = "127.0.0.1", verify_peer = false)) :
+        NC.connect(ND.HostResolver(), "tcp", address)
+    try
+        secure && TL.handshake!(conn::TL.Conn)
+        headers = HT.Headers()
+        HT.set_header!(headers, "Upgrade", "websocket")
+        HT.set_header!(headers, "Connection", "Upgrade")
+        HT.set_header!(headers, "Sec-WebSocket-Key", HT.ws_random_handshake_key())
+        HT.set_header!(headers, "Sec-WebSocket-Version", "13")
+        origin === nothing || HT.set_header!(headers, "Origin", origin)
+        request = HT.Request("GET", "/ws"; headers = headers, host = address, content_length = 0)
+        io = IOBuffer()
+        HT.write_request!(io, request)
+        write(conn, take!(io))
+        return HT._streaming_response(HT._read_incoming_response(HT._ConnReader(conn), request))
+    finally
+        try
+            if conn isa TL.Conn
+                TL.close!(conn::TL.Conn)
+            else
+                NC.close!(conn::NC.Conn)
+            end
+        catch
+        end
+    end
+end
+
+@testset "HTTP.WebSockets server listen! over ws" begin
+    server = W.listen!("127.0.0.1", 0) do ws
+        msg = W.receive(ws)
+        W.send(ws, msg)
+    end
+    try
+        address = _wait_server_addr(server)
+        ws = W.open("ws://$address/echo")
+        try
+            W.send(ws, "hello")
+            @test W.receive(ws) == "hello"
+        finally
+            close(ws)
+        end
+    finally
+        close(server)
+    end
+end
+
+@testset "HTTP.WebSockets server listen! over wss" begin
+    server = W.listen!(
+        "127.0.0.1",
+        0;
+        tls_config = TL.Config(verify_peer = false, cert_file = _TLS_CERT_PATH, key_file = _TLS_KEY_PATH),
+    ) do ws
+        W.send(ws, "secure")
+    end
+    try
+        address = _wait_server_addr(server)
+        ws = W.open("wss://$address/secure"; require_ssl_verification = false)
+        try
+            @test W.receive(ws) == "secure"
+        finally
+            close(ws)
+        end
+    finally
+        close(server)
+    end
+end
+
+@testset "HTTP.WebSockets server subprotocol negotiation" begin
+    server = W.listen!("127.0.0.1", 0; subprotocols = ["chat"]) do ws
+        W.send(ws, "ok")
+    end
+    try
+        address = _wait_server_addr(server)
+        ws = W.open("ws://$address/proto"; subprotocols = ["chat", "superchat"])
+        try
+            @test ws.subprotocol == "chat"
+            @test W.receive(ws) == "ok"
+        finally
+            close(ws)
+        end
+    finally
+        close(server)
+    end
+end
+
+@testset "HTTP.WebSockets server default origin policy rejects mismatched origins" begin
+    server = W.listen!("127.0.0.1", 0) do ws
+        W.send(ws, "nope")
+    end
+    try
+        address = _wait_server_addr(server)
+        response = _raw_upgrade_response(address; origin = "http://evil.example")
+        @test response.status_code == 403
+    finally
+        close(server)
+    end
+end
+
+@testset "HTTP.WebSockets server custom origin policy can allow requests" begin
+    server = W.listen!(
+        "127.0.0.1",
+        0;
+        check_origin = (request, origin) -> true,
+    ) do ws
+        W.send(ws, "allowed")
+    end
+    try
+        address = _wait_server_addr(server)
+        ws = W.open("ws://$address/origin"; headers = ["Origin" => "http://evil.example"])
+        try
+            @test W.receive(ws) == "allowed"
+        finally
+            close(ws)
+        end
+    finally
+        close(server)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ test_files = [
     "http_websocket_codec_tests.jl",
     "http_websocket_client_tests.jl",
     "http_websocket_server_tests.jl",
+    "http_websocket_integration_tests.jl",
     "http_client_transport_tests.jl",
     "http_client_proxy_tests.jl",
     "http_client_tests.jl",
@@ -66,4 +67,8 @@ for test_file in test_files
         continue
     end
     _include_with_progress(test_file)
+end
+
+if get(ENV, "RESEAU_RUN_WEBSOCKET_AUTOBAHN", "") == "1"
+    _include_with_progress("http_websocket_autobahn.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ test_files = [
     "http1_wire_tests.jl",
     "http_cookie_tests.jl",
     "http_forms_tests.jl",
+    "http_websocket_codec_tests.jl",
     "http_client_transport_tests.jl",
     "http_client_proxy_tests.jl",
     "http_client_tests.jl",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,7 @@ test_files = [
     "http_cookie_tests.jl",
     "http_forms_tests.jl",
     "http_websocket_codec_tests.jl",
+    "http_websocket_client_tests.jl",
     "http_client_transport_tests.jl",
     "http_client_proxy_tests.jl",
     "http_client_tests.jl",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,7 @@ test_files = [
     "http_forms_tests.jl",
     "http_websocket_codec_tests.jl",
     "http_websocket_client_tests.jl",
+    "http_websocket_server_tests.jl",
     "http_client_transport_tests.jl",
     "http_client_proxy_tests.jl",
     "http_client_tests.jl",

--- a/test/websockets/config/fuzzingclient.json
+++ b/test/websockets/config/fuzzingclient.json
@@ -1,0 +1,12 @@
+{
+    "outdir": "./reports/server",
+    "servers": [
+        {
+            "agent": "reseau",
+            "url": "ws://host.docker.internal:9002"
+        }
+    ],
+    "cases": ["*"],
+    "exclude-cases": ["9.*"],
+    "exclude-agent-cases": {}
+}


### PR DESCRIPTION
## Summary
- add a pure-Julia RFC 6455 websocket codec/session core to `Reseau.HTTP`
- add `HTTP.WebSockets` client support for `ws://` and `wss://`, including redirects, cookies, subprotocols, and forward-proxy support
- add dedicated `HTTP.WebSockets` server APIs with TCP/TLS listeners, origin checks, and subprotocol negotiation
- add websocket codec/client/server/integration tests plus an opt-in Autobahn harness

## Testing
- `RESEAU_TEST_ONLY=http_websocket_codec_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
- `RESEAU_TEST_ONLY=http_websocket_client_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
- `RESEAU_TEST_ONLY=http_websocket_server_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
- `RESEAU_TEST_ONLY=http_websocket_integration_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
- `RESEAU_TEST_ONLY=http_client_proxy_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
- `julia --project=. --startup-file=no --history-file=no test/runtests.jl`

## Notes
- `HTTP.jl origin/master` does not currently contain a websocket module; this work used the local `HTTP` `merge-awhttp-internals` branch plus `AwsHTTP`'s websocket codec as the reference implementation.
- I attempted a docs build, but this repo currently has no `docs/` tree.
