### PR TITLE
Tighten TLS roots and move DNS lookup off scheduler threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,9 @@
 /docs/build/
 /docs/Manifest.toml
 /Manifest.toml
+/Manifest-*.toml
 /aws-c-io
 /deps/usr/
 /deps/deps.jl
 /echo_trim_safe
 /echo_trim_safe.exe
-Manifest.toml
-Manifest-v1.12.toml

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The main entry points are the exported `TCP` and `TLS` modules:
 
 ## Quick Start
 
-### Direct-address TCP
+### TCP
 
 ```julia
 using Reseau

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # Reseau.jl
 
-`Reseau.jl` is a pure-Julia networking stack organized in roughly the same layers as Go's `net`, `crypto/tls`, and `net/http` implementations.
+`Reseau.jl` is a pure-Julia networking transport stack organized in roughly the
+same layers as Go's `runtime`, `internal/poll`, `net`, and `crypto/tls`
+packages.
 
-Today the package includes:
-- cross-platform event-loop backends for macOS (`kqueue`), Linux (`epoll`), and Windows (`IOCP`)
+Reseau owns:
+
+- cross-platform event-loop backends for macOS (`kqueue`), Linux (`epoll`),
+  and Windows (`IOCP`)
 - low-level socket operations and internal poll/runtime plumbing
 - TCP connections and listeners
-- host resolution + dialing/listening helpers
-- TLS client/server support
-- HTTP/1.1 and HTTP/2 client/server support
-- precompile and `--trim=safe` compile workloads in the test suite
+- host parsing, resolution, and timeout-aware dialing
+- TLS clients and listeners
+- precompile and `--trim=safe` validation in the test suite
 
-The public API is intentionally layered. Most users will spend their time in:
-- `Reseau.TCP`
-- `Reseau.HostResolvers`
-- `Reseau.TLS`
-- `Reseau.HTTP`
+HTTP.jl 2.0 is built on top of this transport stack. If you want HTTP clients,
+servers, WebSockets, or HTTP/2, use HTTP.jl on top of Reseau.
 
 ## Installation
 
@@ -24,226 +24,165 @@ using Pkg
 Pkg.add("Reseau")
 ```
 
-For development:
+## Main Entry Points
 
-```julia
-julia --project=. -e 'using Pkg; Pkg.instantiate()'
-julia --project=. -e 'using Pkg; Pkg.test()'
-```
+The public API is intentionally module-qualified:
 
-## Package Layout
-
-- `Reseau.EventLoops`: platform event-loop backends (`kqueue` / `epoll` / `IOCP`)
-- `Reseau.SocketOps`: raw socket syscalls, sockaddr helpers, and platform quirks
-- `Reseau.IOPoll`: internal poll-descriptor and deadline layer
-- `Reseau.TCP`: TCP endpoints, `Conn`, `Listener`, deadlines, close semantics
-- `Reseau.HostResolvers`: `host:port` parsing, `getaddrinfo`, Happy Eyeballs-style connect orchestration
-- `Reseau.TLS`: TLS connections/listeners built on top of `TCP`
-- `Reseau.HTTP`: HTTP core types, HTTP/1.1, HPACK, HTTP/2, high-level client/server APIs
+- `Reseau.TCP` for concrete-address TCP work
+- `Reseau.HostResolvers` for string-address resolution and dialing
+- `Reseau.TLS` for TLS clients and listeners
 
 ## Quick Start
 
-### TCP
+### Direct-address TCP
 
 ```julia
 using Reseau
-const TCP = Reseau.TCP
 
-listener = TCP.listen(TCP.loopback_addr(0); backlog = 128)
-addr = TCP.addr(listener)
+listener = Reseau.TCP.listen(Reseau.TCP.loopback_addr(0); backlog = 128)
+addr = Reseau.TCP.addr(listener)
 
 server_task = errormonitor(Threads.@spawn begin
-    conn = TCP.accept!(listener)
-    buf = Vector{UInt8}(undef, 5)
-    read!(conn, buf)
-    write(conn, buf)
-    TCP.close!(conn)
+    conn = Reseau.TCP.accept!(listener)
+    try
+        buf = Vector{UInt8}(undef, 5)
+        read!(conn, buf)
+        write(conn, buf)
+    finally
+        Reseau.TCP.close!(conn)
+    end
 end)
 
-client = TCP.connect(addr)
+client = Reseau.TCP.connect(addr)
 write(client, collect(codeunits("hello")))
 reply = Vector{UInt8}(undef, 5)
 read!(client, reply)
 
-TCP.close!(client)
-TCP.close!(listener)
+Reseau.TCP.close!(client)
+Reseau.TCP.close!(listener)
 wait(server_task)
 ```
 
-### Host Resolution + Connect/Listen by Address String
+### String-address dialing
 
 ```julia
 using Reseau
-const ND = Reseau.HostResolvers
-const TCP = Reseau.TCP
 
-conn = ND.connect("tcp", "example.com:80")
-TCP.close!(conn)
+conn = Reseau.HostResolvers.connect("tcp", "example.com:80")
+Reseau.TCP.close!(conn)
 
-listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 64)
-println(TCP.addr(listener))
-TCP.close!(listener)
+listener = Reseau.HostResolvers.listen("tcp", "127.0.0.1:0"; backlog = 64)
+println(Reseau.TCP.addr(listener))
+Reseau.TCP.close!(listener)
 ```
 
-If you want custom resolution behavior, timeouts, or a static resolver:
+You can also take control of timeout, deadline, and resolver policy explicitly:
 
 ```julia
 using Reseau
-const ND = Reseau.HostResolvers
 
-resolver = ND.HostResolver(; timeout_ns = 2_000_000_000)
-conn = ND.connect(resolver, "tcp", "example.com:80")
+resolver = Reseau.HostResolvers.HostResolver(
+    timeout_ns = 2_000_000_000,
+    fallback_delay_ns = 300_000_000,
+)
+
+conn = Reseau.HostResolvers.connect(resolver, "tcp", "example.com:80")
 Reseau.TCP.close!(conn)
 ```
 
-### TLS
+### TLS client
 
 ```julia
 using Reseau
-const TLS = Reseau.TLS
 
-conn = TLS.connect("tcp", "www.google.com:443")
-state = TLS.connection_state(conn)
-println((state.handshake_complete, state.negotiated_protocol))
-TLS.close!(conn)
+conn = Reseau.TLS.connect(
+    "tcp",
+    "www.google.com:443";
+    alpn_protocols = ["h2", "http/1.1"],
+)
+
+state = Reseau.TLS.connection_state(conn)
+println((state.handshake_complete, state.alpn_protocol))
+Reseau.TLS.close!(conn)
 ```
 
-Server-side TLS listeners are built on top of `TCP` listeners:
+By default, outbound TLS verification uses `NetworkOptions.ca_roots_path()` when
+`ca_file` is omitted.
+
+### TLS listener
 
 ```julia
 using Reseau
-const TLS = Reseau.TLS
 
-config = TLS.Config(
+config = Reseau.TLS.Config(
     cert_file = "server.crt",
     key_file = "server.key",
 )
-listener = TLS.listen("tcp", "127.0.0.1:8443", config)
-conn = TLS.accept!(listener)
-TLS.close!(conn)
-TLS.close!(listener)
+
+listener = Reseau.TLS.listen("tcp", "127.0.0.1:8443", config)
+conn = Reseau.TLS.accept!(listener)
+
+Reseau.TLS.close!(conn)
+Reseau.TLS.close!(listener)
 ```
 
-### HTTP Client
+For verified client-certificate auth, provide `client_ca_file` explicitly:
 
 ```julia
 using Reseau
-const HTTP = Reseau.HTTP
 
-resp = HTTP.get("https://www.google.com")
-println(resp.status)
-println(length(resp.body))
-
-resp = HTTP.post(
-    "https://httpbin.org/post",
-    ["Content-Type" => "application/json"],
-    collect(codeunits("{\"hello\":true}"));
-    status_exception = false,
-)
-println(resp.status)
-```
-
-You can also create a reusable client explicitly:
-
-```julia
-using Reseau
-const HTTP = Reseau.HTTP
-
-client = HTTP.Client(; prefer_http2 = true)
-resp = HTTP.get("https://www.google.com"; client = client)
-close(client)
-```
-
-High-level request retries are enabled by default for replayable request bodies.
-You can tune them per call with `retry`, `retries`, `retry_non_idempotent`,
-`retry_if`, `respect_retry_after`, and `retry_bucket`:
-
-```julia
-using Reseau
-const HTTP = Reseau.HTTP
-
-resp = HTTP.get(
-    "https://example.com/health";
-    retries = 2,
-    retry_if = (attempt, err, req, resp) -> nothing,
+config = Reseau.TLS.Config(
+    cert_file = "server.crt",
+    key_file = "server.key",
+    client_auth = Reseau.TLS.ClientAuthMode.RequireAndVerifyClientCert,
+    client_ca_file = "client-ca.pem",
 )
 ```
 
-The built-in default is conservative: it retries replayable idempotent requests
-(`GET`, `HEAD`, `OPTIONS`, `TRACE`, `PUT`, `DELETE`) and requests carrying
-`Idempotency-Key`, honors `Retry-After` on retryable `429`/`503` responses, and
-does not automatically retry request read timeouts.
+## Why Use Reseau
 
-### HTTP Server
+- Deadlines and readiness behavior are first-class instead of layered on later.
+- Concrete-address and string-address dialing are both supported cleanly.
+- TLS lives in the same transport stack instead of hanging off a different socket
+  abstraction.
+- HTTP.jl 2.0 uses this exact transport layer, so networking semantics stay
+  aligned across the stack.
 
-```julia
-using Reseau
-const HTTP = Reseau.HTTP
+## Package Layout
 
-server = HTTP.serve!("127.0.0.1", 8080) do req
-    body = HTTP.BytesBody(collect(codeunits("hello from reseau")))
-    return HTTP.Response(200; body = body, content_length = 17)
-end)
+- `Reseau.EventLoops`: backend-specific pollers and timer scheduling
+- `Reseau.SocketOps`: raw socket syscalls, sockaddr helpers, and platform quirks
+- `Reseau.IOPoll`: internal poll-descriptor, deadline, and readiness machinery
+- `Reseau.TCP`: TCP endpoints, listeners, deadlines, and lifecycle operations
+- `Reseau.HostResolvers`: host/service parsing, resolution, and Happy
+  Eyeballs-style dialing
+- `Reseau.TLS`: TLS configuration, clients, listeners, and handshake behavior
 
-println(HTTP.server_addr(server))
+## Documentation
 
-# ... run requests ...
+- [TCP and Resolution](docs/src/tcp.md)
+- [TLS](docs/src/tls.md)
+- [Sockets Migration Guide](docs/src/migrate-sockets.md)
+- [API Reference](docs/src/reference.md)
 
-close(server)
-wait(server)
-```
+## Development
 
-Router-style handlers are available too:
+From a local checkout:
 
-```julia
-using Reseau
-const HTTP = Reseau.HTTP
-
-router = HTTP.Router()
-HTTP.register!(router, "GET", "/hello/{name}") do req
-    payload = "hello " * HTTP.getparam(req, "name")
-    bytes = collect(codeunits(payload))
-    return HTTP.Response(200; body = HTTP.BytesBody(bytes), content_length = length(bytes))
-end
-
-server = HTTP.serve!(router, "127.0.0.1", 8080)
-
-# cookie parsing middleware is available as HTTP.Handlers.cookie_middleware
-
-close(server)
-wait(server)
-```
-
-## Notes on Lower Layers
-
-`Reseau.EventLoops`, `Reseau.SocketOps`, and `Reseau.IOPoll` are real implementations, not stubs, and they are heavily tested. They exist primarily to support the higher-level TCP/TLS/HTTP stack, but they are also useful when you want to reason about readiness, deadlines, or platform-specific event-loop behavior.
-
-## Testing and Benchmarks
-
-Useful commands during development:
-
-```julia
-julia --project=. test/runtests.jl
-julia --project=. benchmarks/benchmarks.jl
+```sh
+julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate()'
+JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.test(; coverage=false)'
 ```
 
 The test suite also exercises:
+
 - precompile workloads
 - `--trim=safe` compile workloads
-- platform-specific event-loop/socket paths
+- platform-specific event-loop and socket paths
 
 ## Windows Compiled-Binary Note
 
-On Windows, fully compiled or `--trim=safe` executables should bundle dependent artifacts/JLLs so runtime libraries like OpenSSL are present next to the built executable.
-
-In practice, that means preferring a bundled build flow such as JuliaC's `--bundle` mode for Windows executables. The repository's trim-compile tests exercise this path directly in [`test/trim_compile_tests.jl`](/Users/jacob.quinn/.julia/dev/Reseau/test/trim_compile_tests.jl).
-
-## Status
-
-Reseau is a serious rewrite with production-oriented goals:
-- direct OS syscalls instead of libuv-mediated sockets
-- Go-inspired layering and semantics
-- broad test coverage, including trim-compile validation
-- cross-platform event-loop backends for macOS, Linux, and Windows
-
-The implementation is still evolving, but the intended direction is clear: a full networking stack in Julia with predictable semantics from raw sockets up through HTTP.
+On Windows, fully compiled or `--trim=safe` executables should bundle dependent
+artifacts and JLLs so runtime libraries like OpenSSL are available next to the
+built executable. The trim-compile tests in `test/trim_compile_tests.jl`
+exercise that path directly.

--- a/README.md
+++ b/README.md
@@ -10,12 +10,9 @@ Reseau owns:
   and Windows (`IOCP`)
 - low-level socket operations and internal poll/runtime plumbing
 - TCP connections and listeners
-- host parsing, resolution, and timeout-aware dialing
+- hostname-aware dialing and listening on top of the TCP stack
 - TLS clients and listeners
 - precompile and `--trim=safe` validation in the test suite
-
-HTTP.jl 2.0 is built on top of this transport stack. If you want HTTP clients,
-servers, WebSockets, or HTTP/2, use HTTP.jl on top of Reseau.
 
 ## Installation
 
@@ -26,11 +23,10 @@ Pkg.add("Reseau")
 
 ## Main Entry Points
 
-The public API is intentionally module-qualified:
+The main entry points are the exported `TCP` and `TLS` modules:
 
-- `Reseau.TCP` for concrete-address TCP work
-- `Reseau.HostResolvers` for string-address resolution and dialing
-- `Reseau.TLS` for TLS clients and listeners
+- `TCP` for TCP connections, listeners, deadlines, and string-address dialing
+- `TLS` for TLS clients and listeners
 
 ## Quick Start
 
@@ -39,27 +35,27 @@ The public API is intentionally module-qualified:
 ```julia
 using Reseau
 
-listener = Reseau.TCP.listen(Reseau.TCP.loopback_addr(0); backlog = 128)
-addr = Reseau.TCP.addr(listener)
+listener = TCP.listen(TCP.loopback_addr(0); backlog = 128)
+addr = TCP.addr(listener)
 
 server_task = errormonitor(Threads.@spawn begin
-    conn = Reseau.TCP.accept!(listener)
+    conn = TCP.accept!(listener)
     try
         buf = Vector{UInt8}(undef, 5)
         read!(conn, buf)
         write(conn, buf)
     finally
-        Reseau.TCP.close!(conn)
+        TCP.close!(conn)
     end
 end)
 
-client = Reseau.TCP.connect(addr)
+client = TCP.connect(addr)
 write(client, collect(codeunits("hello")))
 reply = Vector{UInt8}(undef, 5)
 read!(client, reply)
 
-Reseau.TCP.close!(client)
-Reseau.TCP.close!(listener)
+TCP.close!(client)
+TCP.close!(listener)
 wait(server_task)
 ```
 
@@ -68,26 +64,26 @@ wait(server_task)
 ```julia
 using Reseau
 
-conn = Reseau.HostResolvers.connect("tcp", "example.com:80")
-Reseau.TCP.close!(conn)
+conn = TCP.connect("example.com:80")
+TCP.close!(conn)
 
-listener = Reseau.HostResolvers.listen("tcp", "127.0.0.1:0"; backlog = 64)
-println(Reseau.TCP.addr(listener))
-Reseau.TCP.close!(listener)
+listener = TCP.listen("127.0.0.1:0"; backlog = 64)
+println(TCP.addr(listener))
+TCP.close!(listener)
 ```
 
-You can also take control of timeout, deadline, and resolver policy explicitly:
+The hostname/address-string behavior is available directly on `TCP.connect`,
+`TCP.listen`, and `TLS.connect`; you do not need to reach into the internal
+resolution layer for normal usage.
+
+You can also set deadlines directly on live connections:
 
 ```julia
 using Reseau
 
-resolver = Reseau.HostResolvers.HostResolver(
-    timeout_ns = 2_000_000_000,
-    fallback_delay_ns = 300_000_000,
-)
-
-conn = Reseau.HostResolvers.connect(resolver, "tcp", "example.com:80")
-Reseau.TCP.close!(conn)
+conn = TCP.connect("example.com:80")
+TCP.set_read_deadline!(conn, time_ns() + 5_000_000_000)
+TCP.close!(conn)
 ```
 
 ### TLS client
@@ -95,15 +91,14 @@ Reseau.TCP.close!(conn)
 ```julia
 using Reseau
 
-conn = Reseau.TLS.connect(
-    "tcp",
+conn = TLS.connect(
     "www.google.com:443";
     alpn_protocols = ["h2", "http/1.1"],
 )
 
-state = Reseau.TLS.connection_state(conn)
+state = TLS.connection_state(conn)
 println((state.handshake_complete, state.alpn_protocol))
-Reseau.TLS.close!(conn)
+TLS.close!(conn)
 ```
 
 By default, outbound TLS verification uses `NetworkOptions.ca_roots_path()` when
@@ -114,16 +109,16 @@ By default, outbound TLS verification uses `NetworkOptions.ca_roots_path()` when
 ```julia
 using Reseau
 
-config = Reseau.TLS.Config(
+config = TLS.Config(
     cert_file = "server.crt",
     key_file = "server.key",
 )
 
-listener = Reseau.TLS.listen("tcp", "127.0.0.1:8443", config)
-conn = Reseau.TLS.accept!(listener)
+listener = TLS.listen("tcp", "127.0.0.1:8443", config)
+conn = TLS.accept!(listener)
 
-Reseau.TLS.close!(conn)
-Reseau.TLS.close!(listener)
+TLS.close!(conn)
+TLS.close!(listener)
 ```
 
 For verified client-certificate auth, provide `client_ca_file` explicitly:
@@ -131,10 +126,10 @@ For verified client-certificate auth, provide `client_ca_file` explicitly:
 ```julia
 using Reseau
 
-config = Reseau.TLS.Config(
+config = TLS.Config(
     cert_file = "server.crt",
     key_file = "server.key",
-    client_auth = Reseau.TLS.ClientAuthMode.RequireAndVerifyClientCert,
+    client_auth = TLS.ClientAuthMode.RequireAndVerifyClientCert,
     client_ca_file = "client-ca.pem",
 )
 ```
@@ -142,21 +137,18 @@ config = Reseau.TLS.Config(
 ## Why Use Reseau
 
 - Deadlines and readiness behavior are first-class instead of layered on later.
-- Concrete-address and string-address dialing are both supported cleanly.
+- Concrete-address and hostname-based dialing both work through the same `TCP`
+  and `TLS` entrypoints.
 - TLS lives in the same transport stack instead of hanging off a different socket
   abstraction.
-- HTTP.jl 2.0 uses this exact transport layer, so networking semantics stay
-  aligned across the stack.
 
 ## Package Layout
 
 - `Reseau.EventLoops`: backend-specific pollers and timer scheduling
 - `Reseau.SocketOps`: raw socket syscalls, sockaddr helpers, and platform quirks
 - `Reseau.IOPoll`: internal poll-descriptor, deadline, and readiness machinery
-- `Reseau.TCP`: TCP endpoints, listeners, deadlines, and lifecycle operations
-- `Reseau.HostResolvers`: host/service parsing, resolution, and Happy
-  Eyeballs-style dialing
-- `Reseau.TLS`: TLS configuration, clients, listeners, and handshake behavior
+- `TCP`: TCP endpoints, listeners, deadlines, and hostname-aware dial/listen helpers
+- `TLS`: TLS configuration, clients, listeners, and handshake behavior
 
 ## Documentation
 

--- a/src/5_host_resolvers.jl
+++ b/src/5_host_resolvers.jl
@@ -384,6 +384,8 @@ end
 function _native_getaddrinfo(hostname::AbstractString; flags::Cint = Cint(0))::Vector{TCP.SocketEndpoint}
     SocketOps.ensure_winsock!()
     addresses = TCP.SocketEndpoint[]
+    hostname_s = String(hostname)
+    null_service = Ptr{UInt8}(C_NULL)
     hints = Ref{_AddrInfo}()
     hints_ptr = Base.unsafe_convert(Ptr{_AddrInfo}, hints)
     Base.Libc.memset(hints_ptr, 0, sizeof(_AddrInfo))
@@ -394,24 +396,27 @@ function _native_getaddrinfo(hostname::AbstractString; flags::Cint = Cint(0))::V
         unsafe_store!(Ptr{Cint}(hints_bytes + fieldoffset(_AddrInfo, 3)), _SOCK_STREAM)
     end
     result_ptr = Ref{Ptr{_AddrInfo}}(C_NULL)
-    ret = GC.@preserve hints begin
-        @static if Sys.iswindows()
-            @gcsafe_ccall "Ws2_32".getaddrinfo(
-                String(hostname)::Cstring,
-                C_NULL::Cstring,
-                hints_ptr::Ptr{_AddrInfo},
-                result_ptr::Ptr{Ptr{_AddrInfo}},
-            )::Cint
-        else
-            @gcsafe_ccall getaddrinfo(
-                String(hostname)::Cstring,
-                C_NULL::Cstring,
-                hints_ptr::Ptr{_AddrInfo},
-                result_ptr::Ptr{Ptr{_AddrInfo}},
-            )::Cint
-        end
+    # `getaddrinfo` can block inside the system resolver stack. Run it on Julia's
+    # libuv worker pool so hostname resolution does not occupy a Julia scheduler
+    # thread while callers wait on timeout/deadline machinery.
+    ret = @static if Sys.iswindows()
+        @threadcall((:getaddrinfo, "Ws2_32"), Cint,
+            (Cstring, Cstring, Ptr{_AddrInfo}, Ptr{Ptr{_AddrInfo}}),
+            hostname_s,
+            null_service,
+            hints,
+            result_ptr,
+        )
+    else
+        @threadcall(:getaddrinfo, Cint,
+            (Cstring, Cstring, Ptr{_AddrInfo}, Ptr{Ptr{_AddrInfo}}),
+            hostname_s,
+            null_service,
+            hints,
+            result_ptr,
+        )
     end
-    ret == 0 || _addr_error("lookup failed: $(_gai_error_string(ret))", String(hostname))
+    ret == 0 || _addr_error("lookup failed: $(_gai_error_string(ret))", hostname_s)
     try
         current = result_ptr[]
         while current != C_NULL
@@ -1324,9 +1329,10 @@ function _resolve_with_deadline(
     done = Ref(false)
     timed_out = Ref(false)
     result_ref = Ref{Union{Nothing, Vector{TCP.SocketEndpoint}, Exception}}(nothing)
-    # Resolution still relies on Julia tasks + Timer rather than the lower-level
-    # poller timer heap. That is acceptable here because DNS resolution is not
-    # currently driven by the socket event loop itself.
+    # Resolution ownership still relies on a Julia task + Timer handoff rather
+    # than the lower-level poller timer heap. The raw blocking system lookup now
+    # runs on Julia's `@threadcall` worker pool, but timeout/cancellation
+    # semantics remain caller-local for now.
     timer = Timer(timeout_s) do _
         lock(mtx)
         try

--- a/src/5_host_resolvers.jl
+++ b/src/5_host_resolvers.jl
@@ -18,6 +18,7 @@ resolution logic remains factored into its own file.
 module HostResolvers
 
 using ..Reseau: @gcsafe_ccall
+using ..Reseau.EventLoops
 using ..Reseau.SocketOps
 using ..Reseau.IOPoll
 
@@ -1314,6 +1315,37 @@ function _connect_deadline_ns(d::HostResolver)::Int64
     return _min_nonzero(timeout_deadline, d.deadline_ns)
 end
 
+function _wait_for_timer!(timer::EventLoops.TimerState)::Bool
+    while true
+        reason = EventLoops.pollwait!(timer.waiter)
+        reason == EventLoops.PollWakeReason.READY && return true
+        (@atomic :acquire timer.closed) && return false
+        (@atomic :acquire timer.deadline_ns) == 0 && return true
+    end
+end
+
+function _spawn_timer_task(f::F, deadline_ns::Int64) where {F}
+    timer = EventLoops.TimerState(deadline_ns, Int64(0))
+    EventLoops.schedule_timer!(timer, deadline_ns) || return nothing, nothing
+    task = errormonitor(Threads.@spawn begin
+        _wait_for_timer!(timer) || return nothing
+        f()
+        return nothing
+    end)
+    return timer, task
+end
+
+function _close_timer_task!(
+        timer::Union{Nothing, EventLoops.TimerState},
+        task::Union{Nothing, Task},
+    )
+    timer === nothing && return nothing
+    EventLoops._close_timer!(timer)
+    task === nothing && return nothing
+    wait(task)
+    return nothing
+end
+
 function _resolve_with_deadline(
         d::HostResolver,
         network::AbstractString,
@@ -1323,17 +1355,12 @@ function _resolve_with_deadline(
     deadline_ns == 0 && return resolve_tcp_addrs(d.resolver, network, address; op = :connect, policy = d.policy)
     now_ns = Int64(time_ns())
     now_ns >= deadline_ns && throw(DNSTimeoutError(String(address)))
-    timeout_s = (deadline_ns - now_ns) / 1.0e9
     mtx = ReentrantLock()
     condition = Threads.Condition(mtx)
     done = Ref(false)
     timed_out = Ref(false)
     result_ref = Ref{Union{Nothing, Vector{TCP.SocketEndpoint}, Exception}}(nothing)
-    # Resolution ownership still relies on a Julia task + Timer handoff rather
-    # than the lower-level poller timer heap. The raw blocking system lookup now
-    # runs on Julia's `@threadcall` worker pool, but timeout/cancellation
-    # semantics remain caller-local for now.
-    timer = Timer(timeout_s) do _
+    timer, timer_task = _spawn_timer_task(deadline_ns) do
         lock(mtx)
         try
             done[] && return nothing
@@ -1369,7 +1396,7 @@ function _resolve_with_deadline(
         end
     finally
         unlock(mtx)
-        close(timer)
+        _close_timer_task!(timer, timer_task)
     end
     timed_out[] && throw(DNSTimeoutError(String(address)))
     result = result_ref[]
@@ -1553,7 +1580,7 @@ function _resolve_parallel(
     # This is the Happy Eyeballs-style stagger: start one address family first,
     # then launch the fallback family if the primary path has not succeeded
     # quickly enough.
-    fallback_timer = Timer(delay_ns / 1.0e9) do _
+    fallback_timer, fallback_timer_task = _spawn_timer_task(Int64(time_ns()) + delay_ns) do
         _emit_event!(:fallback_timer)
     end
     primary_done = false
@@ -1583,10 +1610,7 @@ function _resolve_parallel(
                 end
                 if !fallback_started && !(@atomic :acquire state.done)
                     fallback_started = true
-                    try
-                        close(fallback_timer)
-                    catch
-                    end
+                    _close_timer_task!(fallback_timer, fallback_timer_task)
                     _start_racer(false, fallbacks)
                 end
             else
@@ -1603,10 +1627,7 @@ function _resolve_parallel(
             end
         end
     finally
-        try
-            close(fallback_timer)
-        catch
-        end
+        _close_timer_task!(fallback_timer, fallback_timer_task)
         try
             close(events)
         catch

--- a/src/6_tls.jl
+++ b/src/6_tls.jl
@@ -142,9 +142,10 @@ Keyword arguments:
 - `client_auth`: server-side client certificate policy.
 - `cert_file` / `key_file`: PEM-encoded certificate chain and private key. Servers must
   provide both; clients may provide both for mutual TLS.
-- `ca_file`: PEM bundle used to verify remote servers. When omitted, the platform/OpenSSL
-  defaults are used when possible.
-- `client_ca_file`: PEM bundle used by servers to verify client certificates.
+- `ca_file`: CA bundle or hashed CA directory used to verify remote servers. When omitted,
+  client verification uses `NetworkOptions.ca_roots_path()`.
+- `client_ca_file`: CA bundle or hashed CA directory used by servers to verify client
+  certificates. This is required for server configs that verify presented client certs.
 - `alpn_protocols`: ordered ALPN protocol preference list.
 - `handshake_timeout_ns`: optional cap, in monotonic nanoseconds, applied only while the
   handshake is running. Existing transport deadlines still win if they are earlier.
@@ -240,16 +241,39 @@ end
     ca_path === nothing && return nothing
     ca_path_s = String(ca_path)
     isempty(ca_path_s) && return nothing
-    isfile(ca_path_s) || return nothing
+    ispath(ca_path_s) || return nothing
     return ca_path_s
+end
+
+@inline function _server_needs_verified_client_ca(config::Config)::Bool
+    mode = config.client_auth
+    return mode == ClientAuthMode.VerifyClientCertIfGiven || mode == ClientAuthMode.RequireAndVerifyClientCert
 end
 
 @inline function _effective_ca_file(config::Config; is_server::Bool)::Union{Nothing, String}
     if is_server
-        return config.client_ca_file
+        return _server_needs_verified_client_ca(config) ? config.client_ca_file : nothing
     end
     config.ca_file !== nothing && return config.ca_file::String
     return _default_ca_file_path()
+end
+
+function _load_verify_locations!(ctx::Ptr{Cvoid}, ca_path::String)
+    ok = if isdir(ca_path)
+        @gcsafe_ccall _LIBSSL.SSL_CTX_load_verify_locations(
+            ctx::Ptr{Cvoid},
+            C_NULL::Cstring,
+            ca_path::Cstring,
+        )::Cint
+    else
+        @gcsafe_ccall _LIBSSL.SSL_CTX_load_verify_locations(
+            ctx::Ptr{Cvoid},
+            ca_path::Cstring,
+            C_NULL::Cstring,
+        )::Cint
+    end
+    ok == 1 || throw(_make_tls_error("SSL_CTX_load_verify_locations", Int32(ok)))
+    return nothing
 end
 
 """
@@ -532,11 +556,16 @@ function _validate_config(config::Config; is_server::Bool)
     end
     if config.ca_file !== nothing
         ca_path = config.ca_file::String
-        isfile(ca_path) || throw(ConfigError("CA file not found: $ca_path"))
+        ispath(ca_path) || throw(ConfigError("CA roots path not found: $ca_path"))
     end
     if config.client_ca_file !== nothing
         client_ca_path = config.client_ca_file::String
-        isfile(client_ca_path) || throw(ConfigError("client CA file not found: $client_ca_path"))
+        ispath(client_ca_path) || throw(ConfigError("client CA roots path not found: $client_ca_path"))
+    elseif is_server && _server_needs_verified_client_ca(config)
+        throw(ConfigError("server TLS with verified client auth requires `client_ca_file`"))
+    end
+    if !is_server && config.verify_peer && config.ca_file === nothing
+        _default_ca_file_path() === nothing && throw(ConfigError("client TLS verification requires a CA roots path from NetworkOptions.ca_roots_path()"))
     end
     if config.min_version !== nothing && config.max_version !== nothing
         (config.min_version::UInt16) <= (config.max_version::UInt16) || throw(ConfigError("min_version must be <= max_version"))
@@ -671,25 +700,14 @@ function _ssl_ctx_new(config::Config; is_server::Bool)::Ptr{Cvoid}
             _set_ctx_max_version!(ctx, config.max_version::UInt16)
         end
         need_verify_paths = if is_server
-            config.client_auth != ClientAuthMode.NoClientCert
+            _server_needs_verified_client_ca(config)
         else
             config.verify_peer
         end
         if need_verify_paths
             ca_path = _effective_ca_file(config; is_server = is_server)
-            if ca_path === nothing
-                ok = @gcsafe_ccall _LIBSSL.SSL_CTX_set_default_verify_paths(
-                    ctx::Ptr{Cvoid},
-                )::Cint
-                ok == 1 || throw(_make_tls_error("SSL_CTX_set_default_verify_paths", Int32(ok)))
-            else
-                ok = @gcsafe_ccall _LIBSSL.SSL_CTX_load_verify_locations(
-                    ctx::Ptr{Cvoid},
-                    ca_path::Cstring,
-                    C_NULL::Cstring,
-                )::Cint
-                ok == 1 || throw(_make_tls_error("SSL_CTX_load_verify_locations", Int32(ok)))
-            end
+            ca_path === nothing && throw(ConfigError("no CA roots path available for TLS verification"))
+            _load_verify_locations!(ctx, ca_path::String)
         end
         if is_server
             cert_file = config.cert_file::String

--- a/src/Reseau.jl
+++ b/src/Reseau.jl
@@ -10,6 +10,8 @@ The package is organized in layers:
 """
 module Reseau
 
+export TCP, TLS
+
 include("0_memory_compat.jl")
 include("0_gcsafe_ccall_compat.jl")
 include("1_eventloops.jl")

--- a/test/host_resolvers_tests.jl
+++ b/test/host_resolvers_tests.jl
@@ -12,6 +12,20 @@ struct _SlowResolver <: ND.AbstractResolver
     addrs::Vector{NC.SocketEndpoint}
 end
 
+struct _ThreadcallResolver <: ND.AbstractResolver
+    delay_ms::UInt32
+    addrs::Vector{NC.SocketEndpoint}
+end
+
+function _nd_blocking_sleep_ms(delay_ms::UInt32)
+    @static if Sys.iswindows()
+        Base.@threadcall((:Sleep, "kernel32"), Cvoid, (UInt32,), delay_ms)
+    else
+        Base.@threadcall(:usleep, Cint, (Cuint,), Cuint(delay_ms * UInt32(1000)))
+    end
+    return nothing
+end
+
 function ND.resolve_tcp_addrs(
         resolver::_SlowResolver,
         network::AbstractString,
@@ -24,6 +38,21 @@ function ND.resolve_tcp_addrs(
     _ = op
     _ = policy
     sleep(resolver.delay_s)
+    return copy(resolver.addrs)
+end
+
+function ND.resolve_tcp_addrs(
+        resolver::_ThreadcallResolver,
+        network::AbstractString,
+        address::AbstractString;
+        op::Symbol = :connect,
+        policy::ND.ResolverPolicy = ND.ResolverPolicy(),
+    )::Vector{NC.SocketEndpoint}
+    _ = network
+    _ = address
+    _ = op
+    _ = policy
+    _nd_blocking_sleep_ms(resolver.delay_ms)
     return copy(resolver.addrs)
 end
 
@@ -530,6 +559,20 @@ else
                 @test timeout_err.err isa ND.DNSTimeoutError
             end
             @test elapsed_ms < 1_000.0
+            threadcall_resolver = _ThreadcallResolver(UInt32(250), NC.SocketEndpoint[NC.loopback_addr(1)])
+            threadcall_started_ns = time_ns()
+            threadcall_timeout_err = try
+                NC.connect("tcp", "threadcall.local:80"; timeout_ns = 20_000_000, resolver = threadcall_resolver)
+                nothing
+            catch ex
+                ex
+            end
+            threadcall_elapsed_ms = (time_ns() - threadcall_started_ns) / 1.0e6
+            @test threadcall_timeout_err isa ND.DNSOpError
+            if threadcall_timeout_err isa ND.DNSOpError
+                @test threadcall_timeout_err.err isa ND.DNSTimeoutError
+            end
+            @test threadcall_elapsed_ms < 1_000.0
             empty_net_err = try
                 ND.resolve_tcp_addrs("", "127.0.0.1:1")
                 nothing

--- a/test/host_resolvers_trim_safe.jl
+++ b/test/host_resolvers_trim_safe.jl
@@ -4,6 +4,27 @@ const ND = Reseau.HostResolvers
 const NC = Reseau.TCP
 const EL = Reseau.EventLoops
 
+struct _TrimResolver <: ND.AbstractResolver
+    addr::NC.SocketEndpoint
+end
+
+function ND.lookup_port(::_TrimResolver, network::AbstractString, service::AbstractString)::Int
+    _ = network
+    return parse(Int, service)
+end
+
+function ND._resolve_host_ips(resolver::_TrimResolver, network::AbstractString, host::AbstractString)::Vector{NC.SocketEndpoint}
+    _ = network
+    host == "trim.local" || throw(ND.AddressError("unknown host", String(host)))
+    addr = resolver.addr
+    if addr isa NC.SocketAddrV4
+        v4 = addr::NC.SocketAddrV4
+        return NC.SocketEndpoint[NC.SocketAddrV4(v4.ip, 0)]
+    end
+    v6 = addr::NC.SocketAddrV6
+    return NC.SocketEndpoint[NC.SocketAddrV6(v6.ip, 0; scope_id = Int(v6.scope_id))]
+end
+
 function _trim_read_exact!(conn::NC.Conn, buf::Vector{UInt8})::Int
     offset = 0
     while offset < length(buf)
@@ -22,9 +43,10 @@ function run_host_resolvers_trim_sample()::Nothing
     client::Union{Nothing, NC.Conn} = nothing
     server::Union{Nothing, NC.Conn} = nothing
     try
-        listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 16)
-        laddr = NC.addr(listener)
-        client = ND.connect("tcp", "127.0.0.1:$(Int((laddr::NC.SocketAddrV4).port))")
+        listener = NC.listen(NC.loopback_addr(0); backlog = 16)
+        laddr = NC.addr(listener)::NC.SocketAddrV4
+        resolver = _TrimResolver(NC.loopback_addr(Int(laddr.port)))
+        client = ND.connect("tcp", "trim.local:$(Int(laddr.port))"; resolver = resolver, fallback_delay_ns = -1)
         server = NC.accept!(listener)
         payload = UInt8[0x66, 0x67, 0x68]
         recv_buf = Vector{UInt8}(undef, length(payload))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,9 @@ using Reseau
 _log_test_progress("[runtests] loaded Reseau")
 _log_test_progress("[runtests] julia threads: $(Threads.nthreads())")
 
+@test TCP === Reseau.TCP
+@test TLS === Reseau.TLS
+
 function _include_with_progress(path::AbstractString)
     _log_test_progress("[runtests] include START: $(path)")
     include(path)

--- a/test/tls_tests.jl
+++ b/test/tls_tests.jl
@@ -91,26 +91,39 @@ else
                     nothing
                 else
                     path_s = String(path)
-                    isempty(path_s) || !isfile(path_s) ? nothing : path_s
+                    isempty(path_s) || !ispath(path_s) ? nothing : path_s
                 end
             catch
                 nothing
             end
             if expected_default_ca !== nothing
                 @test default_ca == expected_default_ca
-                @test isfile(default_ca::String)
+                @test ispath(default_ca::String)
             else
                 @test default_ca === nothing
             end
             @test TL._effective_ca_file(cfg_default; is_server = false) == default_ca
             explicit_ca_cfg = TL.Config(server_name = "localhost", ca_file = _TLS_CERT_PATH)
             @test TL._effective_ca_file(explicit_ca_cfg; is_server = false) == _TLS_CERT_PATH
+            @test TL._effective_ca_file(TL.Config(verify_peer = false, client_auth = TL.ClientAuthMode.RequestClientCert); is_server = true) === nothing
+            verified_client_auth_cfg = TL.Config(
+                verify_peer = false,
+                client_auth = TL.ClientAuthMode.VerifyClientCertIfGiven,
+                client_ca_file = _TLS_CERT_PATH,
+            )
+            @test TL._effective_ca_file(verified_client_auth_cfg; is_server = true) == _TLS_CERT_PATH
             @test_throws TL.ConfigError TL.Config(cert_file = _TLS_CERT_PATH)
             @test_throws TL.ConfigError TL.Config(key_file = _TLS_KEY_PATH)
             @test_throws TL.ConfigError TL.Config(handshake_timeout_ns = -1)
             @test_throws TL.ConfigError TL._validate_config(TL.Config(min_version = TL.TLS1_3_VERSION, max_version = TL.TLS1_2_VERSION); is_server = false)
             @test_throws TL.ConfigError TL._validate_config(TL.Config(verify_peer = false, ca_file = joinpath(@__DIR__, "missing-ca.pem")); is_server = false)
             @test_throws TL.ConfigError TL._validate_config(TL.Config(verify_peer = false, client_ca_file = joinpath(@__DIR__, "missing-client-ca.pem")); is_server = true)
+            @test_throws TL.ConfigError TL._validate_config(TL.Config(
+                cert_file = _TLS_CERT_PATH,
+                key_file = _TLS_KEY_PATH,
+                verify_peer = false,
+                client_auth = TL.ClientAuthMode.VerifyClientCertIfGiven,
+            ); is_server = true)
             @test_throws TL.ConfigError TL.listen("tcp", "127.0.0.1:0", TL.Config(verify_peer = false))
             EL.shutdown!()
             listener = nothing

--- a/test/tls_trim_safe.jl
+++ b/test/tls_trim_safe.jl
@@ -2,7 +2,6 @@ using Reseau
 
 const TL = Reseau.TLS
 const NC = Reseau.TCP
-const ND = Reseau.HostResolvers
 const EL = Reseau.EventLoops
 
 const _TLS_CERT_PATH = joinpath(@__DIR__, "resources", "unittests.crt")
@@ -16,9 +15,9 @@ function run_tls_trim_sample()::Nothing
     client_tls::Union{Nothing, TL.Conn} = nothing
     server_tls::Union{Nothing, TL.Conn} = nothing
     try
-        listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
+        listener = NC.listen(NC.loopback_addr(0); backlog = 8)
         laddr = NC.addr(listener)::NC.SocketAddrV4
-        client_tcp = ND.connect("tcp", "127.0.0.1:$(Int(laddr.port))")
+        client_tcp = NC.connect(NC.loopback_addr(Int(laddr.port)))
         server_tcp = NC.accept!(listener)
         client_cfg = TL.Config(verify_peer = false, server_name = "localhost", handshake_timeout_ns = 1_000_000_000)
         server_cfg = TL.Config(


### PR DESCRIPTION
## Summary
- tighten TLS CA-root handling so client verification follows `NetworkOptions` and verified server client auth requires explicit `client_ca_file`
- refresh the README/front page and keep the repo root manifestless for release-style checkouts
- move blocking `getaddrinfo` calls onto Julia's `@threadcall` worker pool and add coverage for timeout behavior
- keep trim-safe coverage green by routing the trim workloads through verifier-friendly concrete transport/resolver paths

## Testing
- `JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'`
- `JULIA_NUM_THREADS=1 julia +1.10 --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'`
