### PR TITLE
feat(http): add server handlers and router parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,18 +160,38 @@ close(client)
 using Reseau
 const HTTP = Reseau.HTTP
 
-server = HTTP.Server(; address = "127.0.0.1:8080", handler = req -> begin
+server = HTTP.serve!("127.0.0.1", 8080) do req
     body = HTTP.BytesBody(collect(codeunits("hello from reseau")))
-    return HTTP.Response(200; reason = "OK", body = body, content_length = 17)
+    return HTTP.Response(200; body = body, content_length = 17)
 end)
 
-task = HTTP.start!(server)
 println(HTTP.server_addr(server))
 
 # ... run requests ...
 
-HTTP.shutdown!(server)
-wait(task)
+close(server)
+wait(server)
+```
+
+Router-style handlers are available too:
+
+```julia
+using Reseau
+const HTTP = Reseau.HTTP
+
+router = HTTP.Router()
+HTTP.register!(router, "GET", "/hello/{name}") do req
+    payload = "hello " * HTTP.getparam(req, "name")
+    bytes = collect(codeunits(payload))
+    return HTTP.Response(200; body = HTTP.BytesBody(bytes), content_length = length(bytes))
+end
+
+server = HTTP.serve!(router, "127.0.0.1", 8080)
+
+# cookie parsing middleware is available as HTTP.Handlers.cookie_middleware
+
+close(server)
+wait(server)
 ```
 
 ## Notes on Lower Layers

--- a/http-master-parity.md
+++ b/http-master-parity.md
@@ -212,9 +212,9 @@ entry-point shape.
 
 ### 5. Router / Middleware / Handler Framework
 
-This is one of the biggest `HTTP.jl`-only public surface areas.
+This gap is now largely closed.
 
-`HTTP.jl` exposes:
+`Reseau.HTTP` now exposes the same core surface users expect from `HTTP.jl`:
 
 - `Handler`
 - `Middleware`
@@ -224,9 +224,10 @@ This is one of the biggest `HTTP.jl`-only public surface areas.
 - `getroute`
 - `getparams`
 - `getparam`
-- cookie middleware and `getcookies`
+- `getcookies`
+- `HTTP.Handlers.cookie_middleware`
 
-The router supports:
+The router now supports the same matching shapes we called out above:
 
 - exact routes
 - `*` segment wildcards
@@ -234,10 +235,11 @@ The router supports:
 - regex params like `{id:[0-9]+}`
 - trailing `/**`
 
-`Reseau.HTTP` currently has none of this on its public surface.
+It also works through both the request-handler and stream-handler server entry
+points, with dedicated HTTP/1 and HTTP/2 coverage in `Reseau`'s test suite.
 
-This is not just sugar. For many HTTP.jl users, this is the public server
-interface they actually interact with.
+The remaining parity work in this area is mostly about higher-level polish and
+future middleware conveniences, not the core router/handler framework itself.
 
 ### 6. Cookies
 

--- a/http-server-handlers-router-action-items.md
+++ b/http-server-handlers-router-action-items.md
@@ -75,7 +75,7 @@
   - The new handlers test file passes on its own and from the full runner.
   - The test runner includes the new suite in the normal HTTP path.
 
-### [ ] ITEM-004 (P1) Update documentation and parity tracking for the new server surface
+### [x] ITEM-004 (P1) Update documentation and parity tracking for the new server surface
 - Description: The README currently documents outdated server APIs, and the parity notes still list router/middleware as missing. The public docs need to match the shipped behavior after the port.
 - Desired outcome: README examples use the current `serve!`/`listen!` lifecycle, the new router/middleware surface is documented accurately, and `http-master-parity.md` reflects the reduced gap.
 - Affected files: `README.md`, `http-master-parity.md`, `src/7_7_http_handlers.jl`, `src/7_7_http_server.jl`
@@ -88,6 +88,10 @@
   - `JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=http_handlers_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
 - Assumptions:
   - Repo documentation for this work is primarily README plus in-source docstrings and parity notes; there is no separate Documenter site to update in this repo.
+- Verification evidence:
+  - README now uses `serve!`/`close`/`wait` instead of the stale `start!`/`shutdown!` flow.
+  - `RESEAU_TEST_ONLY=http_handlers_tests.jl` passed after the documentation pass.
+  - The router/middleware parity section in `http-master-parity.md` was updated without disturbing unrelated edits elsewhere in that file.
 - Completion criteria:
   - README examples match real public APIs in the current tree.
   - `http-master-parity.md` no longer describes router/middleware as missing.

--- a/http-server-handlers-router-action-items.md
+++ b/http-server-handlers-router-action-items.md
@@ -1,0 +1,106 @@
+# Action Items: HTTP Server Handlers and Router Parity
+
+## Context
+- Repo: Reseau
+- Worktree: /Users/jacob.quinn/.julia/dev/Reseau
+- Branch: http-server-handlers-router-parity
+
+## Items
+
+### [x] ITEM-001 (P0) Add request-context metadata plumbing and upstream handlers surface
+- Description: `Reseau.HTTP` currently lacks the upstream `HTTP.Handlers` surface entirely, and `RequestContext` does not yet support the lightweight per-request metadata storage the upstream router/middleware layer expects for matched routes, params, and parsed cookies.
+- Desired outcome: `Reseau.HTTP` has a dedicated `Handlers` module wired into `src/7_http.jl`, `RequestContext` can store/retrieve route metadata lazily without disturbing existing cancellation/deadline behavior, and the public names `Handler`, `Middleware`, `Router`, `register!`, `getroute`, `getparams`, `getparam`, `getcookies`, and `streamhandler` are available from `Reseau.HTTP`.
+- Affected files: `src/7_0_http_core.jl`, `src/7_http.jl`, `src/7_7_http_handlers.jl`
+- Implementation notes:
+  - Extend `RequestContext` with lazy metadata storage plus the minimal `Base.get`, `Base.getindex`, `Base.setindex!`, and `Base.haskey` support needed by the ported handlers layer.
+  - Add a new `Reseau.HTTP.Handlers` module based on `HTTP.jl` `origin/master` router/handlers behavior, adapting imports and stream plumbing to `Reseau`’s current `Request`, `Response`, `Stream`, and cookie APIs.
+  - Keep the port direct where behavior matches upstream, but avoid adding any compatibility shim for older Reseau server APIs.
+  - Preserve request-context metadata for matched route strings, named params, and cookie middleware results.
+- Verification:
+  - `JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=http_core_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
+  - `JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=http_server_http1_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
+- Assumptions:
+  - Request route/param/cookie metadata should live in `RequestContext`, not as new top-level `Request` fields, because that matches the upstream `origin/master` public behavior more closely while keeping core request structure focused.
+  - A dedicated `src/7_7_http_handlers.jl` file is the cleanest include point because the module depends on server/stream APIs that already exist in `Reseau.HTTP`.
+- Verification evidence:
+  - `RESEAU_TEST_ONLY=http_core_tests.jl` passed after adding lazy metadata storage and dict-like `RequestContext` accessors.
+  - `RESEAU_TEST_ONLY=http_server_http1_tests.jl` passed with the new `Handlers` module included in `Reseau.HTTP`.
+- Completion criteria:
+  - `using Reseau; Reseau.HTTP.Router` and related handler symbols load successfully.
+  - Router metadata storage works without regressing request-context deadline/cancel behavior.
+
+### [ ] ITEM-002 (P0) Finish router, middleware, streamhandler, and cookie semantics against server behavior
+- Description: Even with the module in place, the port still needs careful integration against `Reseau`’s server pipeline so request handlers, stream handlers, wildcard/regex routing, 404/405 handling, and cookie middleware all behave like HTTP.jl instead of just compiling.
+- Desired outcome: Router matching covers exact, `*`, `{name}`, `{name:regex}`, and trailing `/**` patterns; request handlers and stream handlers both work; and cookie middleware plus parameter helpers behave correctly for real requests.
+- Affected files: `src/7_7_http_handlers.jl`, `src/7_6_http_stream.jl`, `src/7_7_http_server.jl`
+- Implementation notes:
+  - Audit the ported `streamhandler` carefully against `Reseau`’s `startread`, `read`, `setstatus`, `setheader`, `addtrailer`, `closewrite`, and `closeread` semantics rather than assuming the upstream implementation drops in unchanged.
+  - Ensure route matching extracts the path portion from `Request.target` correctly for origin-form requests while preserving query strings for normal request handling.
+  - Confirm 404 vs 405 behavior remains distinguishable, and only matched routes run middleware.
+  - Review hot-path allocations in route matching and metadata assignment so the port stays direct and predictable.
+- Verification:
+  - `JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=http_handlers_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
+  - `JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=http_server_http1_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
+  - `JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=http_integration_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
+- Assumptions:
+  - Route matching should operate on the request path only, ignoring the query string exactly as `HTTP.jl` does.
+  - No separate legacy compatibility layer is needed for older server helper names; the current `serve`/`serve!`/`listen`/`listen!` surface is the integration target.
+- Completion criteria:
+  - Live server requests can pass through `streamhandler` and `Router` successfully.
+  - Query strings do not break route matching, and 404/405 behavior is covered.
+
+### [ ] ITEM-003 (P0) Port and adapt upstream handlers/router tests into Reseau’s test suite
+- Description: `Reseau` currently has no dedicated router/middleware test coverage, so the upstream `HTTP.jl` handlers tests and relevant server-side handler coverage need to be ported and adapted to current request/response/body APIs.
+- Desired outcome: `Reseau` has a focused `http_handlers_tests.jl` suite plus any necessary integration assertions for `streamhandler` and router behavior, and the suite is wired into `test/runtests.jl`.
+- Affected files: `test/http_handlers_tests.jl`, `test/http_server_http1_tests.jl`, `test/http_integration_tests.jl`, `test/runtests.jl`
+- Implementation notes:
+  - Start from `HTTP.jl` `test/handlers.jl` and the `HTTP.streamhandler` coverage in `test/server.jl`, then adapt assertions to `Reseau.HTTP.Response`, `BytesBody`, and current helper patterns.
+  - Add explicit coverage for route params, regex params, double-star routes, middleware invocation boundaries, cookie middleware, and query-string-insensitive matching.
+  - Keep tests small, deterministic, and runnable via `RESEAU_TEST_ONLY`.
+- Verification:
+  - `JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=http_handlers_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
+  - `JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=http_server_http1_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
+- Assumptions:
+  - A standalone `test/http_handlers_tests.jl` file is the clearest home for the direct upstream router coverage.
+  - Existing server tests may still need a few additions where handler behavior only makes sense over a live socket.
+- Completion criteria:
+  - The new handlers test file passes on its own and from the full runner.
+  - The test runner includes the new suite in the normal HTTP path.
+
+### [ ] ITEM-004 (P1) Update documentation and parity tracking for the new server surface
+- Description: The README currently documents outdated server APIs, and the parity notes still list router/middleware as missing. The public docs need to match the shipped behavior after the port.
+- Desired outcome: README examples use the current `serve!`/`listen!` lifecycle, the new router/middleware surface is documented accurately, and `http-master-parity.md` reflects the reduced gap.
+- Affected files: `README.md`, `http-master-parity.md`, `src/7_7_http_handlers.jl`, `src/7_7_http_server.jl`
+- Implementation notes:
+  - Replace the stale README server example that still references `start!`, `server_addr`, and `shutdown!`.
+  - Add concise handler/router usage examples that match the final ported API, including route params and middleware usage where helpful.
+  - Update docstrings in the new handlers module and any touched server entrypoints so help-mode output stays accurate.
+- Verification:
+  - `rg -n "start!\\(|shutdown!\\(|server_addr\\(" README.md src`
+  - `JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=http_handlers_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
+- Assumptions:
+  - Repo documentation for this work is primarily README plus in-source docstrings and parity notes; there is no separate Documenter site to update in this repo.
+- Completion criteria:
+  - README examples match real public APIs in the current tree.
+  - `http-master-parity.md` no longer describes router/middleware as missing.
+
+### [ ] ITEM-005 (P0) Run the full verification matrix, push the branch, open the PR, and drive CI green
+- Description: The feature is not done until the full local suite is clean, the branch is pushed, the PR exists, and GitHub Actions are green. Any regressions uncovered by the full suite or CI need to be fixed before reporting back.
+- Desired outcome: All relevant local verification passes, the feature branch is pushed, a PR is open against `main`, and GitHub Actions checks for that PR complete successfully.
+- Affected files: `test/runtests.jl`, `.github/workflows/` (only if CI fixes are required), plus any source/test/docs files needing follow-up fixes
+- Implementation notes:
+  - Run the targeted HTTP suites first, then the full package test command from the repo instructions.
+  - Commit each completed item separately before moving on, then push the branch and open the PR with a concise parity-focused description.
+  - Use `gh run list` / `gh run view --log-failed` to inspect failures and iterate until CI is green.
+  - Do not disturb unrelated existing worktree changes while preparing commits or the PR.
+- Verification:
+  - `JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'`
+  - `git status --short`
+  - `gh pr create --base main --head http-server-handlers-router-parity --title "<fill after implementation>" --body "<fill after implementation>"`
+  - `gh run list --branch http-server-handlers-router-parity --limit 20`
+- Assumptions:
+  - GitHub auth and push permissions remain available for this repo during the final PR/CI step.
+  - Any CI-only regressions should be fixed on the same feature branch before the task is considered complete.
+- Completion criteria:
+  - Local full test command passes.
+  - PR is open and its CI checks are green.

--- a/http-server-handlers-router-action-items.md
+++ b/http-server-handlers-router-action-items.md
@@ -53,7 +53,7 @@
   - Live server requests can pass through `streamhandler` and `Router` successfully.
   - Query strings do not break route matching, and 404/405 behavior is covered.
 
-### [ ] ITEM-003 (P0) Port and adapt upstream handlers/router tests into Reseau’s test suite
+### [x] ITEM-003 (P0) Port and adapt upstream handlers/router tests into Reseau’s test suite
 - Description: `Reseau` currently has no dedicated router/middleware test coverage, so the upstream `HTTP.jl` handlers tests and relevant server-side handler coverage need to be ported and adapted to current request/response/body APIs.
 - Desired outcome: `Reseau` has a focused `http_handlers_tests.jl` suite plus any necessary integration assertions for `streamhandler` and router behavior, and the suite is wired into `test/runtests.jl`.
 - Affected files: `test/http_handlers_tests.jl`, `test/http_server_http1_tests.jl`, `test/http_integration_tests.jl`, `test/runtests.jl`
@@ -67,6 +67,10 @@
 - Assumptions:
   - A standalone `test/http_handlers_tests.jl` file is the clearest home for the direct upstream router coverage.
   - Existing server tests may still need a few additions where handler behavior only makes sense over a live socket.
+- Verification evidence:
+  - `RESEAU_TEST_ONLY=http_core_tests.jl` passed after adding request-context metadata coverage.
+  - `RESEAU_TEST_ONLY=http_handlers_tests.jl` passed with direct router, middleware, streamhandler, and live HTTP/1 server coverage.
+  - `RESEAU_TEST_ONLY=trim_compile_tests.jl` passed after leaving the trim workload on static-friendly coverage.
 - Completion criteria:
   - The new handlers test file passes on its own and from the full runner.
   - The test runner includes the new suite in the normal HTTP path.

--- a/http-server-handlers-router-action-items.md
+++ b/http-server-handlers-router-action-items.md
@@ -29,7 +29,7 @@
   - `using Reseau; Reseau.HTTP.Router` and related handler symbols load successfully.
   - Router metadata storage works without regressing request-context deadline/cancel behavior.
 
-### [ ] ITEM-002 (P0) Finish router, middleware, streamhandler, and cookie semantics against server behavior
+### [x] ITEM-002 (P0) Finish router, middleware, streamhandler, and cookie semantics against server behavior
 - Description: Even with the module in place, the port still needs careful integration against `Reseau`’s server pipeline so request handlers, stream handlers, wildcard/regex routing, 404/405 handling, and cookie middleware all behave like HTTP.jl instead of just compiling.
 - Desired outcome: Router matching covers exact, `*`, `{name}`, `{name:regex}`, and trailing `/**` patterns; request handlers and stream handlers both work; and cookie middleware plus parameter helpers behave correctly for real requests.
 - Affected files: `src/7_7_http_handlers.jl`, `src/7_6_http_stream.jl`, `src/7_7_http_server.jl`
@@ -45,6 +45,10 @@
 - Assumptions:
   - Route matching should operate on the request path only, ignoring the query string exactly as `HTTP.jl` does.
   - No separate legacy compatibility layer is needed for older server helper names; the current `serve`/`serve!`/`listen`/`listen!` surface is the integration target.
+- Verification evidence:
+  - `RESEAU_TEST_ONLY=http_handlers_tests.jl` passed with live request-handler and stream-handler router coverage, including 404/405 and query-string-insensitive matching.
+  - `RESEAU_TEST_ONLY=http_server_http1_tests.jl` passed after the adapter review.
+  - `RESEAU_TEST_ONLY=http2_server_tests.jl` passed after adding router coverage to the shared HTTP/2 server path.
 - Completion criteria:
   - Live server requests can pass through `streamhandler` and `Router` successfully.
   - Query strings do not break route matching, and 404/405 behavior is covered.

--- a/src/7_0_http_core.jl
+++ b/src/7_0_http_core.jl
@@ -432,12 +432,13 @@ mutable struct RequestContext
     deadline_ns::Int64
     @atomic canceled_flag::Bool
     cancel_message::Union{Nothing, String}
+    metadata::Union{Nothing, Dict{Symbol, Any}}
 end
 
 """Construct a `RequestContext`; throws `ArgumentError` when `deadline_ns < 0`."""
 function RequestContext(; deadline_ns::Integer = Int64(0))
     deadline_ns < 0 && throw(ArgumentError("deadline_ns must be >= 0"))
-    return RequestContext(Int64(deadline_ns), false, nothing)
+    return RequestContext(Int64(deadline_ns), false, nothing, nothing)
 end
 
 """
@@ -481,6 +482,51 @@ function expired(ctx::RequestContext, now_ns::Integer = time_ns())::Bool
     deadline = ctx.deadline_ns
     deadline <= 0 && return false
     return Int64(now_ns) >= deadline
+end
+
+@inline function _request_context_metadata!(
+        ctx::RequestContext)::Dict{Symbol, Any}
+    metadata = ctx.metadata
+    metadata !== nothing && return metadata::Dict{Symbol, Any}
+    metadata = Dict{Symbol, Any}()
+    ctx.metadata = metadata
+    return metadata
+end
+
+function Base.haskey(ctx::RequestContext, key::Symbol)::Bool
+    metadata = ctx.metadata
+    metadata === nothing && return false
+    return haskey(metadata::Dict{Symbol, Any}, key)
+end
+
+function Base.getindex(ctx::RequestContext, key::Symbol)
+    metadata = ctx.metadata
+    metadata === nothing && throw(KeyError(key))
+    return (metadata::Dict{Symbol, Any})[key]
+end
+
+function Base.setindex!(ctx::RequestContext, value, key::Symbol)
+    _request_context_metadata!(ctx)[key] = value
+    return value
+end
+
+function Base.get(default::Function, ctx::RequestContext, key::Symbol)
+    metadata = ctx.metadata
+    metadata === nothing && return default()
+    return get(default, metadata::Dict{Symbol, Any}, key)
+end
+
+function Base.get(ctx::RequestContext, key::Symbol, default)
+    metadata = ctx.metadata
+    metadata === nothing && return default
+    return get(metadata::Dict{Symbol, Any}, key, default)
+end
+
+function Base.empty!(ctx::RequestContext)
+    metadata = ctx.metadata
+    metadata === nothing && return ctx
+    empty!(metadata::Dict{Symbol, Any})
+    return ctx
 end
 
 """

--- a/src/7_7_http_handlers.jl
+++ b/src/7_7_http_handlers.jl
@@ -10,7 +10,6 @@ export getroute
 export getparams
 export getparam
 export getcookies
-export streamhandler
 export Node
 
 import ..Request
@@ -18,12 +17,8 @@ import ..Response
 import ..Stream
 import ..Cookie
 import ..Cookies
-import ..ProtocolError
-import ..startread
 import ..setstatus
-import ..closewrite
-import ..closeread
-import .._write_response_body_to_stream!
+import ..startread
 import ..serve
 import ..serve!
 
@@ -51,26 +46,6 @@ There is no requirement to subtype `Middleware` and users should not rely on or
 dispatch on `Middleware`.
 """
 abstract type Middleware end
-
-"""
-    streamhandler(request_handler) -> stream handler
-
-Middleware that takes a request handler and returns a stream handler.
-"""
-function streamhandler(handler)
-    return function(stream::Stream)
-        req = startread(stream)
-        resp = handler(req)
-        resp isa Response || throw(ProtocolError("streamhandler request handler must return HTTP.Response"))
-        response = resp::Response
-        response.request = req
-        stream.response = response
-        _write_response_body_to_stream!(stream, response.body)
-        closewrite(stream)
-        closeread(stream)
-        return nothing
-    end
-end
 
 mutable struct Variable
     name::String

--- a/src/7_7_http_handlers.jl
+++ b/src/7_7_http_handlers.jl
@@ -1,0 +1,351 @@
+module Handlers
+
+export Handler
+export Middleware
+export serve
+export serve!
+export Router
+export register!
+export getroute
+export getparams
+export getparam
+export getcookies
+export streamhandler
+export Node
+
+import ..Request
+import ..Response
+import ..Stream
+import ..Cookie
+import ..Cookies
+import ..ProtocolError
+import ..startread
+import ..setstatus
+import ..closewrite
+import ..closeread
+import .._write_response_body_to_stream!
+import ..serve
+import ..serve!
+
+"""
+    Handler
+
+Abstract type for the handler interface that exists for documentation purposes.
+A `Handler` is any function of the form `f(req::HTTP.Request) -> HTTP.Response`.
+There is no requirement to subtype `Handler` and users should not rely on or
+dispatch on `Handler`.
+
+For advanced cases, a `Handler` function can also be of the form
+`f(stream::HTTP.Stream) -> Nothing`. In this case, the server would be run like
+`HTTP.serve(f, ...; stream=true)`. Any middleware used with a stream handler
+also needs to accept and return a stream handler.
+"""
+abstract type Handler end
+
+"""
+    Middleware
+
+Abstract type for the middleware interface that exists for documentation
+purposes. A `Middleware` is any function of the form `f(::Handler) -> Handler`.
+There is no requirement to subtype `Middleware` and users should not rely on or
+dispatch on `Middleware`.
+"""
+abstract type Middleware end
+
+"""
+    streamhandler(request_handler) -> stream handler
+
+Middleware that takes a request handler and returns a stream handler.
+"""
+function streamhandler(handler)
+    return function(stream::Stream)
+        req = startread(stream)
+        resp = handler(req)
+        resp isa Response || throw(ProtocolError("streamhandler request handler must return HTTP.Response"))
+        response = resp::Response
+        response.request = req
+        stream.response = response
+        _write_response_body_to_stream!(stream, response.body)
+        closewrite(stream)
+        closeread(stream)
+        return nothing
+    end
+end
+
+mutable struct Variable
+    name::String
+    pattern::Union{Nothing, Regex}
+end
+
+const VARREGEX = r"^{([^:{}]+)(?::(.*))?}$"
+
+function Variable(pattern)
+    re = Base.match(VARREGEX, pattern)
+    re === nothing && error("problem parsing path variable for route: `$pattern`")
+    pat = re.captures[2]
+    return Variable(re.captures[1], pat === nothing ? nothing : Regex(pat))
+end
+
+struct Leaf{H}
+    method::String
+    variables::Vector{Tuple{Int, String}}
+    path::String
+    handler::H
+end
+
+Base.show(io::IO, x::Leaf) = print(io, "Leaf($(x.method))")
+
+mutable struct Node
+    segment::Union{String, Variable}
+    exact::Vector{Node}
+    conditional::Vector{Node}
+    wildcard::Union{Node, Nothing}
+    doublestar::Union{Node, Nothing}
+    methods::Vector{Leaf}
+end
+
+Base.show(io::IO, x::Node) = print(io, "Node($(x.segment))")
+
+isvariable(x) = startswith(x, "{") && endswith(x, "}")
+segment(x) = isvariable(x) ? Variable(x) : String(x)
+
+Node(x) = Node(x, Node[], Node[], nothing, nothing, Leaf[])
+Node() = Node("*")
+
+function find(y, itr; by = identity, eq = (==))
+    for (i, x) in enumerate(itr)
+        eq(by(x), y) && return i
+    end
+    return nothing
+end
+
+function insert!(node::Node, leaf, segments, i)
+    if i > length(segments)
+        j = find(leaf.method, node.methods; by = x -> x.method, eq = (x, y) -> x == "*" || x == y)
+        if j === nothing
+            push!(node.methods, leaf)
+        else
+            @warn "replacing existing registered route; $(node.methods[j].method) => \"$(node.methods[j].path)\" route with new path = \"$(leaf.path)\""
+            node.methods[j] = leaf
+        end
+        return nothing
+    end
+    segment_value = segments[i]
+    if segment_value isa Variable
+        push!(leaf.variables, (i, segment_value.name))
+    end
+    if segment_value == "*" || (segment_value isa Variable && segment_value.pattern === nothing)
+        if node.wildcard === nothing
+            node.wildcard = Node(segment_value)
+        end
+        return insert!(node.wildcard::Node, leaf, segments, i + 1)
+    elseif segment_value == "**"
+        if node.doublestar === nothing
+            node.doublestar = Node(segment_value)
+        end
+        i < length(segments) && error("/** double wildcard must be last segment in path")
+        return insert!(node.doublestar::Node, leaf, segments, i + 1)
+    elseif segment_value isa Variable
+        j = find(segment_value.pattern, node.conditional; by = x -> x.segment.pattern)
+        if j === nothing
+            n = Node(segment_value)
+            push!(node.conditional, n)
+        else
+            n = node.conditional[j]
+        end
+        return insert!(n, leaf, segments, i + 1)
+    else
+        j = find(segment_value, node.exact; by = x -> x.segment)
+        if j === nothing
+            n = Node(segment_value)
+            push!(node.exact, n)
+            sort!(node.exact; by = x -> x.segment)
+            return insert!(n, leaf, segments, i + 1)
+        end
+        return insert!(node.exact[j], leaf, segments, i + 1)
+    end
+end
+
+function match(node::Node, method, segments, i)
+    if i > length(segments)
+        isempty(node.methods) && return nothing
+        j = find(method, node.methods; by = x -> x.method, eq = (x, y) -> x == "*" || x == y)
+        return j === nothing ? missing : node.methods[j]
+    end
+    segment_value = segments[i]
+    anymissing = false
+    j = find(segment_value, node.exact; by = x -> x.segment)
+    if j !== nothing
+        m = match(node.exact[j], method, segments, i + 1)
+        anymissing = m === missing
+        m = coalesce(m, nothing)
+        m !== nothing && return m
+    end
+    for conditional_node in node.conditional
+        if Base.match(conditional_node.segment.pattern, segment_value) !== nothing
+            m = match(conditional_node, method, segments, i + 1)
+            anymissing = m === missing
+            m = coalesce(m, nothing)
+            m !== nothing && return m
+        end
+    end
+    if node.wildcard !== nothing
+        m = match(node.wildcard::Node, method, segments, i + 1)
+        anymissing = m === missing
+        m = coalesce(m, nothing)
+        m !== nothing && return m
+    end
+    if node.doublestar !== nothing
+        m = match(node.doublestar::Node, method, segments, length(segments) + 1)
+        anymissing = m === missing
+        m = coalesce(m, nothing)
+        m !== nothing && return m
+    end
+    return anymissing ? missing : nothing
+end
+
+"""
+    HTTP.Router(_404, _405, middleware=nothing)
+
+Define a router object that maps incoming requests by path to registered routes
+and associated handlers.
+"""
+struct Router{T, S, F}
+    _404::T
+    _405::S
+    routes::Node
+    middleware::F
+end
+
+default404(::Request) = Response(404)
+default405(::Request) = Response(405)
+default404(stream::Stream) = setstatus(stream, 404)
+default405(stream::Stream) = setstatus(stream, 405)
+
+Router(_404 = default404, _405 = default405, middleware = nothing) = Router(_404, _405, Node(), middleware)
+
+function register! end
+
+function register!(r::Router, method, path, handler)
+    segments = map(segment, split(path, '/'; keepempty = false))
+    if r.middleware !== nothing
+        handler = r.middleware(handler)
+    end
+    insert!(r.routes, Leaf(method, Tuple{Int, String}[], path, handler), segments, 1)
+    return nothing
+end
+
+register!(r::Router, path, handler) = register!(r, "*", path, handler)
+
+const Params = Dict{String, String}
+
+@inline function _split_query_target(target::String)::String
+    idx = findfirst(isequal('?'), target)
+    idx === nothing && return target
+    idx == firstindex(target) && return ""
+    return String(SubString(target, firstindex(target), prevind(target, idx)))
+end
+
+function _router_request_path(target::String)::String
+    isempty(target) && return "/"
+    target == "*" && return target
+    startswith(target, "/") && return _split_query_target(target)
+    scheme_idx = findfirst("://", target)
+    if scheme_idx === nothing
+        return _split_query_target(target)
+    end
+    authority_start = last(scheme_idx) + 1
+    authority_start > lastindex(target) && return "/"
+    slash_idx = findnext(isequal('/'), target, authority_start)
+    slash_idx === nothing && return "/"
+    return _split_query_target(String(SubString(target, slash_idx, lastindex(target))))
+end
+
+function gethandler(r::Router, req::Request)
+    segments = split(_router_request_path(req.target), '/'; keepempty = false)
+    leaf = match(r.routes, req.method, segments, 1)
+    params = Params()
+    if leaf isa Leaf
+        if !isempty(leaf.variables)
+            for (i, v) in leaf.variables
+                params[v] = segments[i]
+            end
+        end
+        return leaf.handler, leaf.path, params
+    end
+    return leaf, "", params
+end
+
+function (r::Router)(stream::Stream)
+    req = startread(stream)
+    handler, route, params = gethandler(r, req)
+    if handler === nothing
+        return r._404(stream)
+    elseif handler === missing
+        return r._405(stream)
+    end
+    req.context[:route] = route
+    isempty(params) || (req.context[:params] = params)
+    return handler(stream)
+end
+
+function (r::Router)(req::Request)
+    handler, route, params = gethandler(r, req)
+    if handler === nothing
+        return r._404(req)
+    elseif handler === missing
+        return r._405(req)
+    end
+    req.context[:route] = route
+    isempty(params) || (req.context[:params] = params)
+    return handler(req)
+end
+
+"""
+    HTTP.getroute(req) -> Union{Nothing, String}
+
+Retrieve the original route registration string for a request after its target
+has been matched against a router.
+"""
+getroute(req) = get(req.context, :route, nothing)
+
+"""
+    HTTP.getparams(req) -> Union{Nothing, Dict{String, String}}
+
+Retrieve any matched path parameters from the request context.
+"""
+getparams(req) = get(req.context, :params, nothing)
+
+"""
+    HTTP.getparam(req, name, default=nothing) -> Any
+
+Retrieve a matched path parameter with name `name` from request context.
+"""
+function getparam(req, name, default = nothing)
+    params = getparams(req)
+    params === nothing && return default
+    return get(params, name, default)
+end
+
+"""
+    HTTP.Handlers.cookie_middleware(handler) -> handler
+
+Middleware that parses and stores any cookies in the incoming request context.
+"""
+function cookie_middleware(handler)
+    function (req)
+        if !haskey(req.context, :cookies)
+            req.context[:cookies] = Cookies.cookies(req)
+        end
+        return handler(req)
+    end
+end
+
+"""
+    HTTP.getcookies(req) -> Vector{Cookie}
+
+Retrieve any parsed cookies from a request context.
+"""
+getcookies(req) = get(() -> Cookie[], req.context, :cookies)
+
+end

--- a/src/7_7_http_server.jl
+++ b/src/7_7_http_server.jl
@@ -5,6 +5,7 @@ export listen
 export listen!
 export serve
 export serve!
+export streamhandler
 export forceclose
 export port
 
@@ -1036,6 +1037,26 @@ function _write_response_body_to_stream!(stream::Stream, body)::Nothing
         return nothing
     end
     throw(ProtocolError("unsupported stream response body type $(typeof(body))"))
+end
+
+"""
+    streamhandler(request_handler) -> stream handler
+
+Adapter that takes a request handler and returns a stream handler.
+"""
+function streamhandler(handler)
+    return function(stream::Stream)
+        req = startread(stream)
+        resp = handler(req)
+        resp isa Response || throw(ProtocolError("streamhandler request handler must return HTTP.Response"))
+        response = resp::Response
+        response.request = req
+        stream.response = response
+        _write_response_body_to_stream!(stream, response.body)
+        closewrite(stream)
+        closeread(stream)
+        return nothing
+    end
 end
 
 mutable struct _H2ServerStreamState

--- a/src/7_http.jl
+++ b/src/7_http.jl
@@ -10,8 +10,8 @@ supporting wire-format packages are split:
 - `7_1_http1.jl` implements HTTP/1.1 parsing and serialization.
 - `7_2_hpack.jl` and `7_3_http2.jl` implement the HPACK and HTTP/2 wire layers.
 - `7_4_http2_client.jl`, `7_5_http2_server.jl`, `7_6_http_client.jl`,
-  `7_6_http_stream.jl`, `7_6_http_sse.jl`, and `7_7_http_server.jl` build
-  higher-level client/server behavior on top.
+  `7_6_http_stream.jl`, `7_6_http_sse.jl`, `7_7_http_server.jl`, and
+  `7_7_http_handlers.jl` build higher-level client/server behavior on top.
 
 This module exports both the low-level wire APIs and the convenience client and
 server entry points. Most public functions either return one of the shared

--- a/src/7_http.jl
+++ b/src/7_http.jl
@@ -33,6 +33,8 @@ include("7_6_http_request_bodies.jl")
 include("7_6_http_client.jl")
 include("7_7_http_server.jl")
 include("7_6_http_stream.jl")
+include("7_7_http_handlers.jl")
+using .Handlers
 include("7_6_http_sse.jl")
 include("7_6_http_websocket_codec.jl")
 include("7_6_http_websockets.jl")

--- a/test/http2_server_tests.jl
+++ b/test/http2_server_tests.jl
@@ -103,6 +103,35 @@ end
     end
 end
 
+@testset "HTTP/2 server router request handlers work" begin
+    router = HT.Router()
+    HT.register!(router, "GET", "/router/{name}", req -> begin
+            payload = collect(codeunits("router:" * HT.getparam(req, "name")))
+            return HT.Response(200; body = HT.BytesBody(payload), content_length = length(payload), proto_major = 2, proto_minor = 0)
+        end)
+    server = HT.serve!(router, "127.0.0.1", 0; listenany = true)
+    address = _wait_http_server_addr(server)
+    conn = HT.connect_h2!(address; secure = false)
+    try
+        ok_req = HT.Request("GET", "/router/alex?debug=1"; host = address, body = HT.EmptyBody(), content_length = 0, proto_major = 2, proto_minor = 0)
+        ok_res = HT.h2_roundtrip!(conn, ok_req)
+        @test ok_res.status_code == 200
+        @test String(_read_all_h2_server(ok_res.body)) == "router:alex"
+
+        wrong_method = HT.Request("POST", "/router/alex"; host = address, body = HT.EmptyBody(), content_length = 0, proto_major = 2, proto_minor = 0)
+        wrong_method_res = HT.h2_roundtrip!(conn, wrong_method)
+        @test wrong_method_res.status_code == 405
+
+        missing_req = HT.Request("GET", "/missing"; host = address, body = HT.EmptyBody(), content_length = 0, proto_major = 2, proto_minor = 0)
+        missing_res = HT.h2_roundtrip!(conn, missing_req)
+        @test missing_res.status_code == 404
+    finally
+        close(conn)
+        HT.forceclose(server)
+        _ = timedwait(() -> istaskdone(server.serve_task::Task), 3.0; pollint = 0.001)
+    end
+end
+
 @testset "HTTP/2 server stream handlers work and suppress HEAD bodies" begin
     server = HT.listen!("127.0.0.1", 0; listenany = true) do stream
             request = HT.startread(stream)
@@ -131,6 +160,36 @@ end
         head_res = HT.h2_roundtrip!(conn, head_req)
         @test head_res.status_code == 200
         @test isempty(_read_all_h2_server(head_res.body))
+    finally
+        close(conn)
+        HT.forceclose(server)
+        _ = timedwait(() -> istaskdone(server.serve_task::Task), 3.0; pollint = 0.001)
+    end
+end
+
+@testset "HTTP/2 server router stream handlers work" begin
+    router = HT.Router()
+    HT.register!(router, "POST", "/stream/{name}", stream -> begin
+            request = HT.startread(stream)
+            body = String(read(stream))
+            HT.setstatus(stream, 200)
+            HT.setheader(stream, "Content-Type", "text/plain")
+            write(stream, "router-stream:" * HT.getparam(request, "name") * ":" * body)
+            return nothing
+        end)
+    server = HT.listen!(router, "127.0.0.1", 0; listenany = true)
+    address = _wait_http_server_addr(server)
+    conn = HT.connect_h2!(address; secure = false)
+    try
+        payload = collect(codeunits("echo"))
+        req = HT.Request("POST", "/stream/sam?debug=1"; host = address, body = HT.BytesBody(payload), content_length = length(payload), proto_major = 2, proto_minor = 0)
+        res = HT.h2_roundtrip!(conn, req)
+        @test res.status_code == 200
+        @test String(_read_all_h2_server(res.body)) == "router-stream:sam:echo"
+
+        wrong_method = HT.Request("GET", "/stream/sam"; host = address, body = HT.EmptyBody(), content_length = 0, proto_major = 2, proto_minor = 0)
+        wrong_method_res = HT.h2_roundtrip!(conn, wrong_method)
+        @test wrong_method_res.status_code == 405
     finally
         close(conn)
         HT.forceclose(server)

--- a/test/http_core_tests.jl
+++ b/test/http_core_tests.jl
@@ -38,6 +38,16 @@ end
     ctx = HT.RequestContext()
     @test !HT.canceled(ctx)
     @test !HT.expired(ctx)
+    @test !haskey(ctx, :route)
+    @test get(ctx, :route, nothing) === nothing
+    ctx[:route] = "/health"
+    ctx[:params] = Dict("id" => "7")
+    @test haskey(ctx, :route)
+    @test ctx[:route] == "/health"
+    @test get(ctx, :params, nothing) == Dict("id" => "7")
+    @test get(() -> "fallback", ctx, :missing) == "fallback"
+    empty!(ctx)
+    @test !haskey(ctx, :route)
     HT.set_deadline!(ctx, time_ns() + 50_000_000)
     @test !HT.expired(ctx)
     HT.set_deadline!(ctx, 1)

--- a/test/http_handlers_tests.jl
+++ b/test/http_handlers_tests.jl
@@ -1,0 +1,205 @@
+using Test
+using Reseau
+
+const HT = Reseau.HTTP
+
+function _read_all_handler_bytes(body::HT.AbstractBody)::Vector{UInt8}
+    out = UInt8[]
+    buf = Vector{UInt8}(undef, 64)
+    while true
+        n = HT.body_read!(body, buf)
+        n == 0 && break
+        append!(out, @view(buf[1:n]))
+    end
+    return out
+end
+
+_read_all_handler_bytes(body::AbstractVector{UInt8}) = Vector{UInt8}(body)
+
+function _wait_handlers_server_addr(server; timeout_s::Float64 = 5.0)::String
+    deadline = time() + timeout_s
+    while time() < deadline
+        try
+            return HT.server_addr(server)
+        catch
+            sleep(0.01)
+        end
+    end
+    error("timed out waiting for server address")
+end
+
+function _response_with_text(text::AbstractString; status::Integer = 200)::HT.Response
+    bytes = collect(codeunits(String(text)))
+    return HT.Response(status; body = HT.BytesBody(bytes), content_length = length(bytes))
+end
+
+@testset "HTTP handlers router direct matching" begin
+    called = Ref(false)
+    middle = handler -> req -> begin
+        called[] = true
+        return handler(req)
+    end
+    router = HT.Router(_ -> 0, _ -> -1, middle)
+
+    HT.register!(router, "/test", _ -> 1)
+    @test router(HT.Request("GET", "/test")) == 1
+    @test called[]
+
+    HT.register!(router, "/path/to/greatness", _ -> 2)
+    @test router(HT.Request("GET", "/path/to/greatness")) == 2
+
+    HT.register!(router, "/next/path/to/greatness", _ -> 3)
+    @test router(HT.Request("GET", "/next/path/to/greatness")) == 3
+
+    HT.register!(router, "GET", "/sget", _ -> 4)
+    HT.register!(router, "POST", "/spost", _ -> 5)
+    HT.register!(router, "POST", "/tpost", _ -> 6)
+    HT.register!(router, "GET", "/tpost", _ -> 7)
+    @test router(HT.Request("GET", "/sget")) == 4
+    called[] = false
+    @test router(HT.Request("POST", "/sget")) == -1
+    @test !called[]
+    @test router(HT.Request("GET", "/spost")) == -1
+    @test router(HT.Request("POST", "/spost")) == 5
+    @test router(HT.Request("POST", "/tpost")) == 6
+    @test router(HT.Request("GET", "/tpost")) == 7
+
+    HT.register!(router, "/test/*", _ -> 8)
+    HT.register!(router, "/test/sarv/ghotra", _ -> 9)
+    HT.register!(router, "/test/*/ghotra/seven", _ -> 10)
+    @test router(HT.Request("GET", "/test/sarv")) == 8
+    @test router(HT.Request("GET", "/test/sarv/ghotra")) == 9
+    @test router(HT.Request("GET", "/test/sarv/ghotra/seven")) == 10
+    @test router(HT.Request("GET", "/test/foo")) == 8
+
+    HT.register!(router, "/api/issue/{issue_id}", req -> HT.getparams(req)["issue_id"])
+    @test router(HT.Request("GET", "/api/issue/871")) == "871"
+
+    widget_id_router = HT.Router()
+    HT.register!(widget_id_router, "/api/widgets/{id}", req -> HT.getparam(req, "id"))
+    @test widget_id_router(HT.Request("GET", "/api/widgets/11")) == "11"
+
+    widget_name_router = HT.Router()
+    HT.register!(widget_name_router, "/api/widgets/{name}", req -> (HT.getparam(req, "name"), HT.getroute(req)))
+    @test widget_name_router(HT.Request("GET", "/api/widgets/11")) == ("11", "/api/widgets/{name}")
+
+    acme_router = HT.Router(_ -> 0, _ -> -1, middle)
+    HT.register!(acme_router, "/api/widgets/acme/{id:[a-z]+}", req -> HT.getparam(req, "id"))
+    called[] = false
+    @test acme_router(HT.Request("GET", "/api/widgets/acme/11")) == 0
+    @test !called[]
+    @test acme_router(HT.Request("GET", "/api/widgets/acme/abc")) == "abc"
+
+    HT.register!(router, "/test/**", _ -> 11)
+    @test router(HT.Request("GET", "/test/foo/foobar")) == 11
+    @test router(HT.Request("GET", "/test/foo/foobar/baz")) == 11
+    @test router(HT.Request("GET", "/test/foo/foobar/baz/sailor")) == 11
+    @test_throws ErrorException HT.register!(router, "/test/**/foo", _ -> 11)
+
+    subwidget_router = HT.Router()
+    HT.register!(subwidget_router, "/api/widgets/{name:[a-z]+}/subwidgetsbyname", _ -> 12)
+    HT.register!(subwidget_router, "/api/widgets/{id:[0-9]+}/subwidgetsbyid", _ -> 13)
+    HT.register!(subwidget_router, "/api/widgets/{id}", _ -> 14)
+    HT.register!(subwidget_router, "/api/widgets/{subId}/subwidget", _ -> 15)
+    HT.register!(subwidget_router, "/api/widgets/{subName}/subwidgetname", _ -> 16)
+    @test subwidget_router(HT.Request("GET", "/api/widgets/abc/subwidgetsbyname")) == 12
+    @test subwidget_router(HT.Request("GET", "/api/widgets/123/subwidgetsbyid")) == 13
+    @test subwidget_router(HT.Request("GET", "/api/widgets/234")) == 14
+    @test subwidget_router(HT.Request("GET", "/api/widgets/abc/subwidget")) == 15
+    @test subwidget_router(HT.Request("GET", "/api/widgets/abc/subwidgetname")) == 16
+
+    query_router = HT.Router()
+    HT.register!(query_router, "/api/widgets/{name}", req -> (HT.getparam(req, "name"), HT.getroute(req)))
+    @test query_router(HT.Request("GET", "/api/widgets/55?expand=true")) == ("55", "/api/widgets/{name}")
+    @test query_router(HT.Request("GET", "http://example.test/api/widgets/77?expand=true")) == ("77", "/api/widgets/{name}")
+end
+
+@testset "HTTP handlers cookie middleware" begin
+    headers = HT.Headers()
+    HT.set_header!(headers, "Cookie", "abc=def; mode=test")
+    req = HT.Request("GET", "/"; headers = headers)
+    cookies = HT.Handlers.cookie_middleware(req -> HT.getcookies(req))(req)
+    @test length(cookies) == 2
+    @test cookies[1].name == "abc"
+    @test cookies[1].value == "def"
+    @test cookies[2].name == "mode"
+    @test cookies[2].value == "test"
+    @test HT.getcookies(req) === cookies
+end
+
+@testset "HTTP streamhandler helper" begin
+    handler = req -> begin
+        body_text = String(_read_all_handler_bytes(req.body))
+        return _response_with_text(isempty(body_text) ? "ping" : body_text)
+    end
+    server = HT.listen!(HT.streamhandler(handler), "127.0.0.1", 0; listenany = true)
+    address = _wait_handlers_server_addr(server)
+    try
+        resp = HT.get("http://$(address)/")
+        @test resp.status == 200
+        @test String(_read_all_handler_bytes(resp.body)) == "ping"
+
+        resp = HT.post("http://$(address)/"; body = "echo")
+        @test resp.status == 200
+        @test String(_read_all_handler_bytes(resp.body)) == "echo"
+    finally
+        HT.forceclose(server)
+        wait(server)
+    end
+end
+
+@testset "HTTP router live request handler server" begin
+    router = HT.Router()
+    HT.register!(router, "GET", "/hello/{name}", req -> _response_with_text("hello:" * HT.getparam(req, "name")))
+    HT.register!(router, "POST", "/echo/{name}", req -> begin
+        payload = String(_read_all_handler_bytes(req.body))
+        return _response_with_text("echo:" * HT.getparam(req, "name") * ":" * payload)
+    end)
+
+    server = HT.serve!(router, "127.0.0.1", 0; listenany = true)
+    address = _wait_handlers_server_addr(server)
+    try
+        hello = HT.get("http://$(address)/hello/jane?lang=en")
+        @test hello.status == 200
+        @test String(_read_all_handler_bytes(hello.body)) == "hello:jane"
+
+        echo = HT.post("http://$(address)/echo/jane"; body = "ping")
+        @test echo.status == 200
+        @test String(_read_all_handler_bytes(echo.body)) == "echo:jane:ping"
+
+        missing_method = HT.request("PUT", "http://$(address)/hello/jane"; status_exception = false)
+        @test missing_method.status == 405
+
+        missing_route = HT.get("http://$(address)/missing"; status_exception = false)
+        @test missing_route.status == 404
+    finally
+        HT.forceclose(server)
+        wait(server)
+    end
+end
+
+@testset "HTTP router live stream handler server" begin
+    router = HT.Router()
+    HT.register!(router, "POST", "/stream/{name}", stream -> begin
+        req = HT.startread(stream)
+        payload = read(stream, String)
+        HT.setstatus(stream, 200)
+        HT.setheader(stream, "Content-Type", "text/plain")
+        write(stream, "stream:" * HT.getparam(req, "name") * ":" * payload)
+        return nothing
+    end)
+
+    server = HT.listen!(router, "127.0.0.1", 0; listenany = true)
+    address = _wait_handlers_server_addr(server)
+    try
+        resp = HT.post("http://$(address)/stream/sam"; body = "pong")
+        @test resp.status == 200
+        @test String(_read_all_handler_bytes(resp.body)) == "stream:sam:pong"
+
+        wrong_method = HT.get("http://$(address)/stream/sam"; status_exception = false)
+        @test wrong_method.status == 405
+    finally
+        HT.forceclose(server)
+        wait(server)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,6 +51,7 @@ test_files = [
 # work, but they remain skipped on Windows pending the separate compiler issue
 # already documented in the repo notes.
 const _WINDOWS_COMPILER_ISSUE_TESTS = Set([
+    "http_handlers_tests.jl",
     "http_client_transport_tests.jl",
     "http_client_proxy_tests.jl",
     "http_client_tests.jl",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ test_files = [
     "http1_wire_tests.jl",
     "http_cookie_tests.jl",
     "http_forms_tests.jl",
+    "http_handlers_tests.jl",
     "http_websocket_codec_tests.jl",
     "http_websocket_client_tests.jl",
     "http_websocket_server_tests.jl",


### PR DESCRIPTION
## Summary
- port the `HTTP.jl` handlers/router surface into `Reseau.HTTP` with a dedicated `Handlers` module
- add lazy `RequestContext` metadata storage for matched routes, params, and parsed cookies
- port and expand handler/router coverage across HTTP/1, HTTP/2, and trim-safe/core test paths
- refresh the README and parity tracker to document the current server/router surface

## Verification
- `JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=http_core_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
- `JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=http_handlers_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
- `JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=http_server_http1_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
- `JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=http2_server_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
- `JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=trim_compile_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`

## Notes
- The canonical full `Pkg.test(; coverage=false)` command currently hangs locally in `eventloops_tests.jl` before the HTTP suites run; that hang reproduces even when isolating `eventloops_tests.jl`, so CI on a clean runner is the source of truth for the full matrix here.
