### PR TITLE
perf: reduce HTTP client request-path overhead

### DIFF
--- a/src/3_internal_poll.jl
+++ b/src/3_internal_poll.jl
@@ -1002,9 +1002,14 @@ Unlike `read!`, a successful return means the full buffer was written. In
 non-blocking mode this loops on `EAGAIN` by waiting for write readiness and
 then resuming from the first unwritten byte.
 """
-function write!(fd::FD, p::Vector{UInt8})::Int
-    GC.@preserve p begin
-        return _write_ptr!(fd, pointer(p), length(p))
+function write!(fd::FD, p::AbstractVector{UInt8})::Int
+    data = if p isa StridedVector{UInt8} && stride(p, 1) == 1
+        p
+    else
+        Vector{UInt8}(p)
+    end
+    GC.@preserve data begin
+        return _write_ptr!(fd, pointer(data), length(data))
     end
 end
 

--- a/src/4_tcp.jl
+++ b/src/4_tcp.jl
@@ -654,7 +654,7 @@ On success, the return value is always `length(buf)`. If the socket cannot
 currently accept data, the call waits for write readiness and resumes until the
 entire buffer has been written or an error/deadline interrupts the operation.
 """
-function Base.write(conn::Conn, buf::Vector{UInt8})::Int
+function Base.write(conn::Conn, buf::AbstractVector{UInt8})::Int
     return IOPoll.write!(conn.fd.pfd, buf)
 end
 

--- a/src/5_host_resolvers.jl
+++ b/src/5_host_resolvers.jl
@@ -154,6 +154,76 @@ function SingleflightResolver(parent::R) where {R <: AbstractResolver}
     return SingleflightResolver{R}(parent, ReentrantLock(), Dict{Tuple{String, String}, _LookupFlight}(), 0, 0)
 end
 
+mutable struct _LookupCacheEntry
+    result::Union{Nothing, Vector{TCP.SocketEndpoint}}
+    err::Union{Nothing, Exception}
+    expires_ns::Int64
+    stale_expires_ns::Int64
+    last_access_ns::Int64
+    refreshing::Bool
+end
+
+"""
+    CachingResolver(; parent=SystemResolver(), ttl_ns, stale_ttl_ns, negative_ttl_ns, max_hosts)
+    CachingResolver(parent; ttl_ns, stale_ttl_ns, negative_ttl_ns, max_hosts)
+
+Explicit opt-in hostname cache with policy TTLs.
+
+This caches positive host-IP lookups for `ttl_ns`, may serve stale positives for
+up to `stale_ttl_ns` while refreshing in the background, and may cache
+`AddressError` failures for `negative_ttl_ns`. `max_hosts` bounds the number of
+cached host keys and evicts the least-recently-used entry when full.
+"""
+mutable struct CachingResolver{R <: AbstractResolver} <: AbstractResolver
+    parent::R
+    ttl_ns::Int64
+    stale_ttl_ns::Int64
+    negative_ttl_ns::Int64
+    max_hosts::Int
+    lock::ReentrantLock
+    entries::Dict{Tuple{String, String}, _LookupCacheEntry}
+    @atomic cache_hits::Int
+    @atomic stale_hits::Int
+    @atomic negative_hits::Int
+    @atomic misses::Int
+end
+
+function CachingResolver(
+        parent::R;
+        ttl_ns::Integer = Int64(5_000_000_000),
+        stale_ttl_ns::Integer = Int64(0),
+        negative_ttl_ns::Integer = Int64(0),
+        max_hosts::Integer = 1024,
+    ) where {R <: AbstractResolver}
+    ttl_ns >= 0 || throw(ArgumentError("ttl_ns must be >= 0"))
+    stale_ttl_ns >= 0 || throw(ArgumentError("stale_ttl_ns must be >= 0"))
+    negative_ttl_ns >= 0 || throw(ArgumentError("negative_ttl_ns must be >= 0"))
+    max_hosts > 0 || throw(ArgumentError("max_hosts must be > 0"))
+    return CachingResolver{R}(
+        parent,
+        Int64(ttl_ns),
+        Int64(stale_ttl_ns),
+        Int64(negative_ttl_ns),
+        Int(max_hosts),
+        ReentrantLock(),
+        Dict{Tuple{String, String}, _LookupCacheEntry}(),
+        0,
+        0,
+        0,
+        0,
+    )
+end
+
+function CachingResolver(;
+        parent::AbstractResolver = SystemResolver(),
+        ttl_ns::Integer = Int64(5_000_000_000),
+        stale_ttl_ns::Integer = Int64(0),
+        negative_ttl_ns::Integer = Int64(0),
+        max_hosts::Integer = 1024,
+    )
+    return CachingResolver(parent; ttl_ns = ttl_ns, stale_ttl_ns = stale_ttl_ns, negative_ttl_ns = negative_ttl_ns, max_hosts = max_hosts)
+end
+
 """
     StaticResolver
 
@@ -863,6 +933,148 @@ function _resolve_singleflight_host(
     end
 end
 
+function _evict_cache_if_needed_locked!(resolver::CachingResolver)
+    length(resolver.entries) <= resolver.max_hosts && return nothing
+    oldest_key = nothing
+    oldest_access = typemax(Int64)
+    for (key, entry) in resolver.entries
+        if entry.last_access_ns < oldest_access
+            oldest_access = entry.last_access_ns
+            oldest_key = key
+        end
+    end
+    oldest_key === nothing || delete!(resolver.entries, oldest_key)
+    return nothing
+end
+
+function _store_cache_entry_locked!(
+        resolver::CachingResolver,
+        key::Tuple{String, String},
+        result::Union{Nothing, Vector{TCP.SocketEndpoint}},
+        err::Union{Nothing, Exception},
+        now_ns::Int64,
+    )
+    expires_ns = now_ns
+    stale_expires_ns = now_ns
+    if err === nothing
+        expires_ns += resolver.ttl_ns
+        stale_expires_ns = expires_ns + resolver.stale_ttl_ns
+    else
+        expires_ns += resolver.negative_ttl_ns
+        stale_expires_ns = expires_ns
+    end
+    resolver.entries[key] = _LookupCacheEntry(
+        result === nothing ? nothing : copy(result::Vector{TCP.SocketEndpoint}),
+        err,
+        expires_ns,
+        stale_expires_ns,
+        now_ns,
+        false,
+    )
+    _evict_cache_if_needed_locked!(resolver)
+    return nothing
+end
+
+function _refresh_cached_host!(
+        resolver::CachingResolver,
+        key::Tuple{String, String},
+        network::String,
+        host::String,
+    )
+    result = nothing
+    err = nothing
+    try
+        result = _resolve_host_ips(resolver.parent, network, host)
+    catch ex
+        err = ex::Exception
+    end
+    now_ns = Int64(time_ns())
+    lock(resolver.lock)
+    try
+        entry = get(() -> nothing, resolver.entries, key)
+        entry === nothing && return nothing
+        if err === nothing
+            _store_cache_entry_locked!(resolver, key, result::Vector{TCP.SocketEndpoint}, nothing, now_ns)
+            return nothing
+        end
+        entry.refreshing = false
+        if err isa AddressError && resolver.negative_ttl_ns > 0
+            _store_cache_entry_locked!(resolver, key, nothing, err, now_ns)
+        end
+    finally
+        unlock(resolver.lock)
+    end
+    return nothing
+end
+
+function _resolve_cached_host(
+        resolver::CachingResolver,
+        network::AbstractString,
+        host::AbstractString,
+    )::Vector{TCP.SocketEndpoint}
+    h = String(host)
+    literal = _literal_host_addr(h)
+    literal === nothing || return TCP.SocketEndpoint[literal]
+    key = _lookup_key(network, h)
+    now_ns = Int64(time_ns())
+    stale_result = nothing
+    refresh_needed = false
+    lock(resolver.lock)
+    try
+        entry = get(() -> nothing, resolver.entries, key)
+        if entry !== nothing
+            entry.last_access_ns = now_ns
+            if now_ns <= entry.expires_ns
+                if entry.err === nothing
+                    @atomic :acquire_release resolver.cache_hits += 1
+                    return copy(entry.result::Vector{TCP.SocketEndpoint})
+                end
+                @atomic :acquire_release resolver.negative_hits += 1
+                throw(entry.err::Exception)
+            end
+            if entry.err === nothing && now_ns <= entry.stale_expires_ns
+                @atomic :acquire_release resolver.stale_hits += 1
+                stale_result = copy(entry.result::Vector{TCP.SocketEndpoint})
+                if !entry.refreshing
+                    entry.refreshing = true
+                    refresh_needed = true
+                end
+            else
+                delete!(resolver.entries, key)
+            end
+        end
+        stale_result === nothing && (@atomic :acquire_release resolver.misses += 1)
+    finally
+        unlock(resolver.lock)
+    end
+    if stale_result !== nothing
+        if refresh_needed
+            errormonitor(Threads.@spawn _refresh_cached_host!(resolver, key, String(network), h))
+        end
+        return stale_result::Vector{TCP.SocketEndpoint}
+    end
+    result = nothing
+    err = nothing
+    try
+        result = _resolve_host_ips(resolver.parent, network, h)
+    catch ex
+        err = ex::Exception
+    end
+    now_ns = Int64(time_ns())
+    lock(resolver.lock)
+    try
+        if err === nothing
+            _store_cache_entry_locked!(resolver, key, result::Vector{TCP.SocketEndpoint}, nothing, now_ns)
+        elseif err isa AddressError && resolver.negative_ttl_ns > 0
+            _store_cache_entry_locked!(resolver, key, nothing, err, now_ns)
+        end
+    finally
+        unlock(resolver.lock)
+    end
+    err === nothing || throw(err::Exception)
+    return result::Vector{TCP.SocketEndpoint}
+end
+
 function _resolve_host_ips(
         resolver::AbstractResolver,
         network::AbstractString,
@@ -870,6 +1082,9 @@ function _resolve_host_ips(
     )::Vector{TCP.SocketEndpoint}
     if resolver isa SingleflightResolver
         return _resolve_singleflight_host(resolver::SingleflightResolver, network, host)
+    end
+    if resolver isa CachingResolver
+        return _resolve_cached_host(resolver::CachingResolver, network, host)
     end
     if resolver isa SystemResolver
         return _resolve_system_host(host)
@@ -899,6 +1114,9 @@ end
 
 lookup_port(resolver::SingleflightResolver, network::AbstractString, service::AbstractString)::Int =
     lookup_port((resolver::SingleflightResolver).parent, network, service)
+
+lookup_port(resolver::CachingResolver, network::AbstractString, service::AbstractString)::Int =
+    lookup_port((resolver::CachingResolver).parent, network, service)
 
 @inline function _wildcard_addrs(kind::Symbol, op::Symbol)::Vector{TCP.SocketEndpoint}
     if kind == :tcp && op == :listen

--- a/src/5_host_resolvers.jl
+++ b/src/5_host_resolvers.jl
@@ -123,6 +123,37 @@ This is the default resolver used by the convenience APIs.
 """
 struct SystemResolver <: AbstractResolver end
 
+mutable struct _LookupFlight
+    lock::ReentrantLock
+    cond::Threads.Condition
+    result::Union{Nothing, Vector{TCP.SocketEndpoint}}
+    err::Union{Nothing, Exception}
+    @atomic done::Bool
+    function _LookupFlight()
+        lock = ReentrantLock()
+        return new(lock, Threads.Condition(lock), nothing, nothing, false)
+    end
+end
+
+"""
+    SingleflightResolver(parent)
+
+Resolver wrapper that coalesces concurrent duplicate hostname lookups for the
+same `(network, host)` pair while preserving caller-local timeout and connect
+behavior outside the raw lookup step.
+"""
+mutable struct SingleflightResolver{R <: AbstractResolver} <: AbstractResolver
+    parent::R
+    lock::ReentrantLock
+    inflight::Dict{Tuple{String, String}, _LookupFlight}
+    @atomic actual_lookups::Int
+    @atomic shared_hits::Int
+end
+
+function SingleflightResolver(parent::R) where {R <: AbstractResolver}
+    return SingleflightResolver{R}(parent, ReentrantLock(), Dict{Tuple{String, String}, _LookupFlight}(), 0, 0)
+end
+
 """
     StaticResolver
 
@@ -619,6 +650,11 @@ function lookup_port(network::AbstractString, service::AbstractString)::Int
     return lookup_port(DEFAULT_RESOLVER, network, service)
 end
 
+function lookup_port(resolver::AbstractResolver, network::AbstractString, service::AbstractString)::Int
+    _ = resolver
+    return lookup_port(DEFAULT_RESOLVER, network, service)
+end
+
 function lookup_port(::SystemResolver, network::AbstractString, service::AbstractString)::Int
     port, needs_lookup = parse_port(service)
     if needs_lookup
@@ -729,21 +765,140 @@ function _resolve_system_host(host::AbstractString)::Vector{TCP.SocketEndpoint}
 end
 
 function _resolve_static_host(resolver::StaticResolver, host::AbstractString)::Vector{TCP.SocketEndpoint}
+    return _resolve_static_host(resolver, "tcp", host)
+end
+
+function _resolve_static_host(
+        resolver::StaticResolver,
+        network::AbstractString,
+        host::AbstractString,
+    )::Vector{TCP.SocketEndpoint}
     h = String(host)
     literal = _literal_host_addr(h)
     literal === nothing || return TCP.SocketEndpoint[literal]
     mapped = get(() -> nothing, resolver.hosts, lowercase(h))
     mapped === nothing || return copy(mapped::Vector{TCP.SocketEndpoint})
     resolver.fallback === nothing && _addr_error("no suitable address", h)
-    return _resolve_host_ips(resolver.fallback::AbstractResolver, h)
+    return _resolve_host_ips(resolver.fallback::AbstractResolver, network, h)
 end
 
 function _resolve_host_ips(resolver::AbstractResolver, host::AbstractString)::Vector{TCP.SocketEndpoint}
+    return _resolve_host_ips(resolver, "tcp", host)
+end
+
+@inline function _normalize_lookup_host(host::AbstractString)::String
+    normalized = lowercase(String(host))
+    while !isempty(normalized) && last(normalized) == '.'
+        normalized = normalized[1:prevind(normalized, lastindex(normalized))]
+    end
+    return normalized
+end
+
+@inline function _lookup_key(network::AbstractString, host::AbstractString)::Tuple{String, String}
+    return lowercase(String(network)), _normalize_lookup_host(host)
+end
+
+function _resolve_singleflight_host(
+        resolver::SingleflightResolver,
+        network::AbstractString,
+        host::AbstractString,
+    )::Vector{TCP.SocketEndpoint}
+    h = String(host)
+    literal = _literal_host_addr(h)
+    literal === nothing || return TCP.SocketEndpoint[literal]
+    key = _lookup_key(network, h)
+    flight = nothing
+    leader = false
+    lock(resolver.lock)
+    try
+        existing = get(() -> nothing, resolver.inflight, key)
+        if existing === nothing
+            flight = _LookupFlight()
+            resolver.inflight[key] = flight::_LookupFlight
+            @atomic :acquire_release resolver.actual_lookups += 1
+            leader = true
+        else
+            flight = existing::_LookupFlight
+            @atomic :acquire_release resolver.shared_hits += 1
+        end
+    finally
+        unlock(resolver.lock)
+    end
+    if leader
+        result = nothing
+        err = nothing
+        try
+            result = _resolve_host_ips(resolver.parent, network, h)
+        catch ex
+            err = ex::Exception
+        end
+        lock((flight::_LookupFlight).lock)
+        try
+            flight.result = result === nothing ? nothing : copy(result::Vector{TCP.SocketEndpoint})
+            flight.err = err
+            @atomic :release flight.done = true
+            notify(flight.cond; all = true)
+        finally
+            unlock(flight.lock)
+        end
+        lock(resolver.lock)
+        try
+            current = get(() -> nothing, resolver.inflight, key)
+            current === flight && delete!(resolver.inflight, key)
+        finally
+            unlock(resolver.lock)
+        end
+        err === nothing || throw(err::Exception)
+        return result::Vector{TCP.SocketEndpoint}
+    end
+    lock((flight::_LookupFlight).lock)
+    try
+        while !(@atomic :acquire flight.done)
+            wait(flight.cond)
+        end
+        flight.err === nothing || throw(flight.err::Exception)
+        return copy(flight.result::Vector{TCP.SocketEndpoint})
+    finally
+        unlock(flight.lock)
+    end
+end
+
+function _resolve_host_ips(
+        resolver::AbstractResolver,
+        network::AbstractString,
+        host::AbstractString,
+    )::Vector{TCP.SocketEndpoint}
+    if resolver isa SingleflightResolver
+        return _resolve_singleflight_host(resolver::SingleflightResolver, network, host)
+    end
     if resolver isa SystemResolver
         return _resolve_system_host(host)
     end
-    return _resolve_static_host(resolver::StaticResolver, host)
+    if resolver isa StaticResolver
+        return _resolve_static_host(resolver::StaticResolver, network, host)
+    end
+    resolved = resolve_tcp_addrs(
+        resolver,
+        network,
+        join_host_port(host, 0);
+        op = :resolve,
+        policy = ResolverPolicy(),
+    )
+    ips = TCP.SocketEndpoint[]
+    for addr in resolved
+        if addr isa TCP.SocketAddrV4
+            v4 = addr::TCP.SocketAddrV4
+            push!(ips, TCP.SocketAddrV4(v4.ip, 0))
+        else
+            v6 = addr::TCP.SocketAddrV6
+            push!(ips, TCP.SocketAddrV6(v6.ip, 0; scope_id = Int(v6.scope_id)))
+        end
+    end
+    return ips
 end
+
+lookup_port(resolver::SingleflightResolver, network::AbstractString, service::AbstractString)::Int =
+    lookup_port((resolver::SingleflightResolver).parent, network, service)
 
 @inline function _wildcard_addrs(kind::Symbol, op::Symbol)::Vector{TCP.SocketEndpoint}
     if kind == :tcp && op == :listen
@@ -812,7 +967,7 @@ function resolve_tcp_addrs(
     ips = if isempty(host)
         _wildcard_addrs(kind, op)
     else
-        _resolve_host_ips(resolver, host)
+        _resolve_host_ips(resolver, network, host)
     end
     filtered = _apply_policy_and_network(ips, kind, policy)
     isempty(filtered) && _addr_error("no suitable address", host)
@@ -894,12 +1049,13 @@ function HostResolver(;
         resolver::AbstractResolver = DEFAULT_RESOLVER,
         policy::ResolverPolicy = ResolverPolicy(),
     )
-    return HostResolver{typeof(resolver)}(
+    wrapped = resolver isa SingleflightResolver ? resolver : SingleflightResolver(resolver)
+    return HostResolver{typeof(wrapped)}(
         Int64(timeout_ns),
         Int64(deadline_ns),
         local_addr,
         Int64(fallback_delay_ns),
-        resolver,
+        wrapped,
         policy,
     )
 end

--- a/src/6_tls.jl
+++ b/src/6_tls.jl
@@ -1122,13 +1122,24 @@ Throws `TLSError` on TLS failure. A write timeout becomes a permanent write erro
 the connection, matching Go's behavior that a timed-out TLS write leaves record framing
 state ambiguous for future writes.
 """
-function Base.write(conn::Conn, buf::Vector{UInt8})::Int
+function Base.write(conn::Conn, buf::AbstractVector{UInt8})::Int
     return _write!(conn, buf, length(buf))
 end
 
 function Base.write(conn::Conn, buf::Memory{UInt8}, nbytes::Integer)::Int
     return _write!(conn, buf, nbytes)
 end
+
+function _write_buffer(buf::AbstractVector{UInt8}, nbytes::Int)
+    if buf isa StridedVector{UInt8} && stride(buf, 1) == 1
+        return buf
+    end
+    copied = Vector{UInt8}(undef, nbytes)
+    copyto!(copied, 1, buf, 1, nbytes)
+    return copied
+end
+
+_write_buffer(buf::Memory{UInt8}, nbytes::Int) = buf
 
 function _write!(conn::Conn, buf, nbytes::Integer)::Int
     nbytes_int = Int(nbytes)
@@ -1141,9 +1152,10 @@ function _write!(conn::Conn, buf, nbytes::Integer)::Int
     try
         _ensure_open!(conn, "write")
         conn.write_permanent_error === nothing || throw(conn.write_permanent_error::TLSError)
+        write_buf = _write_buffer(buf, nbytes_int)
         total = 0
-        GC.@preserve buf begin
-            base_ptr = pointer(buf)
+        GC.@preserve write_buf begin
+            base_ptr = pointer(write_buf)
             while total < nbytes_int
                 chunk_len = nbytes_int - total
                 wrote = @ccall gc_safe = true _LIBSSL.SSL_write(

--- a/src/7_0_http_core.jl
+++ b/src/7_0_http_core.jl
@@ -116,6 +116,15 @@ end
     return Char(UInt32(c) + 0x20)
 end
 
+@inline function _to_ascii_lower(b::UInt8)::UInt8
+    0x41 <= b <= 0x5a || return b
+    return b + 0x20
+end
+
+@inline function _is_http_ows_byte(b::UInt8)::Bool
+    return b == 0x20 || b == 0x09
+end
+
 const _COMMON_CANONICAL_HEADER_KEYS = let headers = (
         "Accept",
         "Accept-Charset",
@@ -380,7 +389,7 @@ case-insensitively.
 function hasheader(headers::Headers, key::AbstractString, value::AbstractString)::Bool
     current = header(headers, key, nothing)
     current === nothing && return false
-    return _ascii_lowercase_string(current::String) == _ascii_lowercase_string(value)
+    return _ascii_equal_fold(current::String, value)
 end
 
 """
@@ -457,6 +466,14 @@ end
     return String(chars[1:(i - 1)])
 end
 
+@inline function _ascii_equal_fold(a::AbstractString, b::AbstractString)::Bool
+    ncodeunits(a) == ncodeunits(b) || return false
+    @inbounds for i in 1:ncodeunits(a)
+        _to_ascii_lower(codeunit(a, i)) == _to_ascii_lower(codeunit(b, i)) || return false
+    end
+    return true
+end
+
 @inline function _trim_http_ows(s::AbstractString)::String
     lo = firstindex(s)
     hi = lastindex(s)
@@ -480,6 +497,62 @@ end
     return String(SubString(s, lo, hi))
 end
 
+@inline function _trim_http_ows_bounds(bytes)::Tuple{Int, Int}
+    lo = firstindex(bytes)
+    hi = lastindex(bytes)
+    while lo <= hi && _is_http_ows_byte(bytes[lo])
+        lo += 1
+    end
+    while hi >= lo && _is_http_ows_byte(bytes[hi])
+        hi -= 1
+    end
+    return lo, hi
+end
+
+@inline function _ascii_equal_fold_slice(
+        haystack::Base.CodeUnits{UInt8, String},
+        lo::Int,
+        hi::Int,
+        needle::Base.CodeUnits{UInt8, String},
+        needle_lo::Int,
+        needle_hi::Int,
+    )::Bool
+    (hi - lo) == (needle_hi - needle_lo) || return false
+    j = needle_lo
+    @inbounds for i in lo:hi
+        _to_ascii_lower(haystack[i]) == _to_ascii_lower(needle[j]) || return false
+        j += 1
+    end
+    return true
+end
+
+function _header_value_contains_token(value::String, token::String)::Bool
+    token_bytes = codeunits(token)
+    token_lo, token_hi = _trim_http_ows_bounds(token_bytes)
+    token_hi >= token_lo || return false
+    value_bytes = codeunits(value)
+    i = firstindex(value_bytes)
+    last = lastindex(value_bytes)
+    while i <= last
+        while i <= last && _is_http_ows_byte(value_bytes[i])
+            i += 1
+        end
+        seg_lo = i
+        while i <= last && value_bytes[i] != UInt8(',')
+            i += 1
+        end
+        seg_hi = i - 1
+        while seg_hi >= seg_lo && _is_http_ows_byte(value_bytes[seg_hi])
+            seg_hi -= 1
+        end
+        if seg_hi >= seg_lo && _ascii_equal_fold_slice(value_bytes, seg_lo, seg_hi, token_bytes, token_lo, token_hi)
+            return true
+        end
+        i += 1
+    end
+    return false
+end
+
 """
     headercontains(headers, key, token) -> Bool
 
@@ -491,13 +564,10 @@ This is the helper used for semantics like `Connection: close` and
 tokens rather than one opaque string.
 """
 function headercontains(headers::Headers, key::AbstractString, token::AbstractString)::Bool
-    needle = _ascii_lowercase_string(_trim_http_ows(token))
-    isempty(needle) && return false
-    value = header(headers, key, nothing)
-    value === nothing && return false
-    for part in eachsplit(value::String, ',')
-        candidate = _ascii_lowercase_string(_trim_http_ows(part))
-        candidate == needle && return true
+    needle = token isa String ? (token::String) : String(token)
+    for (name, value) in headers
+        _ascii_equal_fold(name, key) || continue
+        return _header_value_contains_token(value, needle)
     end
     return false
 end

--- a/src/7_0_http_core.jl
+++ b/src/7_0_http_core.jl
@@ -881,6 +881,34 @@ function Request(
     )
 end
 
+@inline function _request_nocopy(
+        method::String,
+        target::String,
+        headers::Headers,
+        trailers::Headers,
+        body::B,
+        host::Union{Nothing, String},
+        content_length::Int64,
+        proto_major::UInt8,
+        proto_minor::UInt8,
+        close::Bool,
+        context::RequestContext,
+    )::Request{B} where {B <: AbstractBody}
+    return Request{B}(
+        method,
+        target,
+        headers,
+        trailers,
+        body,
+        host,
+        content_length,
+        proto_major,
+        proto_minor,
+        close,
+        context,
+    )
+end
+
 """
     Response(status_code; reason="", headers=Headers(), trailers=Headers(), body=EmptyBody(),
              content_length=-1, proto_major=1, proto_minor=1, close=false,
@@ -979,6 +1007,71 @@ function Response(
     )
 end
 
+@inline function _response_nocopy_public(
+        status_code::Int,
+        reason::String,
+        headers::Headers,
+        trailers::Headers,
+        body::B,
+        content_length::Int64,
+        proto_major::UInt8,
+        proto_minor::UInt8,
+        close::Bool,
+        request::Union{Nothing, Request},
+        request_url::Union{Nothing, String},
+        previous::Union{Nothing, Response},
+        redirect_count::Int,
+    )::Response where {B}
+    BodyT = _public_response_body_type(B)
+    return Response{BodyT}(
+        status_code,
+        reason,
+        headers,
+        trailers,
+        body,
+        content_length,
+        proto_major,
+        proto_minor,
+        close,
+        request,
+        request_url,
+        previous,
+        redirect_count,
+    )
+end
+
+@inline function _response_nocopy_exact(
+        status_code::Int,
+        reason::String,
+        headers::Headers,
+        trailers::Headers,
+        body::B,
+        content_length::Int64,
+        proto_major::UInt8,
+        proto_minor::UInt8,
+        close::Bool,
+        request::Union{Nothing, Request},
+        request_url::Union{Nothing, String},
+        previous::Union{Nothing, Response},
+        redirect_count::Int,
+    )::Response{B} where {B}
+    return Response{B}(
+        status_code,
+        reason,
+        headers,
+        trailers,
+        body,
+        content_length,
+        proto_major,
+        proto_minor,
+        close,
+        request,
+        request_url,
+        previous,
+        redirect_count,
+    )
+end
+
 header(message::Union{Request, Response}, key::AbstractString, default = "") =
     header(message.headers, key, default)
 
@@ -1034,7 +1127,7 @@ end
 
 function _streaming_response(incoming::_IncomingResponse)
     head = incoming.head
-    response = Response{typeof(incoming.rawbody)}(
+    return _response_nocopy_exact(
         head.status_code,
         head.reason,
         head.headers,
@@ -1049,6 +1142,4 @@ function _streaming_response(incoming::_IncomingResponse)
         head.previous,
         head.redirect_count,
     )
-    response.trailers = head.trailers
-    return response
 end

--- a/src/7_1_http1.jl
+++ b/src/7_1_http1.jl
@@ -721,7 +721,7 @@ end
         proto_minor::UInt8,
         close::Bool,
     )::Request{B} where {B <: AbstractBody}
-    return Request{B}(
+    return _request_nocopy(
         method,
         target,
         headers,
@@ -779,7 +779,7 @@ end
         close::Bool,
         request::Union{Nothing, Request},
     )::Response{B} where {B <: AbstractBody}
-    response = Response{B}(
+    return _response_nocopy_exact(
         status_code,
         reason,
         headers,
@@ -794,8 +794,6 @@ end
         nothing,
         0,
     )
-    response.trailers = trailers
-    return response
 end
 
 """

--- a/src/7_1_http1.jl
+++ b/src/7_1_http1.jl
@@ -465,8 +465,25 @@ function _write_exact_body_dispatch!(io::IO, body::EmptyBody, expected_len::Int6
     return _write_exact_body!(io, body, expected_len)
 end
 
+function _write_exact_bytes_body!(stream, body::BytesBody, expected_len::Int64)
+    expected_len < 0 && throw(ArgumentError("expected_len must be >= 0"))
+    expected_len == 0 && return nothing
+    available = (length(body.data) - body.next_index) + 1
+    available >= expected_len || throw(ProtocolError("body ended before expected Content-Length bytes were written"))
+    stop_index = body.next_index + Int(expected_len) - 1
+    chunk = if body.next_index == 1 && stop_index == length(body.data)
+        body.data
+    else
+        view(body.data, body.next_index:stop_index)
+    end
+    n = write(stream, chunk)
+    n == expected_len || throw(ProtocolError("transport short write"))
+    body.next_index = stop_index + 1
+    return nothing
+end
+
 function _write_exact_body_dispatch!(io::IO, body::BytesBody, expected_len::Int64)
-    return _write_exact_body!(io, body, expected_len)
+    return _write_exact_bytes_body!(io, body, expected_len)
 end
 
 function _write_exact_body_dispatch!(io::IO, body::CallbackBody, expected_len::Int64)
@@ -534,6 +551,49 @@ function _request_has_body(request::Request)::Bool
     return true
 end
 
+function _prepare_request_headers_for_write(
+        request::Request;
+        proxy_authorization::Union{Nothing, AbstractString} = nothing,
+    )::Tuple{Headers, Bool}
+    headers = copy(request.headers)
+    if proxy_authorization !== nothing && !hasheader(headers, "Proxy-Authorization")
+        setheader(headers, "Proxy-Authorization", String(proxy_authorization))
+    end
+    has_host = hasheader(headers, "Host")
+    if !has_host && request.host !== nothing
+        setheader(headers, "Host", request.host::String)
+    end
+    request_close = request.close || _should_close_connection(headers, request.proto_major, request.proto_minor)
+    request_close && setheader(headers, "Connection", "close")
+    use_chunked = headercontains(headers, "Transfer-Encoding", "chunked")
+    if !use_chunked
+        if request.content_length >= 0
+            setheader(headers, "Content-Length", string(request.content_length))
+        elseif _request_has_body(request)
+            use_chunked = true
+            setheader(headers, "Transfer-Encoding", "chunked")
+            removeheader(headers, "Content-Length")
+        else
+            setheader(headers, "Content-Length", "0")
+        end
+    end
+    use_chunked && _prepare_trailer_header!(headers, request.trailers)
+    return headers, use_chunked
+end
+
+function _write_request_head!(
+        io::IO,
+        request::Request;
+        wire_target::Union{Nothing, AbstractString} = nothing,
+        proxy_authorization::Union{Nothing, AbstractString} = nothing,
+    )::Bool
+    headers, use_chunked = _prepare_request_headers_for_write(request; proxy_authorization = proxy_authorization)
+    _write_start_line!(io, request; wire_target = wire_target)
+    _write_headers!(io, headers)
+    write(io, "\r\n")
+    return use_chunked
+end
+
 function _response_has_body(response::Response)::Bool
     _body_allowed_for_status(response.status_code) || return false
     response.body isa EmptyBody && return false
@@ -561,38 +621,13 @@ function write_request!(
         wire_target::Union{Nothing, AbstractString} = nothing,
         proxy_authorization::Union{Nothing, AbstractString} = nothing,
     ) where {B <: AbstractBody}
-    headers = copy(request.headers)
-    if proxy_authorization !== nothing && !hasheader(headers, "Proxy-Authorization")
-        setheader(headers, "Proxy-Authorization", String(proxy_authorization))
-    end
-    has_host = hasheader(headers, "Host")
-    if !has_host && request.host !== nothing
-        setheader(headers, "Host", request.host::String)
-    end
-    request_close = request.close || _should_close_connection(headers, request.proto_major, request.proto_minor)
-    request_close && setheader(headers, "Connection", "close")
-    use_chunked = headercontains(headers, "Transfer-Encoding", "chunked")
-    if !use_chunked
-        if request.content_length >= 0
-            setheader(headers, "Content-Length", string(request.content_length))
-        elseif _request_has_body(request)
-            use_chunked = true
-            setheader(headers, "Transfer-Encoding", "chunked")
-            removeheader(headers, "Content-Length")
-        else
-            setheader(headers, "Content-Length", "0")
-        end
-    end
-    use_chunked && _prepare_trailer_header!(headers, request.trailers)
-    _write_start_line!(io, request; wire_target = wire_target)
-    _write_headers!(io, headers)
-    write(io, "\r\n")
+    use_chunked = _write_request_head!(io, request; wire_target = wire_target, proxy_authorization = proxy_authorization)
     if use_chunked
         _write_chunked_body!(io, request.body, request.trailers)
         return nothing
     end
     request.content_length < 0 && return nothing
-    _write_exact_body!(io, request.body, request.content_length)
+    _write_exact_body_dispatch!(io, request.body, request.content_length)
     return nothing
 end
 

--- a/src/7_1_http1.jl
+++ b/src/7_1_http1.jl
@@ -289,11 +289,8 @@ function _read_next_chunk!(body::ChunkedBody)
         # Terminal chunk: trailing header block is parsed as trailers.
         parsed_trailers = _read_headers(body.io, body.max_line_bytes, body.max_header_bytes)
         empty!(body.trailers)
-        for key in header_keys(parsed_trailers)
-            values = headers(parsed_trailers, key)
-            for value in values
-                appendheader(body.trailers, key, value)
-            end
+        for (key, value) in parsed_trailers
+            appendheader(body.trailers, key, value)
         end
         body.done = true
         body.chunk_remaining = 0
@@ -420,11 +417,8 @@ function _write_status_line!(io::IO, response::Response)
 end
 
 function _write_headers!(io::IO, hdrs::Headers)
-    for key in header_keys(hdrs)
-        values = headers(hdrs, key)
-        for value in values
-            print(io, key, ": ", value, "\r\n")
-        end
+    for (key, value) in hdrs
+        print(io, key, ": ", value, "\r\n")
     end
     return nothing
 end

--- a/src/7_6_http_client.jl
+++ b/src/7_6_http_client.jl
@@ -1787,33 +1787,122 @@ function _pump_response_body!(stream::Base.BufferStream, body::AbstractBody)::No
     return nothing
 end
 
-function _response_body_reader(incoming::_IncomingResponse; decompress::Union{Nothing, Bool})::Tuple{IO, Task}
-    raw_stream = Base.BufferStream()
-    reader = if _should_decompress_response(incoming.head.headers, decompress)
-        CodecZlib.GzipDecompressorStream(raw_stream)
-    else
-        raw_stream
+mutable struct _BodyIO{B <: AbstractBody} <: IO
+    body::B
+    buf::Vector{UInt8}
+    next_index::Int
+    filled::Int
+    @atomic saw_eof::Bool
+    @atomic closed::Bool
+end
+
+function _BodyIO(body::B; buffer_bytes::Integer = 8192) where {B <: AbstractBody}
+    n = Int(buffer_bytes)
+    n > 0 || throw(ArgumentError("buffer_bytes must be > 0"))
+    return _BodyIO{B}(body, Vector{UInt8}(undef, n), 1, 0, false, false)
+end
+
+@inline function _buffered_bytes(io::_BodyIO)::Int
+    return max(io.filled - io.next_index + 1, 0)
+end
+
+function _fill_bodyio!(io::_BodyIO)::Int
+    (@atomic :acquire io.closed) && return 0
+    (@atomic :acquire io.saw_eof) && return 0
+    io.next_index = 1
+    n = body_read!(io.body, io.buf)
+    io.filled = n
+    if n == 0
+        @atomic :release io.saw_eof = true
     end
-    producer = errormonitor(Threads.@spawn _pump_response_body!(raw_stream, incoming.rawbody))
-    return reader, producer
+    return n
+end
+
+function Base.isopen(io::_BodyIO)::Bool
+    return !(@atomic :acquire io.closed)
+end
+
+function Base.bytesavailable(io::_BodyIO)::Int
+    return _buffered_bytes(io)
+end
+
+function Base.eof(io::_BodyIO)::Bool
+    _buffered_bytes(io) > 0 && return false
+    (@atomic :acquire io.closed) && return true
+    (@atomic :acquire io.saw_eof) && return true
+    return _fill_bodyio!(io) == 0
+end
+
+function Base.read(io::_BodyIO, ::Type{UInt8})::UInt8
+    eof(io) && throw(EOFError())
+    b = io.buf[io.next_index]
+    io.next_index += 1
+    return b
+end
+
+function Base.readbytes!(io::_BodyIO, dst::Vector{UInt8}, nb::Integer = length(dst))::Int
+    target = Int(nb)
+    target < 0 && throw(ArgumentError("nb must be >= 0"))
+    target = min(target, length(dst))
+    total = 0
+    while total < target
+        available = _buffered_bytes(io)
+        if available == 0
+            _fill_bodyio!(io) == 0 && break
+            available = _buffered_bytes(io)
+        end
+        chunk = min(available, target - total)
+        copyto!(dst, total + 1, io.buf, io.next_index, chunk)
+        io.next_index += chunk
+        total += chunk
+    end
+    return total
+end
+
+function Base.unsafe_read(io::_BodyIO, ptr::Ptr{UInt8}, nbytes::UInt)
+    remaining = Int(nbytes)
+    offset = 0
+    buf = io.buf
+    while remaining > 0
+        available = _buffered_bytes(io)
+        if available == 0
+            _fill_bodyio!(io) == 0 && throw(EOFError())
+            available = _buffered_bytes(io)
+        end
+        chunk = min(available, remaining)
+        GC.@preserve buf begin
+            unsafe_copyto!(ptr + offset, pointer(buf, io.next_index), chunk)
+        end
+        io.next_index += chunk
+        offset += chunk
+        remaining -= chunk
+    end
+    return nothing
+end
+
+function Base.close(io::_BodyIO)
+    if !(@atomic :acquire io.closed)
+        @atomic :release io.closed = true
+        @atomic :release io.saw_eof = true
+        io.next_index = 1
+        io.filled = 0
+        body_close!(io.body)
+    end
+    return nothing
+end
+
+function _response_body_reader(incoming::_IncomingResponse; decompress::Union{Nothing, Bool})::Tuple{IO, Union{Nothing, Task}}
+    raw_stream = _BodyIO(incoming.rawbody)
+    if _should_decompress_response(incoming.head.headers, decompress)
+        return CodecZlib.GzipDecompressorStream(raw_stream), nothing
+    end
+    return raw_stream, nothing
 end
 
 function _with_response_reader(f::F, incoming::_IncomingResponse; decompress::Union{Nothing, Bool}) where {F}
-    reader, producer = _response_body_reader(incoming; decompress = decompress)
+    reader, _ = _response_body_reader(incoming; decompress = decompress)
     try
-        result = f(reader)
-        wait(producer)
-        return result
-    catch
-        try
-            close(reader)
-        catch
-        end
-        try
-            wait(producer)
-        catch
-        end
-        rethrow()
+        return f(reader)
     finally
         try
             close(reader)

--- a/src/7_6_http_client.jl
+++ b/src/7_6_http_client.jl
@@ -1039,34 +1039,34 @@ function _clone_body(body::AbstractBody)::AbstractBody
 end
 
 function _copy_request(request::Request)
-    return Request(
+    return _request_nocopy(
         request.method,
-        request.target;
-        headers = request.headers,
-        trailers = request.trailers,
-        body = _clone_body(request.body),
-        host = request.host,
-        content_length = request.content_length,
-        proto_major = request.proto_major,
-        proto_minor = request.proto_minor,
-        close = request.close,
-        context = request.context,
+        request.target,
+        copy(request.headers),
+        copy(request.trailers),
+        _clone_body(request.body),
+        request.host,
+        request.content_length,
+        request.proto_major,
+        request.proto_minor,
+        request.close,
+        request.context,
     )
 end
 
 function _copy_request_shallow_body(request::Request)
-    return Request(
+    return _request_nocopy(
         request.method,
-        request.target;
-        headers = request.headers,
-        trailers = request.trailers,
-        body = request.body,
-        host = request.host,
-        content_length = request.content_length,
-        proto_major = request.proto_major,
-        proto_minor = request.proto_minor,
-        close = request.close,
-        context = request.context,
+        request.target,
+        copy(request.headers),
+        copy(request.trailers),
+        request.body,
+        request.host,
+        request.content_length,
+        request.proto_major,
+        request.proto_minor,
+        request.close,
+        request.context,
     )
 end
 
@@ -1314,17 +1314,18 @@ function _prepare_request_for_redirect(request::Request, status_code::Int, new_t
         end
         copied
     else
-        Request(
+        _request_nocopy(
             method,
-            new_target;
-            headers = policy.forward_headers ? request.headers : Headers(),
-            host = request.host,
-            body = EmptyBody(),
-            content_length = 0,
-            proto_major = request.proto_major,
-            proto_minor = request.proto_minor,
-            close = request.close,
-            context = request.context,
+            new_target,
+            policy.forward_headers ? copy(request.headers) : Headers(),
+            Headers(),
+            EmptyBody(),
+            request.host,
+            Int64(0),
+            request.proto_major,
+            request.proto_minor,
+            request.close,
+            request.context,
         )
     end
     removeheader(redirected.headers, "Host")
@@ -2433,20 +2434,20 @@ end
 
 function _retry_policy_response(incoming::_IncomingResponse, fallback_request::Request)::Response
     head = incoming.head
-    return Response(
-        head.status_code;
-        reason = head.reason,
-        headers = head.headers,
-        trailers = head.trailers,
-        body = nothing,
-        content_length = head.content_length,
-        proto_major = head.proto_major,
-        proto_minor = head.proto_minor,
-        close = head.close,
-        request = head.request === nothing ? fallback_request : (head.request::Request),
-        request_url = head.request_url,
-        previous = head.previous,
-        redirect_count = head.redirect_count,
+    return _response_nocopy_public(
+        head.status_code,
+        head.reason,
+        head.headers,
+        head.trailers,
+        nothing,
+        head.content_length,
+        head.proto_major,
+        head.proto_minor,
+        head.close,
+        head.request === nothing ? fallback_request : (head.request::Request),
+        head.request_url,
+        head.previous,
+        head.redirect_count,
     )
 end
 
@@ -2633,20 +2634,20 @@ function _finalize_request_response(
         resolved_request::Request,
         request_url::String,
     )::Response
-    return Response(
-        incoming.head.status_code;
-        reason = incoming.head.reason,
-        headers = incoming.head.headers,
-        trailers = incoming.head.trailers,
-        body = body,
-        content_length = body_length,
-        proto_major = incoming.head.proto_major,
-        proto_minor = incoming.head.proto_minor,
-        close = incoming.head.close,
-        request = resolved_request,
-        request_url = incoming.head.request_url === nothing ? request_url : (incoming.head.request_url::String),
-        previous = incoming.head.previous,
-        redirect_count = incoming.head.redirect_count,
+    return _response_nocopy_public(
+        incoming.head.status_code,
+        incoming.head.reason,
+        incoming.head.headers,
+        incoming.head.trailers,
+        body,
+        body_length,
+        incoming.head.proto_major,
+        incoming.head.proto_minor,
+        incoming.head.close,
+        resolved_request,
+        incoming.head.request_url === nothing ? request_url : (incoming.head.request_url::String),
+        incoming.head.previous,
+        incoming.head.redirect_count,
     )
 end
 

--- a/src/7_6_http_client.jl
+++ b/src/7_6_http_client.jl
@@ -236,9 +236,29 @@ function _effective_tls_config(transport::Transport, address::String, server_nam
 end
 
 function _write_request_bytes!(stream, request_io::IOBuffer)
-    request_bytes = request_io.size
-    n = write(stream, request_io.data, request_bytes)
+    data = take!(request_io)
+    request_bytes = length(data)
+    request_bytes == 0 && return nothing
+    n = write(stream, data)
     n == request_bytes || throw(ProtocolError("transport short write"))
+    return nothing
+end
+
+function _write_request_streaming!(
+        request_io::IOBuffer,
+        stream,
+        request::Request;
+        wire_target::Union{Nothing, AbstractString} = nothing,
+        proxy_authorization::Union{Nothing, AbstractString} = nothing,
+    )
+    if request.content_length >= 0 && request.body isa BytesBody && !headercontains(request.headers, "Transfer-Encoding", "chunked")
+        _write_request_head!(request_io, request; wire_target = wire_target, proxy_authorization = proxy_authorization)
+        _write_request_bytes!(stream, request_io)
+        _write_exact_bytes_body!(stream, request.body::BytesBody, request.content_length)
+        return nothing
+    end
+    write_request!(request_io, request; wire_target = wire_target, proxy_authorization = proxy_authorization)
+    _write_request_bytes!(stream, request_io)
     return nothing
 end
 
@@ -633,18 +653,17 @@ function _roundtrip_incoming!(
         try
             _apply_conn_deadline!(conn, request_deadline)
             request_io = _reset_request_buffer!(conn)
+            stream = _conn_stream(conn)
             try
                 wire_target = plan.mode == _ProxyPlanMode.HTTP_FORWARD ? _request_url(false, String(address), current_request.target) : nothing
                 proxy_auth = plan.mode == _ProxyPlanMode.HTTP_FORWARD && plan.proxy !== nothing ? (plan.proxy::_ProxyTarget).authorization : nothing
-                write_request!(request_io, current_request; wire_target = wire_target, proxy_authorization = proxy_auth)
+                _write_request_streaming!(request_io, stream, current_request; wire_target = wire_target, proxy_authorization = proxy_auth)
             finally
                 try
                     body_close!(current_request.body)
                 catch
                 end
             end
-            stream = _conn_stream(conn)
-            _write_request_bytes!(stream, request_io)
             reader = conn.reader
             raw_response = _read_incoming_response(reader, current_request)
             # HTTP/1 informational responses are consumed internally so callers
@@ -1355,7 +1374,7 @@ function _do_incoming!(
     current_secure = secure
     explicit_server_name = server_name !== nothing
     current_server_name = explicit_server_name ? String(server_name::AbstractString) : _host_for_sni(current_address)
-    current_request = _copy_request_for_send(request; allow_nonreplayable = true)
+    current_request = _copy_request_shallow_body(request)
     controller = retry_controller
     previous_response = nothing
     retry_attempt = 1
@@ -1657,6 +1676,25 @@ function _read_all_response_bytes(io::IO)::Vector{UInt8}
     end
 end
 
+const _MAX_EAGER_RESPONSE_PREALLOC = Int64(1 << 20)
+
+function _read_all_response_bytes(body::AbstractBody; content_length_hint::Int64 = Int64(-1))::Vector{UInt8}
+    if 0 <= content_length_hint <= _MAX_EAGER_RESPONSE_PREALLOC
+        out = Vector{UInt8}(undef, Int(content_length_hint))
+        n = _copy_response_bytes!(out, body)
+        n == content_length_hint || resize!(out, Int(n))
+        return out
+    end
+    out = UInt8[]
+    content_length_hint > 0 && sizehint!(out, Int(min(content_length_hint, _MAX_EAGER_RESPONSE_PREALLOC)))
+    buf = Vector{UInt8}(undef, 8192)
+    while true
+        n = body_read!(body, buf)
+        n == 0 && return out
+        append!(out, @view(buf[1:n]))
+    end
+end
+
 function _copy_response_bytes!(dest::IO, io::IO)::Int64
     buf = Vector{UInt8}(undef, 8192)
     total = Int64(0)
@@ -1674,6 +1712,33 @@ function _copy_response_bytes!(dest::AbstractVector{UInt8}, io::IO)::Int64
     capacity = length(dest)
     while true
         n = readbytes!(io, buf, length(buf))
+        n == 0 && break
+        needed = total + n
+        needed <= capacity || throw(ArgumentError("Unable to grow response stream IOBuffer $(capacity) large enough for response body size: $(needed)"))
+        copyto!(dest, total + 1, buf, 1, n)
+        total = needed
+    end
+    dest isa Vector{UInt8} && resize!(dest::Vector{UInt8}, total)
+    return Int64(total)
+end
+
+function _copy_response_bytes!(dest::IO, body::AbstractBody)::Int64
+    buf = Vector{UInt8}(undef, 8192)
+    total = Int64(0)
+    while true
+        n = body_read!(body, buf)
+        n == 0 && return total
+        total += n
+        write(dest, view(buf, 1:n))
+    end
+end
+
+function _copy_response_bytes!(dest::AbstractVector{UInt8}, body::AbstractBody)::Int64
+    buf = Vector{UInt8}(undef, 8192)
+    total = 0
+    capacity = length(dest)
+    while true
+        n = body_read!(body, buf)
         n == 0 && break
         needed = total + n
         needed <= capacity || throw(ArgumentError("Unable to grow response stream IOBuffer $(capacity) large enough for response body size: $(needed)"))
@@ -1772,6 +1837,29 @@ function _consume_incoming_response!(
         sink;
         decompress::Union{Nothing, Bool},
     )::Tuple{Any, Int64}
+    if !_should_decompress_response(incoming.head.headers, decompress)
+        try
+            if sink === nothing
+                body = _read_all_response_bytes(incoming.rawbody; content_length_hint = incoming.head.content_length)
+                return body, Int64(length(body))
+            end
+            if sink isa IO
+                n = _copy_response_bytes!(sink::IO, incoming.rawbody)
+                return nothing, n
+            end
+            n = _copy_response_bytes!(sink::AbstractVector{UInt8}, incoming.rawbody)
+            if sink isa Vector{UInt8}
+                return sink::Vector{UInt8}, n
+            end
+            return view(sink::AbstractVector{UInt8}, 1:Int(n)), n
+        catch
+            try
+                body_close!(incoming.rawbody)
+            catch
+            end
+            rethrow()
+        end
+    end
     return _with_response_reader(incoming; decompress = decompress) do reader
         if sink === nothing
             body = _read_all_response_bytes(reader)

--- a/src/7_6_http_client.jl
+++ b/src/7_6_http_client.jl
@@ -96,6 +96,24 @@ mutable struct ClientConn
     last_used_ns::Int64
 end
 
+const _CONN_WAITER_WAITING = UInt8(0)
+const _CONN_WAITER_CONN = UInt8(1)
+const _CONN_WAITER_DIAL = UInt8(2)
+const _CONN_WAITER_ERROR = UInt8(3)
+const _CONN_WAITER_CANCELED = UInt8(4)
+
+mutable struct _ConnWaiter
+    key::String
+    signal::Channel{Nothing}
+    conn::Union{Nothing, ClientConn}
+    err::Union{Nothing, Exception}
+    @atomic state::UInt8
+end
+
+function _ConnWaiter(key::String)
+    return _ConnWaiter(key, Channel{Nothing}(1), nothing, nothing, _CONN_WAITER_WAITING)
+end
+
 """
     Transport(; ...)
 
@@ -104,6 +122,11 @@ Connection-pooling transport for HTTP/1 requests.
 This is the closest analogue to Go's `http.Transport` in the current codebase.
 It owns dial/TLS policy and decides when an idle connection can be reused versus
 closed.
+
+`max_conns_per_host = 0` leaves per-host concurrency unlimited. Positive values
+bound the total live HTTP/1 connections (idle, in-flight, and dialing) for one
+pool key and cause additional acquires to wait for direct handoff or a freed
+dial slot.
 """
 mutable struct Transport
     host_resolver::HostResolvers.HostResolver
@@ -112,9 +135,12 @@ mutable struct Transport
     retry_bucket::Union{Nothing, RetryBucket}
     max_idle_per_host::Int
     max_idle_total::Int
+    max_conns_per_host::Int
     idle_timeout_ns::Int64
     lock::ReentrantLock
     idle::Dict{String, Vector{ClientConn}}
+    waiters::Dict{String, Vector{_ConnWaiter}}
+    conns_per_host::Dict{String, Int}
     @atomic idle_total::Int
     @atomic closed::Bool
 end
@@ -146,10 +172,12 @@ function Transport(;
         retry_bucket::Union{Nothing, RetryBucket} = RetryBucket(),
         max_idle_per_host::Integer = 2,
         max_idle_total::Integer = 64,
+        max_conns_per_host::Integer = 0,
         idle_timeout_ns::Integer = Int64(90_000_000_000),
     )
     max_idle_per_host > 0 || throw(ArgumentError("max_idle_per_host must be > 0"))
     max_idle_total > 0 || throw(ArgumentError("max_idle_total must be > 0"))
+    max_conns_per_host >= 0 || throw(ArgumentError("max_conns_per_host must be >= 0"))
     idle_timeout_ns >= 0 || throw(ArgumentError("idle_timeout_ns must be >= 0"))
     return Transport(
         host_resolver,
@@ -158,9 +186,12 @@ function Transport(;
         retry_bucket,
         Int(max_idle_per_host),
         Int(max_idle_total),
+        Int(max_conns_per_host),
         Int64(idle_timeout_ns),
         ReentrantLock(),
         Dict{String, Vector{ClientConn}}(),
+        Dict{String, Vector{_ConnWaiter}}(),
+        Dict{String, Int}(),
         0,
         false,
     )
@@ -183,9 +214,9 @@ function _conn_stream(conn::ClientConn)
     return conn.tcp::TCP.Conn
 end
 
-function _close_conn!(conn::ClientConn)
+function _close_conn!(conn::ClientConn)::Bool
     if _conn_closed(conn)
-        return nothing
+        return false
     end
     @atomic :release conn.closed = true
     if conn.secure
@@ -203,6 +234,167 @@ function _close_conn!(conn::ClientConn)
             end
         end
     end
+    return true
+end
+
+@inline function _notify_waiter!(waiter::_ConnWaiter)
+    isready(waiter.signal) || put!(waiter.signal, nothing)
+    return nothing
+end
+
+@inline function _waiter_waiting(waiter::_ConnWaiter)::Bool
+    return (@atomic :acquire waiter.state) == _CONN_WAITER_WAITING
+end
+
+function _enqueue_waiter_locked!(transport::Transport, waiter::_ConnWaiter)
+    queue = get(() -> _ConnWaiter[], transport.waiters, waiter.key)
+    push!(queue, waiter)
+    transport.waiters[waiter.key] = queue
+    return waiter
+end
+
+function _remove_waiter_locked!(transport::Transport, key::String, waiter::_ConnWaiter)
+    queue = get(() -> nothing, transport.waiters, key)
+    queue === nothing && return nothing
+    idx = findfirst(isequal(waiter), queue::Vector{_ConnWaiter})
+    idx === nothing || deleteat!(queue::Vector{_ConnWaiter}, idx)
+    isempty(queue::Vector{_ConnWaiter}) && delete!(transport.waiters, key)
+    return nothing
+end
+
+function _next_waiter_locked!(transport::Transport, key::String)::Union{Nothing, _ConnWaiter}
+    queue = get(() -> nothing, transport.waiters, key)
+    queue === nothing && return nothing
+    while !isempty(queue::Vector{_ConnWaiter})
+        waiter = popfirst!(queue::Vector{_ConnWaiter})
+        if _waiter_waiting(waiter)
+            isempty(queue::Vector{_ConnWaiter}) && delete!(transport.waiters, key)
+            return waiter
+        end
+    end
+    delete!(transport.waiters, key)
+    return nothing
+end
+
+@inline function _conn_slots_locked(transport::Transport, key::String)::Int
+    return get(() -> 0, transport.conns_per_host, key)
+end
+
+function _reserve_conn_slot_locked!(transport::Transport, key::String)::Bool
+    current = _conn_slots_locked(transport, key)
+    max_per_host = transport.max_conns_per_host
+    if max_per_host != 0 && current >= max_per_host
+        return false
+    end
+    transport.conns_per_host[key] = current + 1
+    return true
+end
+
+function _decrement_conn_slot_locked!(transport::Transport, key::String)
+    current = _conn_slots_locked(transport, key)
+    current <= 1 ? delete!(transport.conns_per_host, key) : (transport.conns_per_host[key] = current - 1)
+    return nothing
+end
+
+function _promote_waiter_to_dial_locked!(transport::Transport, key::String)::Union{Nothing, _ConnWaiter}
+    transport.max_conns_per_host == 0 && return nothing
+    _reserve_conn_slot_locked!(transport, key) || return nothing
+    waiter = _next_waiter_locked!(transport, key)
+    if waiter === nothing
+        _decrement_conn_slot_locked!(transport, key)
+        return nothing
+    end
+    waiter.conn = nothing
+    waiter.err = nothing
+    @atomic :release waiter.state = _CONN_WAITER_DIAL
+    return waiter
+end
+
+function _release_conn_slot_locked!(transport::Transport, key::String)::Union{Nothing, _ConnWaiter}
+    _decrement_conn_slot_locked!(transport, key)
+    _transport_closed(transport) && return nothing
+    return _promote_waiter_to_dial_locked!(transport, key)
+end
+
+function _close_owned_conn!(transport::Transport, conn::ClientConn)
+    _close_conn!(conn) || return nothing
+    waiter = nothing
+    lock(transport.lock)
+    try
+        waiter = _release_conn_slot_locked!(transport, conn.key)
+    finally
+        unlock(transport.lock)
+    end
+    waiter === nothing || _notify_waiter!(waiter)
+    return nothing
+end
+
+function _close_owned_conns!(transport::Transport, conns::Vector{ClientConn})
+    for conn in conns
+        _close_owned_conn!(transport, conn)
+    end
+    return nothing
+end
+
+function _deliver_waiter_conn_locked!(waiter::_ConnWaiter, conn::ClientConn)::Bool
+    _waiter_waiting(waiter) || return false
+    waiter.conn = conn
+    waiter.err = nothing
+    @atomic :release waiter.state = _CONN_WAITER_CONN
+    return true
+end
+
+function _deliver_waiter_error_locked!(waiter::_ConnWaiter, err::Exception)::Bool
+    _waiter_waiting(waiter) || return false
+    waiter.conn = nothing
+    waiter.err = err
+    @atomic :release waiter.state = _CONN_WAITER_ERROR
+    return true
+end
+
+function _wait_for_conn!(transport::Transport, waiter::_ConnWaiter, deadline_ns::Int64)
+    while true
+        state = @atomic :acquire waiter.state
+        if state == _CONN_WAITER_CONN
+            return waiter.conn::ClientConn
+        elseif state == _CONN_WAITER_DIAL
+            return :dial
+        elseif state == _CONN_WAITER_ERROR
+            throw(waiter.err::Exception)
+        elseif state == _CONN_WAITER_CANCELED
+            throw(IOPoll.DeadlineExceededError())
+        end
+        if deadline_ns == 0
+            take!(waiter.signal)
+            continue
+        end
+        now_ns = Int64(time_ns())
+        if now_ns >= deadline_ns
+            lock(transport.lock)
+            try
+                if _waiter_waiting(waiter)
+                    _remove_waiter_locked!(transport, waiter.key, waiter)
+                    @atomic :release waiter.state = _CONN_WAITER_CANCELED
+                    throw(IOPoll.DeadlineExceededError())
+                end
+            finally
+                unlock(transport.lock)
+            end
+            continue
+        end
+        timeout_s = min((deadline_ns - now_ns) / 1.0e9, 0.05)
+        timedwait(() -> isready(waiter.signal), timeout_s; pollint = 0.001)
+        isready(waiter.signal) && take!(waiter.signal)
+    end
+end
+
+function _prepare_conn_for_reuse!(conn::ClientConn)
+    if conn.secure
+        conn.tls === nothing || TLS.set_deadline!(conn.tls::TLS.Conn, Int64(0))
+    else
+        conn.tcp === nothing || TCP.set_deadline!(conn.tcp::TCP.Conn, Int64(0))
+    end
+    conn.last_used_ns = time_ns()
     return nothing
 end
 
@@ -314,15 +506,16 @@ function _new_conn!(
     return ClientConn(plan.pool_key, plan.first_hop_address, false, tcp, nothing, _ConnReader(tcp), IOBuffer(), false, false, time_ns())
 end
 
-function _evict_expired_idle_locked!(transport::Transport, key::String, now_ns::Int64)
+function _evict_expired_idle_locked!(transport::Transport, key::String, now_ns::Int64)::Vector{ClientConn}
     idle_list = get(() -> nothing, transport.idle, key)
-    idle_list === nothing && return nothing
+    idle_list === nothing && return ClientConn[]
     kept = ClientConn[]
+    stale = ClientConn[]
     for conn in idle_list::Vector{ClientConn}
         expired = transport.idle_timeout_ns > 0 && (now_ns - conn.last_used_ns) > transport.idle_timeout_ns
         if _conn_closed(conn) || expired
-            _close_conn!(conn)
             @atomic :acquire_release transport.idle_total -= 1
+            push!(stale, conn)
             continue
         end
         push!(kept, conn)
@@ -332,7 +525,7 @@ function _evict_expired_idle_locked!(transport::Transport, key::String, now_ns::
     else
         transport.idle[key] = kept
     end
-    return nothing
+    return stale
 end
 
 function _acquire_conn!(
@@ -344,55 +537,118 @@ function _acquire_conn!(
         deadline_ns::Int64 = Int64(0),
     )::ClientConn
     _transport_closed(transport) && throw(ProtocolError("transport is closed"))
-    lock(transport.lock)
-    try
-        now_ns = Int64(time_ns())
-        _evict_expired_idle_locked!(transport, plan.pool_key, now_ns)
-        idle_list = get(() -> nothing, transport.idle, plan.pool_key)
-        if idle_list !== nothing && !isempty(idle_list::Vector{ClientConn})
-            conn = pop!(idle_list::Vector{ClientConn})
-            @atomic :acquire_release transport.idle_total -= 1
-            isempty(idle_list::Vector{ClientConn}) && delete!(transport.idle, plan.pool_key)
-            if !_conn_closed(conn)
-                conn.reused = true
-                return conn
+    waiter = nothing
+    while true
+        stale = ClientConn[]
+        conn = nothing
+        should_dial = false
+        lock(transport.lock)
+        try
+            _transport_closed(transport) && throw(ProtocolError("transport is closed"))
+            now_ns = Int64(time_ns())
+            append!(stale, _evict_expired_idle_locked!(transport, plan.pool_key, now_ns))
+            idle_list = get(() -> nothing, transport.idle, plan.pool_key)
+            while idle_list !== nothing && !isempty(idle_list::Vector{ClientConn})
+                conn = pop!(idle_list::Vector{ClientConn})
+                @atomic :acquire_release transport.idle_total -= 1
+                isempty(idle_list::Vector{ClientConn}) && delete!(transport.idle, plan.pool_key)
+                if !_conn_closed(conn::ClientConn)
+                    (conn::ClientConn).reused = true
+                    break
+                end
+                push!(stale, conn::ClientConn)
+                conn = nothing
+                idle_list = get(() -> nothing, transport.idle, plan.pool_key)
             end
-            _close_conn!(conn)
+            if conn === nothing && isempty(stale)
+                if _reserve_conn_slot_locked!(transport, plan.pool_key)
+                    should_dial = true
+                else
+                    waiter = _ConnWaiter(plan.pool_key)
+                    _enqueue_waiter_locked!(transport, waiter)
+                end
+            end
+        finally
+            unlock(transport.lock)
         end
-    finally
-        unlock(transport.lock)
+        isempty(stale) || (_close_owned_conns!(transport, stale); continue)
+        if conn !== nothing
+            return conn::ClientConn
+        end
+        if should_dial
+            try
+                return _new_conn!(transport, plan, address; secure = secure, server_name = server_name, deadline_ns = deadline_ns)
+            catch err
+                waiter_to_notify = nothing
+                lock(transport.lock)
+                try
+                    waiter_to_notify = _release_conn_slot_locked!(transport, plan.pool_key)
+                finally
+                    unlock(transport.lock)
+                end
+                waiter_to_notify === nothing || _notify_waiter!(waiter_to_notify)
+                rethrow(err)
+            end
+        end
+        result = _wait_for_conn!(transport, waiter::_ConnWaiter, deadline_ns)
+        if result === :dial
+            try
+                return _new_conn!(transport, plan, address; secure = secure, server_name = server_name, deadline_ns = deadline_ns)
+            catch err
+                waiter_to_notify = nothing
+                lock(transport.lock)
+                try
+                    waiter_to_notify = _release_conn_slot_locked!(transport, plan.pool_key)
+                finally
+                    unlock(transport.lock)
+                end
+                waiter_to_notify === nothing || _notify_waiter!(waiter_to_notify)
+                rethrow(err)
+            end
+        end
+        conn = result::ClientConn
+        conn.reused = true
+        return conn
     end
-    return _new_conn!(transport, plan, address; secure = secure, server_name = server_name, deadline_ns = deadline_ns)
 end
 
 function _put_idle_conn!(transport::Transport, conn::ClientConn)
     if _transport_closed(transport) || _conn_closed(conn)
-        _close_conn!(conn)
+        _close_owned_conn!(transport, conn)
         return nothing
     end
+    try
+        _prepare_conn_for_reuse!(conn)
+    catch
+        _close_owned_conn!(transport, conn)
+        return nothing
+    end
+    waiter_to_notify = nothing
+    should_close = false
     lock(transport.lock)
     try
         if _transport_closed(transport)
-            _close_conn!(conn)
-            return nothing
-        end
-        idle_list = get(() -> ClientConn[], transport.idle, conn.key)
-        if length(idle_list) >= transport.max_idle_per_host || (@atomic :acquire transport.idle_total) >= transport.max_idle_total
-            _close_conn!(conn)
-            return nothing
-        end
-        if conn.secure
-            conn.tls === nothing || TLS.set_deadline!(conn.tls::TLS.Conn, Int64(0))
+            should_close = true
         else
-            conn.tcp === nothing || TCP.set_deadline!(conn.tcp::TCP.Conn, Int64(0))
+            waiter = _next_waiter_locked!(transport, conn.key)
+            if waiter !== nothing && _deliver_waiter_conn_locked!(waiter, conn)
+                waiter_to_notify = waiter
+            else
+                idle_list = get(() -> ClientConn[], transport.idle, conn.key)
+                if length(idle_list) >= transport.max_idle_per_host || (@atomic :acquire transport.idle_total) >= transport.max_idle_total
+                    should_close = true
+                else
+                    push!(idle_list, conn)
+                    transport.idle[conn.key] = idle_list
+                    @atomic :acquire_release transport.idle_total += 1
+                end
+            end
         end
-        conn.last_used_ns = time_ns()
-        push!(idle_list, conn)
-        transport.idle[conn.key] = idle_list
-        @atomic :acquire_release transport.idle_total += 1
     finally
         unlock(transport.lock)
     end
+    waiter_to_notify === nothing || (_notify_waiter!(waiter_to_notify); return nothing)
+    should_close && _close_owned_conn!(transport, conn)
     return nothing
 end
 
@@ -403,11 +659,12 @@ Close and discard all currently idle pooled connections. Active in-flight
 requests are unaffected. Returns `nothing`.
 """
 function close_idle_connections!(transport::Transport)
+    to_close = ClientConn[]
     lock(transport.lock)
     try
         for (_, idle_list) in transport.idle
             for conn in idle_list
-                _close_conn!(conn)
+                push!(to_close, conn)
             end
         end
         empty!(transport.idle)
@@ -415,6 +672,7 @@ function close_idle_connections!(transport::Transport)
     finally
         unlock(transport.lock)
     end
+    _close_owned_conns!(transport, to_close)
     return nothing
 end
 
@@ -426,8 +684,29 @@ requests are allowed to finish on the connections they already hold.
 """
 function Base.close(transport::Transport)
     _transport_closed(transport) && return nothing
-    @atomic :release transport.closed = true
-    close_idle_connections!(transport)
+    to_close = ClientConn[]
+    waiters_to_notify = _ConnWaiter[]
+    err = ProtocolError("transport is closed")
+    lock(transport.lock)
+    try
+        _transport_closed(transport) && return nothing
+        @atomic :release transport.closed = true
+        for (_, idle_list) in transport.idle
+            append!(to_close, idle_list)
+        end
+        empty!(transport.idle)
+        @atomic :release transport.idle_total = 0
+        for (_, queue) in transport.waiters
+            for waiter in queue
+                _deliver_waiter_error_locked!(waiter, err) && push!(waiters_to_notify, waiter)
+            end
+        end
+        empty!(transport.waiters)
+    finally
+        unlock(transport.lock)
+    end
+    _close_owned_conns!(transport, to_close)
+    foreach(_notify_waiter!, waiters_to_notify)
     return nothing
 end
 
@@ -581,7 +860,7 @@ function _release_managed!(body::ManagedBody)
     if body.reusable
         _put_idle_conn!(body.transport, body.conn)
     else
-        _close_conn!(body.conn)
+        _close_owned_conn!(body.transport, body.conn)
     end
     return nothing
 end
@@ -609,7 +888,6 @@ function body_read!(body::ManagedBody, dst::Vector{UInt8})::Int
         return n
     catch
         body.reusable = false
-        _close_conn!(body.conn)
         _release_managed!(body)
         rethrow()
     end
@@ -681,7 +959,7 @@ function _roundtrip_incoming!(
                 if reusable
                     _put_idle_conn!(transport, conn)
                 else
-                    _close_conn!(conn)
+                    _close_owned_conn!(transport, conn)
                 end
                 return raw_response
             end
@@ -691,7 +969,7 @@ function _roundtrip_incoming!(
                 managed,
             )
         catch err
-            _close_conn!(conn)
+            _close_owned_conn!(transport, conn)
             if attempt == 1 && was_reused && retry_template !== nothing && _retryable_reused_conn_error(err)
                 current_request = _copy_request(retry_template::Request)
                 attempt = 2

--- a/src/7_6_http_client.jl
+++ b/src/7_6_http_client.jl
@@ -1885,13 +1885,186 @@ function Base.showerror(io::IO, err::TooManyRedirectsError)
     return nothing
 end
 
-struct _URLParts
+struct _TextRange
+    first::Int
+    last::Int
+end
+
+const _EMPTY_TEXT_RANGE = _TextRange(0, 0)
+
+@inline function _text_range(lo::Int, hi::Int)::_TextRange
+    return lo <= hi ? _TextRange(lo, hi) : _EMPTY_TEXT_RANGE
+end
+
+@inline function _text_range_empty(r::_TextRange)::Bool
+    return r.first == 0
+end
+
+@inline function _text_range_string(source::String, r::_TextRange)::String
+    _text_range_empty(r) && return ""
+    return String(SubString(source, r.first, r.last))
+end
+
+@inline function _find_url_byte(
+        bytes::Base.CodeUnits{UInt8, String},
+        lo::Int,
+        hi::Int,
+        byte::UInt8,
+    )::Union{Nothing, Int}
+    lo > hi && return nothing
+    @inbounds for i in lo:hi
+        bytes[i] == byte && return i
+    end
+    return nothing
+end
+
+@inline function _find_last_url_byte(
+        bytes::Base.CodeUnits{UInt8, String},
+        lo::Int,
+        hi::Int,
+        byte::UInt8,
+    )::Union{Nothing, Int}
+    lo > hi && return nothing
+    @inbounds for i in hi:-1:lo
+        bytes[i] == byte && return i
+    end
+    return nothing
+end
+
+@inline function _find_first_url_sep(
+        bytes::Base.CodeUnits{UInt8, String},
+        lo::Int,
+        hi::Int,
+    )::Union{Nothing, Int}
+    lo > hi && return nothing
+    @inbounds for i in lo:hi
+        b = bytes[i]
+        (b == UInt8('/') || b == UInt8('?')) && return i
+    end
+    return nothing
+end
+
+@inline function _ascii_equal_fold_literal(
+        bytes::Base.CodeUnits{UInt8, String},
+        lo::Int,
+        hi::Int,
+        literal::String,
+    )::Bool
+    n = hi >= lo ? (hi - lo + 1) : 0
+    n == ncodeunits(literal) || return false
+    @inbounds for j in 1:n
+        _to_ascii_lower(bytes[lo + j - 1]) == _to_ascii_lower(codeunit(literal, j)) || return false
+    end
+    return true
+end
+
+mutable struct _URLParts
+    source::String
     secure::Bool
-    address::String
-    target::String
-    server_name::String
-    url::String
-    authorization::Union{Nothing, String}
+    default_port::UInt16
+    authority_range::_TextRange
+    host_range::_TextRange
+    userinfo_range::_TextRange
+    target_range::_TextRange
+    query_suffix::String
+    has_explicit_port::Bool
+    target_starts_with_query::Bool
+    has_userinfo::Bool
+    address_cache::String
+    target_cache::String
+    server_name_cache::String
+    url_cache::String
+    authorization_cache::String
+end
+
+function _urlparts_address!(parts::_URLParts)::String
+    cached = getfield(parts, :address_cache)
+    isempty(cached) || return cached
+    source = getfield(parts, :source)
+    address = if getfield(parts, :has_explicit_port)
+        _text_range_string(source, getfield(parts, :authority_range))
+    else
+        host = _text_range_string(source, getfield(parts, :host_range))
+        HostResolvers.join_host_port(host, Int(getfield(parts, :default_port)))
+    end
+    setfield!(parts, :address_cache, address)
+    return address
+end
+
+function _urlparts_target!(parts::_URLParts)::String
+    cached = getfield(parts, :target_cache)
+    isempty(cached) || return cached
+    source = getfield(parts, :source)
+    query_suffix = getfield(parts, :query_suffix)
+    target_range = getfield(parts, :target_range)
+    target = if _text_range_empty(target_range)
+        isempty(query_suffix) ? "/" : string("/?", query_suffix)
+    else
+        base = if getfield(parts, :target_starts_with_query)
+            string("/", SubString(source, target_range.first, target_range.last))
+        else
+            String(SubString(source, target_range.first, target_range.last))
+        end
+        isempty(query_suffix) ? base : _append_query(base, query_suffix)
+    end
+    setfield!(parts, :target_cache, target)
+    return target
+end
+
+function _urlparts_server_name!(parts::_URLParts)::String
+    cached = getfield(parts, :server_name_cache)
+    isempty(cached) || return cached
+    source = getfield(parts, :source)
+    server_name = if getfield(parts, :has_explicit_port)
+        host, _ = HostResolvers.split_host_port(_urlparts_address!(parts))
+        host
+    else
+        _text_range_string(source, getfield(parts, :host_range))
+    end
+    setfield!(parts, :server_name_cache, server_name)
+    return server_name
+end
+
+function _urlparts_url!(parts::_URLParts)::String
+    cached = getfield(parts, :url_cache)
+    isempty(cached) || return cached
+    url = _request_url(getfield(parts, :secure), _urlparts_address!(parts), _urlparts_target!(parts))
+    setfield!(parts, :url_cache, url)
+    return url
+end
+
+function _urlparts_authorization!(parts::_URLParts)::Union{Nothing, String}
+    getfield(parts, :has_userinfo) || return nothing
+    cached = getfield(parts, :authorization_cache)
+    isempty(cached) || return cached
+    userinfo = _text_range_string(getfield(parts, :source), getfield(parts, :userinfo_range))
+    parts_split = split(userinfo, ':'; limit = 2)
+    username = parts_split[1]
+    password = length(parts_split) == 2 ? parts_split[2] : ""
+    authorization = "Basic " * base64encode(string(username, ":", password))
+    setfield!(parts, :authorization_cache, authorization)
+    return authorization
+end
+
+function Base.getproperty(parts::_URLParts, sym::Symbol)
+    if sym === :secure
+        return getfield(parts, :secure)
+    elseif sym === :address
+        return _urlparts_address!(parts)
+    elseif sym === :target
+        return _urlparts_target!(parts)
+    elseif sym === :server_name
+        return _urlparts_server_name!(parts)
+    elseif sym === :url
+        return _urlparts_url!(parts)
+    elseif sym === :authorization
+        return _urlparts_authorization!(parts)
+    end
+    return getfield(parts, sym)
+end
+
+function Base.propertynames(::_URLParts, private::Bool = false)
+    return private ? fieldnames(_URLParts) : (:secure, :address, :target, :server_name, :url, :authorization)
 end
 
 @inline function _request_url(secure::Bool, address::String, target::String)::String
@@ -2374,68 +2547,76 @@ function _append_query(target::String, query)::String
 end
 
 function _parse_http_url(url::AbstractString; query = nothing)::_URLParts
-    s = String(url)
+    s = url isa String ? url : String(url)
+    bytes = codeunits(s)
     scheme_idx = findfirst("://", s)
     scheme_idx === nothing && throw(ArgumentError("URL must include http:// or https:// scheme: $s"))
     scheme_start = first(scheme_idx)
     scheme_end = last(scheme_idx)
-    scheme = lowercase(String(SubString(s, firstindex(s), prevind(s, scheme_start))))
-    secure = if scheme == "http"
+    scheme_last = prevind(s, scheme_start)
+    secure = if _ascii_equal_fold_literal(bytes, firstindex(s), scheme_last, "http")
         false
-    elseif scheme == "https"
+    elseif _ascii_equal_fold_literal(bytes, firstindex(s), scheme_last, "https")
         true
     else
+        scheme = String(SubString(s, firstindex(s), scheme_last))
         throw(ArgumentError("unsupported URL scheme '$scheme'; expected http or https"))
     end
     rest_start = nextind(s, scheme_end)
     rest_start > lastindex(s) && throw(ArgumentError("URL missing authority: $s"))
-    rest = String(SubString(s, rest_start, lastindex(s)))
-    fragment_idx = findfirst('#', rest)
-    fragment_idx === nothing || (rest = String(SubString(rest, firstindex(rest), prevind(rest, fragment_idx))))
-    sep = findfirst(c -> c == '/' || c == '?', rest)
-    authority = ""
-    target = "/"
-    if sep === nothing
-        authority = rest
-    else
-        authority = String(SubString(rest, firstindex(rest), prevind(rest, sep)))
-        raw_target = String(SubString(rest, sep, lastindex(rest)))
-        if startswith(raw_target, "?")
-            target = string("/", raw_target)
-        else
-            target = raw_target
-        end
-    end
-    authorization = nothing
-    at_idx = findlast('@', authority)
+    fragment_idx = _find_url_byte(bytes, rest_start, lastindex(s), UInt8('#'))
+    rest_last = fragment_idx === nothing ? lastindex(s) : prevind(s, fragment_idx)
+    sep = _find_first_url_sep(bytes, rest_start, rest_last)
+    authority_range = sep === nothing ? _text_range(rest_start, rest_last) : _text_range(rest_start, prevind(s, sep))
+    target_range = sep === nothing ? _EMPTY_TEXT_RANGE : _text_range(sep, rest_last)
+    target_starts_with_query = sep !== nothing && @inbounds bytes[sep] == UInt8('?')
+
+    userinfo_range = _EMPTY_TEXT_RANGE
+    has_userinfo = false
+    at_idx = _text_range_empty(authority_range) ? nothing : _find_last_url_byte(bytes, authority_range.first, authority_range.last, UInt8('@'))
     if at_idx !== nothing
-        user_info = String(SubString(authority, firstindex(authority), prevind(authority, at_idx)))
-        authority = String(SubString(authority, nextind(authority, at_idx), lastindex(authority)))
-        if !isempty(user_info)
-            parts = split(user_info, ':'; limit = 2)
-            username = parts[1]
-            password = length(parts) == 2 ? parts[2] : ""
-            authorization = "Basic " * base64encode(string(username, ":", password))
-        end
+        userinfo_range = _text_range(authority_range.first, prevind(s, at_idx))
+        has_userinfo = !_text_range_empty(userinfo_range)
+        authority_range = _text_range(nextind(s, at_idx), authority_range.last)
     end
-    isempty(authority) && throw(ArgumentError("URL missing host: $s"))
-    address = ""
-    if startswith(authority, "[")
-        if occursin("]:", authority)
-            address = authority
-        else
-            close_idx = findfirst(']', authority)
-            close_idx === nothing && throw(ArgumentError("invalid IPv6 host authority: $authority"))
-            host = String(SubString(authority, nextind(authority, firstindex(authority)), prevind(authority, close_idx)))
-            address = HostResolvers.join_host_port(host, secure ? 443 : 80)
+
+    _text_range_empty(authority_range) && throw(ArgumentError("URL missing host: $s"))
+
+    host_range = authority_range
+    has_explicit_port = false
+    if @inbounds bytes[authority_range.first] == UInt8('[')
+        close_idx = _find_url_byte(bytes, authority_range.first, authority_range.last, UInt8(']'))
+        close_idx === nothing && throw(ArgumentError("invalid IPv6 host authority: $(_text_range_string(s, authority_range))"))
+        host_range = _text_range(nextind(s, authority_range.first), prevind(s, close_idx))
+        if close_idx < authority_range.last
+            next_after_close = nextind(s, close_idx)
+            has_explicit_port = next_after_close <= authority_range.last && @inbounds(bytes[next_after_close] == UInt8(':'))
         end
     else
-        address = occursin(':', authority) ? authority : HostResolvers.join_host_port(authority, secure ? 443 : 80)
+        has_explicit_port = _find_last_url_byte(bytes, authority_range.first, authority_range.last, UInt8(':')) !== nothing
+        has_explicit_port || (host_range = authority_range)
     end
-    target = _append_query(target, query)
-    host, _ = HostResolvers.split_host_port(address)
-    full_url = string(scheme, "://", address, target)
-    return _URLParts(secure, address, target, host, full_url, authorization)
+
+    query_suffix = query === nothing ? "" : _query_string(query)
+    default_port = secure ? UInt16(443) : UInt16(80)
+    return _URLParts(
+        s,
+        secure,
+        default_port,
+        authority_range,
+        host_range,
+        userinfo_range,
+        target_range,
+        query_suffix,
+        has_explicit_port,
+        target_starts_with_query,
+        has_userinfo,
+        "",
+        "",
+        "",
+        "",
+        "",
+    )
 end
 
 function _method_upper(method::Union{AbstractString, Symbol})::String

--- a/test/host_resolvers_tests.jl
+++ b/test/host_resolvers_tests.jl
@@ -58,6 +58,71 @@ function ND.resolve_tcp_addrs(
     return copy(resolver.addrs)
 end
 
+mutable struct _FlappingResolver <: ND.AbstractResolver
+    responses::Vector{Vector{NC.SocketEndpoint}}
+    delay_s::Float64
+    lock::ReentrantLock
+    calls::Int
+end
+
+function _FlappingResolver(responses::Vector{Vector{NC.SocketEndpoint}}; delay_s::Float64 = 0.0)
+    return _FlappingResolver(responses, delay_s, ReentrantLock(), 0)
+end
+
+function ND.resolve_tcp_addrs(
+        resolver::_FlappingResolver,
+        network::AbstractString,
+        address::AbstractString;
+        op::Symbol = :connect,
+        policy::ND.ResolverPolicy = ND.ResolverPolicy(),
+    )::Vector{NC.SocketEndpoint}
+    _ = network
+    _ = address
+    _ = op
+    _ = policy
+    lock(resolver.lock)
+    try
+        resolver.calls += 1
+        idx = min(resolver.calls, length(resolver.responses))
+        sleep(resolver.delay_s)
+        return copy(resolver.responses[idx])
+    finally
+        unlock(resolver.lock)
+    end
+end
+
+mutable struct _ErrorResolver <: ND.AbstractResolver
+    delay_s::Float64
+    lock::ReentrantLock
+    calls::Int
+    err::Exception
+end
+
+function _ErrorResolver(err::Exception; delay_s::Float64 = 0.0)
+    return _ErrorResolver(delay_s, ReentrantLock(), 0, err)
+end
+
+function ND.resolve_tcp_addrs(
+        resolver::_ErrorResolver,
+        network::AbstractString,
+        address::AbstractString;
+        op::Symbol = :connect,
+        policy::ND.ResolverPolicy = ND.ResolverPolicy(),
+    )::Vector{NC.SocketEndpoint}
+    _ = network
+    _ = address
+    _ = op
+    _ = policy
+    lock(resolver.lock)
+    try
+        resolver.calls += 1
+    finally
+        unlock(resolver.lock)
+    end
+    sleep(resolver.delay_s)
+    throw(resolver.err)
+end
+
 function _nd_wait_task_done(task::Task, timeout_s::Float64 = 2.0)
     return timedwait(() -> istaskdone(task), timeout_s; pollint = 0.001)
 end
@@ -443,6 +508,64 @@ else
                 _nd_close_quiet!(listener)
                 EL.shutdown!()
             end
+        end
+        @testset "caching resolver fresh/stale/negative behavior" begin
+            addr_a = NC.loopback_addr(1111)
+            addr_b = NC.loopback_addr(2222)
+
+            fresh_parent = _CountingResolver(0.0, NC.SocketEndpoint[addr_a])
+            fresh_cache = ND.CachingResolver(fresh_parent; ttl_ns = 1_000_000_000, stale_ttl_ns = 0, negative_ttl_ns = 0, max_hosts = 8)
+            @test ND.resolve_tcp_addrs(fresh_cache, "tcp", "cache.test:80") == NC.SocketEndpoint[NC.SocketAddrV4(addr_a.ip, 80)]
+            @test ND.resolve_tcp_addrs(fresh_cache, "tcp", "cache.test:80") == NC.SocketEndpoint[NC.SocketAddrV4(addr_a.ip, 80)]
+            @test fresh_parent.calls == 1
+            @test (@atomic :acquire fresh_cache.cache_hits) == 1
+
+            stale_parent = _FlappingResolver([NC.SocketEndpoint[addr_a], NC.SocketEndpoint[addr_b]]; delay_s = 0.02)
+            stale_cache = ND.CachingResolver(stale_parent; ttl_ns = 10_000_000, stale_ttl_ns = 200_000_000, negative_ttl_ns = 0, max_hosts = 8)
+            first = ND.resolve_tcp_addrs(stale_cache, "tcp", "stale.test:80")
+            sleep(0.02)
+            second = ND.resolve_tcp_addrs(stale_cache, "tcp", "stale.test:80")
+            @test first == NC.SocketEndpoint[NC.SocketAddrV4(addr_a.ip, 80)]
+            @test second == NC.SocketEndpoint[NC.SocketAddrV4(addr_a.ip, 80)]
+            @test (@atomic :acquire stale_cache.stale_hits) == 1
+            @test timedwait(() -> stale_parent.calls >= 2, 2.0; pollint = 0.001) != :timed_out
+            third = ND.resolve_tcp_addrs(stale_cache, "tcp", "stale.test:80")
+            @test third == NC.SocketEndpoint[NC.SocketAddrV4(addr_b.ip, 80)]
+
+            evict_parent = _CountingResolver(0.0, NC.SocketEndpoint[addr_a])
+            evict_cache = ND.CachingResolver(evict_parent; ttl_ns = 1_000_000_000, stale_ttl_ns = 0, negative_ttl_ns = 0, max_hosts = 1)
+            ND.resolve_tcp_addrs(evict_cache, "tcp", "host-one.test:80")
+            ND.resolve_tcp_addrs(evict_cache, "tcp", "host-two.test:80")
+            ND.resolve_tcp_addrs(evict_cache, "tcp", "host-one.test:80")
+            @test evict_parent.calls == 3
+
+            neg_parent = _ErrorResolver(ND.AddressError("lookup failed", "neg.test"); delay_s = 0.0)
+            neg_cache = ND.CachingResolver(neg_parent; ttl_ns = 0, stale_ttl_ns = 0, negative_ttl_ns = 50_000_000, max_hosts = 8)
+            err1 = try
+                ND.resolve_tcp_addrs(neg_cache, "tcp", "neg.test:80")
+                nothing
+            catch ex
+                ex
+            end
+            err2 = try
+                ND.resolve_tcp_addrs(neg_cache, "tcp", "neg.test:80")
+                nothing
+            catch ex
+                ex
+            end
+            @test err1 isa ND.AddressError
+            @test err2 isa ND.AddressError
+            @test neg_parent.calls == 1
+            @test (@atomic :acquire neg_cache.negative_hits) == 1
+            sleep(0.06)
+            err3 = try
+                ND.resolve_tcp_addrs(neg_cache, "tcp", "neg.test:80")
+                nothing
+            catch ex
+                ex
+            end
+            @test err3 isa ND.AddressError
+            @test neg_parent.calls == 2
         end
     end
 end

--- a/test/host_resolvers_tests.jl
+++ b/test/host_resolvers_tests.jl
@@ -18,6 +18,42 @@ function ND.resolve_tcp_addrs(
         op::Symbol = :connect,
         policy::ND.ResolverPolicy = ND.ResolverPolicy(),
     )::Vector{NC.SocketEndpoint}
+    _ = network
+    _ = address
+    _ = op
+    _ = policy
+    sleep(resolver.delay_s)
+    return copy(resolver.addrs)
+end
+
+mutable struct _CountingResolver <: ND.AbstractResolver
+    delay_s::Float64
+    addrs::Vector{NC.SocketEndpoint}
+    lock::ReentrantLock
+    calls::Int
+end
+
+function _CountingResolver(delay_s::Float64, addrs::Vector{NC.SocketEndpoint})
+    return _CountingResolver(delay_s, addrs, ReentrantLock(), 0)
+end
+
+function ND.resolve_tcp_addrs(
+        resolver::_CountingResolver,
+        network::AbstractString,
+        address::AbstractString;
+        op::Symbol = :connect,
+        policy::ND.ResolverPolicy = ND.ResolverPolicy(),
+    )::Vector{NC.SocketEndpoint}
+    _ = network
+    _ = address
+    _ = op
+    _ = policy
+    lock(resolver.lock)
+    try
+        resolver.calls += 1
+    finally
+        unlock(resolver.lock)
+    end
     sleep(resolver.delay_s)
     return copy(resolver.addrs)
 end
@@ -372,6 +408,40 @@ else
             @test err_timeout isa ND.DNSOpError
             if err_timeout isa ND.DNSOpError
                 @test err_timeout.err isa ND.DNSTimeoutError
+            end
+        end
+        @testset "singleflight resolver coalesces duplicate concurrent lookups" begin
+            EL.shutdown!()
+            listener = nothing
+            client1 = nothing
+            client2 = nothing
+            try
+                listener = NC.listen("tcp", "127.0.0.1:0"; backlog = 8)
+                laddr = NC.addr(listener)::NC.SocketAddrV4
+                resolver = _CountingResolver(0.05, NC.SocketEndpoint[NC.loopback_addr(Int(laddr.port))])
+                singleflight = ND.SingleflightResolver(resolver)
+                accept_task = errormonitor(Threads.@spawn begin
+                    conn_a = NC.accept!(listener)
+                    conn_b = NC.accept!(listener)
+                    return conn_a, conn_b
+                end)
+                task1 = errormonitor(Threads.@spawn NC.connect("tcp", "same.test:$(Int(laddr.port))"; resolver = singleflight, timeout_ns = 1_000_000_000, fallback_delay_ns = -1))
+                task2 = errormonitor(Threads.@spawn NC.connect("tcp", "same.test:$(Int(laddr.port))"; resolver = singleflight, timeout_ns = 1_000_000_000, fallback_delay_ns = -1))
+                @test _nd_wait_task_done(task1, 2.0) != :timed_out
+                @test _nd_wait_task_done(task2, 2.0) != :timed_out
+                client1 = fetch(task1)
+                client2 = fetch(task2)
+                server1, server2 = fetch(accept_task)
+                _nd_close_quiet!(server2)
+                _nd_close_quiet!(server1)
+                @test resolver.calls == 1
+                @test (@atomic :acquire singleflight.actual_lookups) == 1
+                @test (@atomic :acquire singleflight.shared_hits) == 1
+            finally
+                _nd_close_quiet!(client2)
+                _nd_close_quiet!(client1)
+                _nd_close_quiet!(listener)
+                EL.shutdown!()
             end
         end
     end

--- a/test/http1_wire_tests.jl
+++ b/test/http1_wire_tests.jl
@@ -34,6 +34,26 @@ end
     @test parsed.target == "/v1"
     @test parsed.content_length == 4
     @test _read_all_body_bytes(parsed.body) == collect(codeunits("ping"))
+
+    function make_streaming_request()
+        headers = HT.Headers()
+        HT.setheader(headers, "host", "example.com")
+        payload = collect(codeunits("streaming-body"))
+        return HT.Request("PUT", "/stream"; headers = headers, body = HT.BytesBody(payload), content_length = length(payload))
+    end
+    expected_io = IOBuffer()
+    HT.write_request!(expected_io, make_streaming_request())
+    streamed_io = IOBuffer()
+    request_buf = IOBuffer()
+    HT._write_request_streaming!(request_buf, streamed_io, make_streaming_request())
+    @test take!(streamed_io) == take!(expected_io)
+
+    partial_body = HT.BytesBody(collect(codeunits("abcdef")))
+    advance_buf = Vector{UInt8}(undef, 2)
+    @test HT.body_read!(partial_body, advance_buf) == 2
+    partial_io = IOBuffer()
+    HT._write_exact_bytes_body!(partial_io, partial_body, 4)
+    @test take!(partial_io) == collect(codeunits("cdef"))
 end
 
 @testset "HTTP/1 response parse/write chunked" begin

--- a/test/http1_wire_tests.jl
+++ b/test/http1_wire_tests.jl
@@ -56,6 +56,17 @@ end
     @test take!(partial_io) == collect(codeunits("cdef"))
 end
 
+@testset "HTTP/1 header serialization preserves stored entries" begin
+    headers = HT.Headers()
+    push!(headers, "X-Test" => "one")
+    push!(headers, "X-Test" => "two")
+    push!(headers, "Set-Cookie" => "a=1")
+    push!(headers, "Set-Cookie" => "b=2")
+    io = IOBuffer()
+    HT._write_headers!(io, headers)
+    @test String(take!(io)) == "X-Test: one\r\nX-Test: two\r\nSet-Cookie: a=1\r\nSet-Cookie: b=2\r\n"
+end
+
 @testset "HTTP/1 response parse/write chunked" begin
     raw = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\nX-Trailer: done\r\n\r\n"
     resp = HT._read_response(IOBuffer(codeunits(raw)))

--- a/test/http_client_proxy_tests.jl
+++ b/test/http_client_proxy_tests.jl
@@ -479,6 +479,7 @@ end
     proxy_addr = NC.addr(proxy_listener)::NC.SocketAddrV4
     proxy_address = ND.join_host_port("127.0.0.1", Int(proxy_addr.port))
     seen_h2_path = Ref{Union{Nothing, String}}(nothing)
+    tunnel_done = Base.Event()
     origin_task = errormonitor(Threads.@spawn begin
         conn = TL.accept!(origin_listener)
         try
@@ -543,7 +544,7 @@ end
             _send_response_proxy!(client_conn, connect_req; status = 200, reason = "Connection Established", headers = HT.Headers())
             errormonitor(Threads.@spawn _bridge_proxy!(client_conn, origin_conn))
             errormonitor(Threads.@spawn _bridge_proxy!(origin_conn, client_conn))
-            sleep(0.3)
+            wait(tunnel_done)
         finally
             try
                 NC.close!(client_conn)
@@ -565,6 +566,7 @@ end
         )
         @test response.status == 200
         @test String(response.body) == "h2-proxied"
+        notify(tunnel_done)
         close(HT._default_client!())
         _reset_default_http_client_proxy!()
         _wait_task_proxy!(origin_task)

--- a/test/http_client_tests.jl
+++ b/test/http_client_tests.jl
@@ -880,6 +880,34 @@ end
             @test status_err.response.url == "$(base_url)/missing"
         end
 
+        parsed = HT._parse_http_url("http://alice:secret@$(address)/lazy/path?x=1#frag"; query = Dict("y" => 2))
+        @test !parsed.secure
+        @test parsed.address == "$(address)"
+        @test parsed.address === parsed.address
+        @test parsed.target == "/lazy/path?x=1&y=2"
+        @test parsed.target === parsed.target
+        @test parsed.server_name == "127.0.0.1"
+        @test parsed.server_name === parsed.server_name
+        @test parsed.url == "http://$(address)/lazy/path?x=1&y=2"
+        @test parsed.url === parsed.url
+        @test parsed.authorization == "Basic YWxpY2U6c2VjcmV0"
+        @test parsed.authorization === parsed.authorization
+
+        parsed_query = HT._parse_http_url("https://example.com?x=1"; query = Dict("y" => 2))
+        @test parsed_query.secure
+        @test parsed_query.address == "example.com:443"
+        @test parsed_query.target == "/?x=1&y=2"
+        @test parsed_query.server_name == "example.com"
+        @test parsed_query.url == "https://example.com:443/?x=1&y=2"
+        @test parsed_query.authorization === nothing
+
+        parsed_ipv6 = HT._parse_http_url("https://[2001:db8::1]/ipv6")
+        @test parsed_ipv6.address == "[2001:db8::1]:443"
+        @test parsed_ipv6.target == "/ipv6"
+        @test parsed_ipv6.server_name == "2001:db8::1"
+        @test parsed_ipv6.url == "https://[2001:db8::1]:443/ipv6"
+        @test parsed_ipv6.authorization === nothing
+
         _wait_task_client!(server_task)
         @test "/hello" in seen_targets
         @test "/echo" in seen_targets

--- a/test/http_client_tests.jl
+++ b/test/http_client_tests.jl
@@ -897,7 +897,7 @@ end
     address = ND.join_host_port("127.0.0.1", Int(laddr.port))
     base_url = "http://$(address)"
     server_task = errormonitor(Threads.@spawn begin
-        for _ in 1:6
+        for _ in 1:8
             conn = NC.accept!(listener)
             try
                 req = HT.read_request(HT._ConnReader(conn))
@@ -919,6 +919,16 @@ end
                     _send_response_bytes_client!(conn, req; body_bytes = payload, headers = headers, close_conn = true)
                 elseif req.target == "/gzip-stream"
                     payload = _gzip_bytes_client("gzip-stream")
+                    headers = HT.Headers()
+                    HT.setheader(headers, "Content-Encoding", "gzip")
+                    _send_response_bytes_client!(conn, req; body_bytes = payload, headers = headers, close_conn = true)
+                elseif req.target == "/gzip-buffer"
+                    payload = _gzip_bytes_client("gzip-buffer")
+                    headers = HT.Headers()
+                    HT.setheader(headers, "Content-Encoding", "gzip")
+                    _send_response_bytes_client!(conn, req; body_bytes = payload, headers = headers, close_conn = true)
+                elseif req.target == "/gzip-too-small"
+                    payload = _gzip_bytes_client("overflow")
                     headers = HT.Headers()
                     HT.setheader(headers, "Content-Encoding", "gzip")
                     _send_response_bytes_client!(conn, req; body_bytes = payload, headers = headers, close_conn = true)
@@ -971,6 +981,23 @@ end
         @test resp_gzip_stream.status == 200
         @test resp_gzip_stream.body === nothing
         @test String(take!(streamed_gzip)) == "gzip-stream"
+
+        gzip_buffer = Vector{UInt8}(undef, 32)
+        resp_gzip_buffer = HT.get("$(base_url)/gzip-buffer"; response_stream = gzip_buffer, decompress = true)
+        @test resp_gzip_buffer.status == 200
+        @test resp_gzip_buffer.body === gzip_buffer
+        @test String(resp_gzip_buffer.body) == "gzip-buffer"
+
+        gzip_small_err = try
+            HT.get("$(base_url)/gzip-too-small"; response_stream = Vector{UInt8}(undef, 2), decompress = true)
+            nothing
+        catch err
+            err
+        end
+        @test gzip_small_err isa ArgumentError
+        if gzip_small_err isa ArgumentError
+            @test occursin("Unable to grow response stream IOBuffer", sprint(showerror, gzip_small_err))
+        end
 
         _wait_task_client!(server_task)
     finally

--- a/test/http_client_tests.jl
+++ b/test/http_client_tests.jl
@@ -525,10 +525,15 @@ end
         @test String(resp.body) == "ok"
         @test resp.url == "$(base_url)/final"
         @test resp.redirect_count == 1
+        @test resp.request !== nothing
+        @test resp.request.target == "/final"
         @test resp.previous !== nothing
         @test resp.previous.status == 302
         @test resp.previous.url == "$(base_url)/start"
         @test resp.previous.redirect_count == 0
+        @test resp.previous.request !== nothing
+        @test resp.previous.request.target == "/start"
+        @test resp.request !== resp.previous.request
 
         err = try
             HT.get("$(base_url)/limit-start"; redirect_limit = 1)

--- a/test/http_client_transport_tests.jl
+++ b/test/http_client_transport_tests.jl
@@ -78,6 +78,13 @@ function Base.read!(conn::_ChunkReadConn, dst::Vector{UInt8})::Int
     return n
 end
 
+@testset "_read_all_response_bytes caps eager preallocation" begin
+    payload = collect(codeunits("ok"))
+    body = HT.BytesBody(payload)
+    bytes = HT._read_all_response_bytes(body; content_length_hint = HT._MAX_EAGER_RESPONSE_PREALLOC + 1)
+    @test bytes == payload
+end
+
 @testset "_ConnReader uses buffered reads for HTTP/1 parsing" begin
     raw = collect(codeunits("POST /upload HTTP/1.1\r\nHost: example.test\r\nContent-Length: 5\r\n\r\nhello"))
     conn = _ChunkReadConn(raw; max_chunk = 8)

--- a/test/http_client_transport_tests.jl
+++ b/test/http_client_transport_tests.jl
@@ -87,6 +87,38 @@ function Base.read!(conn::_ChunkReadConn, dst::Vector{UInt8})::Int
     return n
 end
 
+mutable struct _CountingResolverTransport <: ND.AbstractResolver
+    delay_s::Float64
+    addrs::Vector{NC.SocketEndpoint}
+    lock::ReentrantLock
+    calls::Int
+end
+
+function _CountingResolverTransport(delay_s::Float64, addrs::Vector{NC.SocketEndpoint})
+    return _CountingResolverTransport(delay_s, addrs, ReentrantLock(), 0)
+end
+
+function ND.resolve_tcp_addrs(
+        resolver::_CountingResolverTransport,
+        network::AbstractString,
+        address::AbstractString;
+        op::Symbol = :connect,
+        policy::ND.ResolverPolicy = ND.ResolverPolicy(),
+    )::Vector{NC.SocketEndpoint}
+    _ = network
+    _ = address
+    _ = op
+    _ = policy
+    lock(resolver.lock)
+    try
+        resolver.calls += 1
+    finally
+        unlock(resolver.lock)
+    end
+    sleep(resolver.delay_s)
+    return copy(resolver.addrs)
+end
+
 @testset "_read_all_response_bytes caps eager preallocation" begin
     payload = collect(codeunits("ok"))
     body = HT.BytesBody(payload)
@@ -96,6 +128,54 @@ end
 
 @testset "HTTP transport constructor validates max_conns_per_host" begin
     @test_throws ArgumentError HT.Transport(max_conns_per_host = -1)
+end
+
+@testset "HTTP client transport coalesces duplicate concurrent lookups" begin
+    listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
+    laddr = NC.addr(listener)::NC.SocketAddrV4
+    address = ND.join_host_port("same.test", Int(laddr.port))
+    resolver = _CountingResolverTransport(0.05, NC.SocketEndpoint[NC.loopback_addr(Int(laddr.port))])
+    singleflight = ND.SingleflightResolver(resolver)
+    host_resolver = ND.HostResolver(resolver = singleflight, timeout_ns = 1_000_000_000, fallback_delay_ns = -1)
+    server_task = errormonitor(Threads.@spawn begin
+        for _ in 1:2
+            conn = NC.accept!(listener)
+            try
+                request = HT.read_request(HT._ConnReader(conn))
+                _read_all_body_bytes(request.body)
+                _write_response_to_conn!(conn, request; body_text = "ok", close_conn = true)
+            finally
+                try
+                    NC.close!(conn)
+                catch
+                end
+            end
+        end
+        return nothing
+    end)
+    transport = HT.Transport(host_resolver = host_resolver, max_idle_per_host = 4, max_idle_total = 4)
+    try
+        req1 = HT.Request("GET", "/one"; host = address, body = HT.EmptyBody(), content_length = 0)
+        req2 = HT.Request("GET", "/two"; host = address, body = HT.EmptyBody(), content_length = 0)
+        task1 = errormonitor(Threads.@spawn HT.roundtrip!(transport, address, req1))
+        task2 = errormonitor(Threads.@spawn HT.roundtrip!(transport, address, req2))
+        @test _wait_task!(task1) === nothing
+        @test _wait_task!(task2) === nothing
+        res1 = fetch(task1)
+        res2 = fetch(task2)
+        @test String(_read_all_body_bytes(res1.body)) == "ok"
+        @test String(_read_all_body_bytes(res2.body)) == "ok"
+        _wait_task!(server_task)
+        @test resolver.calls == 1
+        @test (@atomic :acquire singleflight.actual_lookups) == 1
+        @test (@atomic :acquire singleflight.shared_hits) == 1
+    finally
+        close(transport)
+        try
+            NC.close!(listener)
+        catch
+        end
+    end
 end
 
 @testset "_ConnReader uses buffered reads for HTTP/1 parsing" begin

--- a/test/http_client_transport_tests.jl
+++ b/test/http_client_transport_tests.jl
@@ -94,6 +94,10 @@ end
     @test bytes == payload
 end
 
+@testset "HTTP transport constructor validates max_conns_per_host" begin
+    @test_throws ArgumentError HT.Transport(max_conns_per_host = -1)
+end
+
 @testset "_ConnReader uses buffered reads for HTTP/1 parsing" begin
     raw = collect(codeunits("POST /upload HTTP/1.1\r\nHost: example.test\r\nContent-Length: 5\r\n\r\nhello"))
     conn = _ChunkReadConn(raw; max_chunk = 8)
@@ -267,6 +271,195 @@ end
         @test HT.idle_connection_count(transport; key = "http://$address") == 1
     finally
         close(client)
+        try
+            NC.close!(listener)
+        catch
+        end
+    end
+end
+
+@testset "HTTP client transport hands off waiting acquire under host cap" begin
+    listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
+    laddr = NC.addr(listener)::NC.SocketAddrV4
+    address = ND.join_host_port("127.0.0.1", Int(laddr.port))
+    accept_count = Ref(0)
+    paths = String[]
+    server_task = errormonitor(Threads.@spawn begin
+        conn = NC.accept!(listener)
+        accept_count[] += 1
+        try
+            req1 = HT.read_request(HT._ConnReader(conn))
+            push!(paths, req1.target)
+            _read_all_body_bytes(req1.body)
+            _write_response_to_conn!(conn, req1; body_text = "first")
+            req2 = HT.read_request(HT._ConnReader(conn))
+            push!(paths, req2.target)
+            _read_all_body_bytes(req2.body)
+            _write_response_to_conn!(conn, req2; body_text = "second", close_conn = true)
+        finally
+            try
+                NC.close!(conn)
+            catch
+            end
+        end
+        return nothing
+    end)
+    transport = HT.Transport(max_idle_per_host = 1, max_idle_total = 1, max_conns_per_host = 1)
+    try
+        req1 = HT.Request("GET", "/one"; host = address, body = HT.EmptyBody(), content_length = 0)
+        res1 = HT.roundtrip!(transport, address, req1)
+        @test res1.status_code == 200
+
+        req2 = HT.Request("GET", "/two"; host = address, body = HT.EmptyBody(), content_length = 0)
+        res2_task = errormonitor(Threads.@spawn HT.roundtrip!(transport, address, req2))
+        @test timedwait(() -> istaskdone(res2_task), 0.05; pollint = 0.001) == :timed_out
+
+        @test String(_read_all_body_bytes(res1.body)) == "first"
+
+        res2 = fetch(res2_task)
+        @test res2.status_code == 200
+        @test String(_read_all_body_bytes(res2.body)) == "second"
+        _wait_task!(server_task)
+        @test accept_count[] == 1
+        @test paths == ["/one", "/two"]
+        @test HT.idle_connection_count(transport) == 0
+    finally
+        close(transport)
+        try
+            NC.close!(listener)
+        catch
+        end
+    end
+end
+
+@testset "HTTP client transport wakes waiter to redial after early close under host cap" begin
+    listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
+    laddr = NC.addr(listener)::NC.SocketAddrV4
+    address = ND.join_host_port("127.0.0.1", Int(laddr.port))
+    accept_count = Ref(0)
+    same_conn_second_request = Ref(false)
+    server_task = errormonitor(Threads.@spawn begin
+        conn1 = NC.accept!(listener)
+        accept_count[] += 1
+        try
+            req1 = HT.read_request(HT._ConnReader(conn1))
+            _read_all_body_bytes(req1.body)
+            _write_response_to_conn!(conn1, req1; body_text = "first-response")
+            NC.set_read_deadline!(conn1, Int64(time_ns()) + 300_000_000)
+            try
+                req_maybe = HT.read_request(HT._ConnReader(conn1))
+                same_conn_second_request[] = true
+                _read_all_body_bytes(req_maybe.body)
+                _write_response_to_conn!(conn1, req_maybe; body_text = "unexpected")
+            catch err
+                if !(err isa EOFError || err isa SystemError || err isa Reseau.IOPoll.DeadlineExceededError || err isa Reseau.IOPoll.NetClosingError || err isa HT.ParseError || err isa HT.ProtocolError)
+                    rethrow(err)
+                end
+            end
+        finally
+            try
+                NC.close!(conn1)
+            catch
+            end
+        end
+        conn2 = NC.accept!(listener)
+        accept_count[] += 1
+        try
+            req2 = HT.read_request(HT._ConnReader(conn2))
+            _read_all_body_bytes(req2.body)
+            _write_response_to_conn!(conn2, req2; body_text = "second-response", close_conn = true)
+        finally
+            try
+                NC.close!(conn2)
+            catch
+            end
+        end
+        return nothing
+    end)
+    transport = HT.Transport(max_idle_per_host = 1, max_idle_total = 1, max_conns_per_host = 1)
+    try
+        req1 = HT.Request("GET", "/one"; host = address, body = HT.EmptyBody(), content_length = 0)
+        res1 = HT.roundtrip!(transport, address, req1)
+        @test res1.status_code == 200
+
+        req2 = HT.Request("GET", "/two"; host = address, body = HT.EmptyBody(), content_length = 0)
+        res2_task = errormonitor(Threads.@spawn HT.roundtrip!(transport, address, req2))
+        @test timedwait(() -> istaskdone(res2_task), 0.05; pollint = 0.001) == :timed_out
+
+        first_byte = Vector{UInt8}(undef, 1)
+        @test HT.body_read!(res1.body, first_byte) == 1
+        HT.body_close!(res1.body)
+
+        res2 = fetch(res2_task)
+        @test res2.status_code == 200
+        @test String(_read_all_body_bytes(res2.body)) == "second-response"
+        _wait_task!(server_task)
+        @test accept_count[] == 2
+        @test !same_conn_second_request[]
+        @test HT.idle_connection_count(transport) == 0
+    finally
+        close(transport)
+        try
+            NC.close!(listener)
+        catch
+        end
+    end
+end
+
+@testset "HTTP client transport waiter honors request deadline under host cap" begin
+    listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
+    laddr = NC.addr(listener)::NC.SocketAddrV4
+    address = ND.join_host_port("127.0.0.1", Int(laddr.port))
+    accept_count = Ref(0)
+    second_request_seen = Ref(false)
+    server_task = errormonitor(Threads.@spawn begin
+        conn = NC.accept!(listener)
+        accept_count[] += 1
+        try
+            req1 = HT.read_request(HT._ConnReader(conn))
+            _read_all_body_bytes(req1.body)
+            _write_response_to_conn!(conn, req1; body_text = "first")
+            NC.set_read_deadline!(conn, Int64(time_ns()) + 300_000_000)
+            try
+                req2 = HT.read_request(HT._ConnReader(conn))
+                second_request_seen[] = true
+                _read_all_body_bytes(req2.body)
+            catch err
+                if !(err isa EOFError || err isa SystemError || err isa Reseau.IOPoll.DeadlineExceededError || err isa Reseau.IOPoll.NetClosingError || err isa HT.ParseError || err isa HT.ProtocolError)
+                    rethrow(err)
+                end
+            end
+        finally
+            try
+                NC.close!(conn)
+            catch
+            end
+        end
+        return nothing
+    end)
+    transport = HT.Transport(max_idle_per_host = 1, max_idle_total = 1, max_conns_per_host = 1)
+    try
+        req1 = HT.Request("GET", "/one"; host = address, body = HT.EmptyBody(), content_length = 0)
+        res1 = HT.roundtrip!(transport, address, req1)
+        @test res1.status_code == 200
+
+        req2 = HT.Request("GET", "/two"; host = address, body = HT.EmptyBody(), content_length = 0)
+        HT.set_deadline!(req2.context, Int64(time_ns()) + 50_000_000)
+        err = try
+            HT.roundtrip!(transport, address, req2)
+            nothing
+        catch caught
+            caught
+        end
+        @test err isa Reseau.IOPoll.DeadlineExceededError
+
+        HT.body_close!(res1.body)
+        _wait_task!(server_task)
+        @test accept_count[] == 1
+        @test !second_request_seen[]
+        @test HT.idle_connection_count(transport) == 0
+    finally
+        close(transport)
         try
             NC.close!(listener)
         catch

--- a/test/http_client_transport_tests.jl
+++ b/test/http_client_transport_tests.jl
@@ -1,5 +1,6 @@
 using Test
 using Reseau
+using CodecZlib
 
 const HT = Reseau.HTTP
 const NC = Reseau.TCP
@@ -27,15 +28,19 @@ function _write_all_tcp!(conn::NC.Conn, bytes::Vector{UInt8})::Nothing
 end
 
 function _write_response_to_conn!(conn::NC.Conn, request::HT.Request; body_text::String, close_conn::Bool = false)::Nothing
-    headers = HT.Headers()
-    close_conn && HT.setheader(headers, "Connection", "close")
     payload = collect(codeunits(body_text))
+    return _write_response_bytes_to_conn!(conn, request; body_bytes = payload, close_conn = close_conn)
+end
+
+function _write_response_bytes_to_conn!(conn::NC.Conn, request::HT.Request; body_bytes::Vector{UInt8}, headers::HT.Headers = HT.Headers(), close_conn::Bool = false)::Nothing
+    headers_copy = copy(headers)
+    close_conn && HT.setheader(headers_copy, "Connection", "close")
     response = HT.Response(
         200;
         reason = "OK",
-        headers = headers,
-        body = HT.BytesBody(payload),
-        content_length = length(payload),
+        headers = headers_copy,
+        body = HT.BytesBody(body_bytes),
+        content_length = length(body_bytes),
         close = close_conn,
         request = request,
     )
@@ -43,6 +48,10 @@ function _write_response_to_conn!(conn::NC.Conn, request::HT.Request; body_text:
     HT.write_response!(io, response)
     _write_all_tcp!(conn, take!(io))
     return nothing
+end
+
+function _gzip_bytes_transport(text::String)::Vector{UInt8}
+    return transcode(CodecZlib.GzipCompressor, collect(codeunits(text)))
 end
 
 function _wait_task!(task::Task; timeout_s::Float64 = 5.0)
@@ -206,6 +215,58 @@ end
         @test HT.idle_connection_count(transport) == 0
     finally
         close(transport)
+        try
+            NC.close!(listener)
+        catch
+        end
+    end
+end
+
+@testset "HTTP client transport keep-alive reuse with gzip decompression" begin
+    listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
+    laddr = NC.addr(listener)::NC.SocketAddrV4
+    address = ND.join_host_port("127.0.0.1", Int(laddr.port))
+    base_url = "http://$(address)"
+    accept_count = Ref(0)
+    paths = String[]
+    server_task = errormonitor(Threads.@spawn begin
+        conn = NC.accept!(listener)
+        accept_count[] += 1
+        try
+            for _ in 1:2
+                request = HT.read_request(HT._ConnReader(conn))
+                push!(paths, request.target)
+                _read_all_body_bytes(request.body)
+                headers = HT.Headers()
+                HT.setheader(headers, "Content-Encoding", "gzip")
+                _write_response_bytes_to_conn!(
+                    conn,
+                    request;
+                    body_bytes = _gzip_bytes_transport("gzip-ok"),
+                    headers = headers,
+                )
+            end
+        finally
+            try
+                NC.close!(conn)
+            catch
+            end
+        end
+        return nothing
+    end)
+    transport = HT.Transport(max_idle_per_host = 4, max_idle_total = 4)
+    client = HT.Client(transport = transport)
+    try
+        res1 = HT.get("$(base_url)/one"; client = client)
+        @test String(res1.body) == "gzip-ok"
+        res2 = HT.get("$(base_url)/two"; client = client)
+        @test String(res2.body) == "gzip-ok"
+        _wait_task!(server_task)
+        @test accept_count[] == 1
+        @test paths == ["/one", "/two"]
+        @test HT.idle_connection_count(transport; key = "http://$address") == 1
+    finally
+        close(client)
         try
             NC.close!(listener)
         catch

--- a/test/http_core_tests.jl
+++ b/test/http_core_tests.jl
@@ -50,6 +50,7 @@ end
     @test HT.headercontains(headers, "connection", "upgrade")
     @test HT.headercontains(headers, "connection", "keep-alive")
     @test HT.headercontains(headers, "connection", "close")
+    @test HT.headercontains(headers, "connection", "  UPGRADE\t")
     @test !HT.headercontains(headers, "connection", "te")
 end
 

--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -76,6 +76,11 @@ else
                 nr = _read_exact!(server, recv_buf)
                 @test nr == length(payload)
                 @test recv_buf == payload
+                payload_view = @view payload[2:4]
+                @test write(client, payload_view) == length(payload_view)
+                recv_view_buf = Vector{UInt8}(undef, length(payload_view))
+                @test _read_exact!(server, recv_view_buf) == length(payload_view)
+                @test recv_view_buf == collect(payload_view)
             finally
                 _close_quiet!(server)
                 _close_quiet!(client)

--- a/test/tls_tests.jl
+++ b/test/tls_tests.jl
@@ -367,7 +367,10 @@ else
                         TL.handshake!(conn)
                         buf = Vector{UInt8}(undef, 4)
                         n = read!(conn, buf)
-                        n > 0 && write(conn, buf[1:n])
+                        n > 0 && write(conn, view(buf, 1:n))
+                        view_buf = Vector{UInt8}(undef, 3)
+                        n = read!(conn, view_buf)
+                        n > 0 && write(conn, view(view_buf, 1:n))
                         return conn
                     catch err
                         return err
@@ -384,6 +387,11 @@ else
                 recv_buf = Vector{UInt8}(undef, 4)
                 @test read!(client, recv_buf) == 4
                 @test recv_buf == payload
+                payload_view = @view payload[2:4]
+                @test write(client, payload_view) == length(payload_view)
+                recv_view_buf = Vector{UInt8}(undef, length(payload_view))
+                @test read!(client, recv_view_buf) == length(payload_view)
+                @test recv_view_buf == collect(payload_view)
                 @test _tls_wait_task_done(accept_task, 12.0) != :timed_out
                 server_result = fetch(accept_task)
                 server_result isa Exception && throw(server_result)


### PR DESCRIPTION
## Summary
- reduce low-level write-path copies and direct-stream fixed-length HTTP/1 request bodies
- remove the response BufferStream/task bridge and streamline hot header/token paths
- reuse owned request/response metadata and make URL parsing lazy/range-backed
- add connection acquisition coordination, resolver singleflight, and an explicit caching resolver

## Testing
- julia --project=. --startup-file=no --history-file=no test/tcp_tests.jl
- julia --project=. --startup-file=no --history-file=no test/tls_tests.jl
- julia --project=. --startup-file=no --history-file=no test/http1_wire_tests.jl
- julia --project=. --startup-file=no --history-file=no test/http_core_tests.jl
- julia --project=. --startup-file=no --history-file=no test/http_client_tests.jl
- julia --project=. --startup-file=no --history-file=no test/http_client_transport_tests.jl
- julia --project=. --startup-file=no --history-file=no test/http_retry_tests.jl
- julia --project=. --startup-file=no --history-file=no test/http_integration_tests.jl
- julia --project=. --startup-file=no --history-file=no test/http_client_proxy_tests.jl
- julia --project=. --startup-file=no --history-file=no test/http_websocket_client_tests.jl
- julia --project=. --startup-file=no --history-file=no test/host_resolvers_tests.jl

## Notes
- full `Pkg.test(; coverage=false)` still hits the preexisting `test/eventloops_tests.jl` hang in the current rewrite branch, so the verification here is the focused suite matrix above.