### PR TITLE
refactor(api): align TCP and TLS names with Base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,23 +63,31 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: read
+      statuses: write
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1.12'
       - uses: julia-actions/cache@v2
-      - run: |
+      - name: Install docs dependencies
+        run: |
           julia --project=docs --startup-file=no --history-file=no -e '
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
-      - run: |
+      - name: Run docstring doctests
+        run: |
           julia --project=docs --startup-file=no --history-file=no -e '
             using Documenter: doctest
             using Reseau
             doctest(Reseau)'
-      - run: julia --project=docs --startup-file=no --history-file=no docs/make.jl
+      - name: Build and deploy docs
+        run: julia --project=docs --startup-file=no --history-file=no docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/previews-cleanup.yml
+++ b/.github/workflows/previews-cleanup.yml
@@ -4,25 +4,30 @@ on:
   pull_request:
     types: [closed]
 
+concurrency:
+  group: doc-preview-cleanup
+  cancel-in-progress: false
+
 jobs:
   doc-preview-cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
 
-      - name: Delete preview and history
+      - name: Delete preview and history + push changes
         run: |
-            git config user.name "Documenter.jl"
-            git config user.email "documenter@juliadocs.github.io"
-            git rm -rf "previews/PR$PRNUM"
-            git commit -m "delete preview"
-            git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+          if [ -d "${preview_dir}" ]; then
+              git config user.name "Documenter.jl"
+              git config user.email "documenter@juliadocs.github.io"
+              git rm -rf "${preview_dir}"
+              git commit -m "delete preview"
+              git branch gh-pages-new "$(echo "delete history" | git commit-tree "HEAD^{tree}")"
+              git push --force origin gh-pages-new:gh-pages
+          fi
         env:
-            PRNUM: ${{ github.event.number }}
-
-      - name: Push changes
-        run: |
-            git push --force origin gh-pages-new:gh-pages
+          preview_dir: previews/PR${{ github.event.number }}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 same layers as Go's `runtime`, `internal/poll`, `net`, and `crypto/tls`
 packages.
 
+[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliaservices.github.io/Reseau.jl/stable)
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliaservices.github.io/Reseau.jl/dev)
+
 Reseau owns:
 
 - cross-platform event-loop backends for macOS (`kqueue`), Linux (`epoll`),
@@ -152,10 +155,13 @@ config = TLS.Config(
 
 ## Documentation
 
-- [TCP](docs/src/tcp.md)
-- [TLS](docs/src/tls.md)
-- [Sockets Migration Guide](docs/src/migrate-sockets.md)
-- [API Reference](docs/src/reference.md)
+- [Stable docs](https://juliaservices.github.io/Reseau.jl/stable)
+- [Dev docs](https://juliaservices.github.io/Reseau.jl/dev)
+- [TCP](https://juliaservices.github.io/Reseau.jl/stable/tcp/)
+- [TLS](https://juliaservices.github.io/Reseau.jl/stable/tls/)
+- [Name Resolution](https://juliaservices.github.io/Reseau.jl/stable/resolution/)
+- [Sockets Migration Guide](https://juliaservices.github.io/Reseau.jl/stable/migrate-sockets/)
+- [API Reference](https://juliaservices.github.io/Reseau.jl/stable/reference/)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ listener = TCP.listen(TCP.loopback_addr(0); backlog = 128)
 addr = TCP.addr(listener)
 
 server_task = errormonitor(Threads.@spawn begin
-    conn = TCP.accept!(listener)
+    conn = TCP.accept(listener)
     try
         buf = Vector{UInt8}(undef, 5)
         read!(conn, buf)
         write(conn, buf)
     finally
-        TCP.close!(conn)
+        close(conn)
     end
 end)
 
@@ -54,8 +54,8 @@ write(client, collect(codeunits("hello")))
 reply = Vector{UInt8}(undef, 5)
 read!(client, reply)
 
-TCP.close!(client)
-TCP.close!(listener)
+close(client)
+close(listener)
 wait(server_task)
 ```
 
@@ -65,11 +65,11 @@ wait(server_task)
 using Reseau
 
 conn = TCP.connect("example.com:80")
-TCP.close!(conn)
+close(conn)
 
 listener = TCP.listen("127.0.0.1:0"; backlog = 64)
 println(TCP.addr(listener))
-TCP.close!(listener)
+close(listener)
 ```
 
 The hostname/address-string behavior is available directly on `TCP.connect`,
@@ -83,7 +83,7 @@ using Reseau
 
 conn = TCP.connect("example.com:80")
 TCP.set_read_deadline!(conn, time_ns() + 5_000_000_000)
-TCP.close!(conn)
+close(conn)
 ```
 
 ### TLS client
@@ -98,7 +98,7 @@ conn = TLS.connect(
 
 state = TLS.connection_state(conn)
 println((state.handshake_complete, state.alpn_protocol))
-TLS.close!(conn)
+close(conn)
 ```
 
 By default, outbound TLS verification uses `NetworkOptions.ca_roots_path()` when
@@ -115,10 +115,10 @@ config = TLS.Config(
 )
 
 listener = TLS.listen("tcp", "127.0.0.1:8443", config)
-conn = TLS.accept!(listener)
+conn = TLS.accept(listener)
 
-TLS.close!(conn)
-TLS.close!(listener)
+close(conn)
+close(listener)
 ```
 
 For verified client-certificate auth, provide `client_ca_file` explicitly:
@@ -152,7 +152,7 @@ config = TLS.Config(
 
 ## Documentation
 
-- [TCP and Resolution](docs/src/tcp.md)
+- [TCP](docs/src/tcp.md)
 - [TLS](docs/src/tls.md)
 - [Sockets Migration Guide](docs/src/migrate-sockets.md)
 - [API Reference](docs/src/reference.md)

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Reseau = "802f3686-a58f-41ce-bb0c-3c43c75bba36"
 
 [compat]
-Documenter = "1"
+Documenter = "1.17"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,21 +1,31 @@
 using Documenter, Reseau
 
+DocMeta.setdocmeta!(Reseau, :DocTestSetup, :(using Reseau); recursive = true)
+
 makedocs(
     sitename = "Reseau.jl",
-    format = Documenter.HTML(),
     modules = [Reseau],
+    format = Documenter.HTML(
+        prettyurls = true,
+        canonical = "https://juliaservices.github.io/Reseau.jl/stable",
+        collapselevel = 2,
+        edit_link = "main",
+        description = "Pure-Julia TCP and TLS transport stack with deadline-aware I/O, host-aware dialing, and Go-inspired networking architecture.",
+    ),
     pages = [
         "Home" => "index.md",
         "TCP" => "tcp.md",
         "TLS" => "tls.md",
+        "Name Resolution" => "resolution.md",
         "Sockets Migration Guide" => "migrate-sockets.md",
         "API Reference" => "reference.md",
     ],
-    clean = true,
-    checkdocs = :none,
+    pagesonly = true,
+    checkdocs = :exports,
 )
 
 deploydocs(
     repo = "github.com/JuliaServices/Reseau.jl.git",
+    devbranch = "main",
     push_preview = true,
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,7 +6,7 @@ makedocs(
     modules = [Reseau],
     pages = [
         "Home" => "index.md",
-        "TCP and Resolution" => "tcp.md",
+        "TCP" => "tcp.md",
         "TLS" => "tls.md",
         "Sockets Migration Guide" => "migrate-sockets.md",
         "API Reference" => "reference.md",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,17 +1,16 @@
 # Reseau.jl
 
-Reseau.jl is the lower-level networking stack that now sits under the extracted
-HTTP.jl 2.0 package.
+`Reseau.jl` is a pure-Julia networking transport stack organized around the
+same broad layers as Go's `runtime`, `internal/poll`, `net`, and `crypto/tls`
+packages.
 
-After the split, Reseau owns:
+Reseau owns:
 
-- event loop and poller behavior
-- non-blocking socket operations
-- TCP connection and listener types
-- host parsing and resolution
-- TLS connections and listeners
-
-If you want HTTP, WebSockets, SSE, or HTTP/2, use HTTP.jl on top of Reseau.
+- event-loop backends and timer-driven readiness polling
+- non-blocking socket operations and deadline handling
+- TCP connections and listeners
+- hostname-aware dialing and listening through the `TCP` entrypoints
+- TLS clients and listeners
 
 ## Installation
 
@@ -20,41 +19,55 @@ using Pkg
 Pkg.add("Reseau")
 ```
 
-For development from a local checkout:
+## Main Entry Points
 
-```julia
-using Pkg
-Pkg.develop(path="/path/to/Reseau.jl")
-```
+The user-facing API is centered on the exported `TCP` and `TLS` modules:
 
-## Package Shape
-
-The public surface is intentionally module-qualified:
-
-- `Reseau.TCP` for concrete-address TCP work
-- `Reseau.HostResolvers` for string-address resolution and dialing
-- `Reseau.TLS` for TLS clients and listeners
-
-This makes it clearer which layer owns what, and mirrors the way Go splits
-transport, name resolution, and TLS responsibilities.
+- `TCP` for plain TCP connections, listeners, deadlines, and string-address dialing
+- `TLS` for TLS connections, listeners, and handshake/configuration control
 
 ## Quick Start
 
-### Direct-address TCP
+### TCP
 
 ```julia
 using Reseau
 
-listener = Reseau.TCP.listen(Reseau.TCP.loopback_addr(9000))
-conn = Reseau.TCP.accept!(listener)
+listener = TCP.listen(TCP.loopback_addr(0); backlog = 128)
+addr = TCP.addr(listener)
+
+server_task = errormonitor(Threads.@spawn begin
+    conn = TCP.accept(listener)
+    try
+        buf = Vector{UInt8}(undef, 5)
+        read!(conn, buf)
+        write(conn, buf)
+    finally
+        close(conn)
+    end
+end)
+
+client = TCP.connect(addr)
+write(client, collect(codeunits("hello")))
+reply = Vector{UInt8}(undef, 5)
+read!(client, reply)
+
+close(client)
+close(listener)
+wait(server_task)
 ```
 
-### String-address TCP
+### Hostname-Based Dialing
 
 ```julia
 using Reseau
 
-conn = Reseau.HostResolvers.connect("tcp", "example.com:443")
+conn = TCP.connect("example.com:80")
+close(conn)
+
+listener = TCP.listen("127.0.0.1:0"; backlog = 64)
+println(TCP.addr(listener))
+close(listener)
 ```
 
 ### TLS
@@ -62,25 +75,25 @@ conn = Reseau.HostResolvers.connect("tcp", "example.com:443")
 ```julia
 using Reseau
 
-conn = Reseau.TLS.connect(
-    "tcp",
-    "example.com:443";
-    alpn_protocols=["h2", "http/1.1"],
+conn = TLS.connect(
+    "www.google.com:443";
+    alpn_protocols = ["h2", "http/1.1"],
 )
+
+state = TLS.connection_state(conn)
+println((state.handshake_complete, state.alpn_protocol))
+close(conn)
 ```
 
 ## Why Use Reseau
 
-- Deadlines and blocking behavior are explicit and testable.
-- String-address dialing and concrete-address dialing are both first-class.
-- TLS is part of the same stack instead of an afterthought layered over a
-  different transport abstraction.
-- HTTP.jl 2.0 now uses this exact stack, so transport semantics stay aligned
-  across the ecosystem.
+- Deadlines and readiness behavior are part of the transport instead of bolted on outside it.
+- Concrete-address and hostname-based dialing use the same `TCP` and `TLS` entrypoints.
+- TLS lives in the same stack as plain TCP, so timeout and lifecycle behavior stay aligned.
 
 ## Reading Guide
 
-- Read [TCP and Resolution](tcp.md) for the main connection/listener APIs.
-- Read [TLS](tls.md) for client/server TLS configuration.
-- Read [Sockets Migration Guide](migrate-sockets.md) if you are porting from
-  Julia's stdlib `Sockets`.
+- Read [TCP](tcp.md) for plain connections, listeners, deadlines, and string-address dialing.
+- Read [TLS](tls.md) for client/server TLS configuration and handshake behavior.
+- Read [Sockets Migration Guide](migrate-sockets.md) if you are porting from Julia's stdlib `Sockets`.
+- Read [API Reference](reference.md) for the exported surface area.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,16 +1,26 @@
-# Reseau.jl
+```@meta
+Description = "Documentation for Reseau.jl's pure-Julia TCP and TLS transport stack."
+```
+
+# [Reseau.jl](@id home-page)
 
 `Reseau.jl` is a pure-Julia networking transport stack organized around the
 same broad layers as Go's `runtime`, `internal/poll`, `net`, and `crypto/tls`
-packages.
+packages. The public surface is deliberately small: plain TCP lives under
+[`Reseau.TCP`](@ref), TLS lives under [`Reseau.TLS`](@ref), and hostname-aware
+dialing flows through the resolver layer described in [Name Resolution](@ref name-resolution-manual).
 
-Reseau owns:
-
-- event-loop backends and timer-driven readiness polling
-- non-blocking socket operations and deadline handling
-- TCP connections and listeners
-- hostname-aware dialing and listening through the `TCP` entrypoints
-- TLS clients and listeners
+```@contents
+Pages = [
+    "index.md",
+    "tcp.md",
+    "tls.md",
+    "resolution.md",
+    "migrate-sockets.md",
+    "reference.md",
+]
+Depth = 2
+```
 
 ## Installation
 
@@ -19,24 +29,36 @@ using Pkg
 Pkg.add("Reseau")
 ```
 
-## Main Entry Points
+## Module Entry Points
 
-The user-facing API is centered on the exported `TCP` and `TLS` modules:
+The package exports only `TCP` and `TLS`, which keeps the public API module-scoped
+instead of namespace-flat:
 
-- `TCP` for plain TCP connections, listeners, deadlines, and string-address dialing
-- `TLS` for TLS connections, listeners, and handshake/configuration control
+```@docs; canonical=false
+Reseau.TCP
+Reseau.TLS
+```
+
+Read [API Reference](@ref api-reference-manual) for the canonical docstring surface and [Name
+Resolution](@ref name-resolution-manual) for the `resolver`, `policy`, and `"host:port"` dialing layer.
+
+## Why Reseau
+
+- Deadline and readiness behavior live inside the transport instead of in ad hoc timeout wrappers.
+- Concrete-address and hostname-based dialing use the same [`TCP.connect`](@ref Reseau.TCP.connect) and [`TLS.connect`](@ref Reseau.TLS.connect) entrypoints.
+- TLS keeps the same lifecycle and deadline model as TCP, including lazy handshakes and transport-backed I/O.
+- The API stays close to Julia's standard `read!`, `write`, and `close` conventions.
 
 ## Quick Start
 
-### TCP
+This example stays entirely local: it opens a loopback listener, echoes one
+payload, and shows the reply that came back over the socket.
 
-```julia
+```@example home-echo
 using Reseau
 
-listener = TCP.listen(TCP.loopback_addr(0); backlog = 128)
-addr = TCP.addr(listener)
-
-server_task = errormonitor(Threads.@spawn begin
+listener = TCP.listen(TCP.loopback_addr(0); backlog = 16)
+server = @async begin
     conn = TCP.accept(listener)
     try
         buf = Vector{UInt8}(undef, 5)
@@ -44,56 +66,28 @@ server_task = errormonitor(Threads.@spawn begin
         write(conn, buf)
     finally
         close(conn)
+        close(listener)
     end
-end)
+end
 
-client = TCP.connect(addr)
-write(client, collect(codeunits("hello")))
-reply = Vector{UInt8}(undef, 5)
-read!(client, reply)
+client = TCP.connect(TCP.addr(listener))
+reply = UInt8[]
+try
+    write(client, collect(codeunits("hello")))
+    reply = Vector{UInt8}(undef, 5)
+    read!(client, reply)
+finally
+    close(client)
+end
 
-close(client)
-close(listener)
-wait(server_task)
+wait(server)
+String(reply)
 ```
 
-### Hostname-Based Dialing
+## Documentation Map
 
-```julia
-using Reseau
-
-conn = TCP.connect("example.com:80")
-close(conn)
-
-listener = TCP.listen("127.0.0.1:0"; backlog = 64)
-println(TCP.addr(listener))
-close(listener)
-```
-
-### TLS
-
-```julia
-using Reseau
-
-conn = TLS.connect(
-    "www.google.com:443";
-    alpn_protocols = ["h2", "http/1.1"],
-)
-
-state = TLS.connection_state(conn)
-println((state.handshake_complete, state.alpn_protocol))
-close(conn)
-```
-
-## Why Use Reseau
-
-- Deadlines and readiness behavior are part of the transport instead of bolted on outside it.
-- Concrete-address and hostname-based dialing use the same `TCP` and `TLS` entrypoints.
-- TLS lives in the same stack as plain TCP, so timeout and lifecycle behavior stay aligned.
-
-## Reading Guide
-
-- Read [TCP](tcp.md) for plain connections, listeners, deadlines, and string-address dialing.
-- Read [TLS](tls.md) for client/server TLS configuration and handshake behavior.
-- Read [Sockets Migration Guide](migrate-sockets.md) if you are porting from Julia's stdlib `Sockets`.
-- Read [API Reference](reference.md) for the exported surface area.
+- Read [TCP](@ref tcp-manual) for plain connections, address constructors, deadlines, I/O semantics, and socket options.
+- Read [TLS](@ref tls-manual) for `TLS.Config`, client/server wrappers, lazy handshakes, and connection-state inspection.
+- Read [Name Resolution](@ref name-resolution-manual) for `ResolverPolicy`, `HostResolver`, caching, and explicit resolution helpers.
+- Read [Migrating from `Sockets` to Reseau](@ref sockets-migration-manual) if you are porting code from Julia's stdlib `Sockets`.
+- Read [API Reference](@ref api-reference-manual) for canonical docstrings and a generated docstring index.

--- a/docs/src/migrate-sockets.md
+++ b/docs/src/migrate-sockets.md
@@ -1,28 +1,26 @@
 # Migrating from `Sockets` to Reseau
 
-If you are using Julia's stdlib `Sockets`, the main conceptual change is that
-Reseau makes transport layers explicit instead of forcing everything through one
-untyped socket surface.
+If you are using Julia's stdlib `Sockets`, the easiest mental model is:
 
-The payoff is better deadlines, clearer address handling, integrated TLS, and a
-stack that matches what HTTP.jl 2.0 now uses underneath.
+- keep `connect`, `listen`, `accept`, and `close`
+- move plain TCP work onto `TCP`
+- move TLS work onto `TLS`
+- replace ad hoc timeout wrappers with connection deadlines
 
 ## Quick Mapping
 
 | `Sockets` | Reseau |
 | --- | --- |
-| `listen(ip"127.0.0.1", port)` | `Reseau.TCP.listen(Reseau.TCP.loopback_addr(port))` |
-| `connect(ip"127.0.0.1", port)` | `Reseau.TCP.connect(Reseau.TCP.loopback_addr(port))` |
-| `connect("example.com", port)` | `Reseau.HostResolvers.connect("tcp", "example.com:$port")` |
-| `accept(server)` | `Reseau.TCP.accept!(listener)` |
-| `close(sock)` | `Reseau.TCP.close!(conn)` |
-| `getsockname(sock)` | `Reseau.TCP.local_addr(conn)` |
-| `getpeername(sock)` | `Reseau.TCP.remote_addr(conn)` |
-| external TLS wrapper | `Reseau.TLS.connect`, `Reseau.TLS.listen`, `Reseau.TLS.client`, `Reseau.TLS.server` |
+| `listen(ip"127.0.0.1", port)` | `TCP.listen(TCP.loopback_addr(port))` |
+| `connect(ip"127.0.0.1", port)` | `TCP.connect(TCP.loopback_addr(port))` |
+| `connect("example.com", port)` | `TCP.connect("example.com:$port")` |
+| `accept(server)` | `TCP.accept(listener)` |
+| `close(sock)` | `close(conn)` / `close(listener)` |
+| `getsockname(sock)` | `TCP.local_addr(conn)` |
+| `getpeername(sock)` | `TCP.remote_addr(conn)` |
+| external TLS wrapper | `TLS.connect`, `TLS.listen`, `TLS.client`, `TLS.server` |
 
-## The Two Most Common Ports
-
-## 1. Simple TCP server
+## 1. Simple TCP Server
 
 ### `Sockets`
 
@@ -31,6 +29,8 @@ using Sockets
 
 server = listen(ip"127.0.0.1", 9000)
 sock = accept(server)
+close(sock)
+close(server)
 ```
 
 ### `Reseau`
@@ -38,11 +38,13 @@ sock = accept(server)
 ```julia
 using Reseau
 
-listener = Reseau.TCP.listen(Reseau.TCP.loopback_addr(9000))
-conn = Reseau.TCP.accept!(listener)
+listener = TCP.listen(TCP.loopback_addr(9000))
+conn = TCP.accept(listener)
+close(conn)
+close(listener)
 ```
 
-## 2. Hostname-based client dial
+## 2. Hostname-Based Client Dial
 
 ### `Sockets`
 
@@ -50,6 +52,7 @@ conn = Reseau.TCP.accept!(listener)
 using Sockets
 
 sock = connect("example.com", 443)
+close(sock)
 ```
 
 ### `Reseau`
@@ -57,72 +60,74 @@ sock = connect("example.com", 443)
 ```julia
 using Reseau
 
-conn = Reseau.HostResolvers.connect("tcp", "example.com:443")
+conn = TCP.connect("example.com:443")
+close(conn)
 ```
 
 ## Deadlines Are First-Class
 
-This is one of the biggest quality-of-life improvements over `Sockets`.
+One of the biggest quality-of-life improvements over `Sockets` is that the
+deadline lives on the connection itself:
 
 ```julia
 using Reseau
 
-conn = Reseau.HostResolvers.connect("tcp", "example.com:443")
-Reseau.TCP.set_read_deadline!(conn, time_ns() + 5_000_000_000)
+conn = TCP.connect("example.com:443")
+TCP.set_read_deadline!(conn, time_ns() + 5_000_000_000)
+close(conn)
 ```
 
-Instead of managing ad hoc task timeouts around blocking socket calls, the
-deadline is attached to the connection itself.
+Instead of managing task-local timeout wrappers around blocking socket calls,
+the transport itself owns the timeout.
 
-## Shutdown Is Explicit
+## TLS Lives in the Same Package
 
-Half-closing is exposed directly:
-
-```julia
-Reseau.TCP.close_write!(conn)
-Reseau.TCP.close_read!(conn)
-```
-
-That is a better migration target than reaching for low-level shutdown syscalls.
-
-## TLS No Longer Lives Somewhere Else
-
-With `Sockets`, TLS usually meant another package layered on top. With Reseau,
-TLS is part of the same stack:
+With `Sockets`, TLS usually means adding another layer elsewhere. With Reseau,
+plain TCP and TLS share one stack:
 
 ```julia
 using Reseau
 
-tls = Reseau.TLS.connect(
-    "tcp",
+tls = TLS.connect(
     "example.com:443";
-    verify_peer=true,
-    alpn_protocols=["h2", "http/1.1"],
+    verify_peer = true,
+    alpn_protocols = ["h2", "http/1.1"],
 )
+
+close(tls)
 ```
 
 For servers:
 
 ```julia
-cfg = Reseau.TLS.Config(cert_file="server.crt", key_file="server.key")
-listener = Reseau.TLS.listen("tcp", "127.0.0.1:8443", cfg)
+using Reseau
+
+cfg = TLS.Config(cert_file = "server.crt", key_file = "server.key")
+listener = TLS.listen("tcp", "127.0.0.1:8443", cfg)
+close(listener)
 ```
 
-## What to Change in Real Code
+## One Naming Difference To Know
 
-1. Replace direct `Sockets.connect(host, port)` calls with
-   `HostResolvers.connect("tcp", "host:port")`.
-2. Replace direct listen/accept loops with `TCP.listen` + `TCP.accept!`.
-3. Replace manual timeout wrappers with connection deadlines.
-4. Move TLS setup onto `Reseau.TLS.Config` and `Reseau.TLS.connect/listen`.
-5. Update any code that expected raw `Sockets.TCPSocket` internals; Reseau uses
-   its own `TCP.Conn` and `TLS.Conn` types.
+Full connection teardown now matches Base: use `close(conn)` and
+`close(listener)`.
 
-## Benefits of Porting
+Half-close is still spelled with explicit transport helpers:
+
+- `closewrite(conn)`
+- `TCP.closeread(conn)`
+
+## What To Change In Real Code
+
+1. Replace `Sockets.connect(host, port)` with `TCP.connect("host:port")` when you want hostname resolution.
+2. Replace listen/accept loops with `TCP.listen(...)` and `TCP.accept(listener)`.
+3. Replace timeout wrappers with `TCP.set_deadline!`, `TCP.set_read_deadline!`, or `TCP.set_write_deadline!`.
+4. Move TLS setup onto `TLS.Config`, `TLS.connect`, and `TLS.listen`.
+5. Update any code that expected `Sockets.TCPSocket` internals; Reseau uses `TCP.Conn` and `TLS.Conn`.
+
+## Benefits Of Porting
 
 - Better deadline and readiness behavior
-- Clearer address and hostname handling
-- TLS integrated into the same stack
-- The same transport semantics used by HTTP.jl 2.0
-- A package boundary that makes plain TCP, resolved TCP, and TLS easier to test
-  in isolation
+- One TCP surface for both concrete addresses and `"host:port"` dialing
+- TLS integrated into the same transport stack
+- Clearer listener/connection types than raw `Sockets` handles

--- a/docs/src/migrate-sockets.md
+++ b/docs/src/migrate-sockets.md
@@ -1,11 +1,21 @@
-# Migrating from `Sockets` to Reseau
+```@meta
+Description = "How to migrate TCP and TLS code from Julia's stdlib Sockets to Reseau.jl."
+```
 
-If you are using Julia's stdlib `Sockets`, the easiest mental model is:
+# [Migrating from `Sockets` to Reseau](@id sockets-migration-manual)
 
-- keep `connect`, `listen`, `accept`, and `close`
-- move plain TCP work onto `TCP`
-- move TLS work onto `TLS`
-- replace ad hoc timeout wrappers with connection deadlines
+If you are porting code from Julia's stdlib `Sockets`, the easiest mental model
+is:
+
+- keep the familiar `connect`, `listen`, `accept`, `read!`, `write`, and `close` flow
+- move plain transport work onto [`Reseau.TCP`](@ref)
+- move TLS work onto [`Reseau.TLS`](@ref)
+- replace timeout wrappers with connection deadlines
+
+```@contents
+Pages = ["migrate-sockets.md"]
+Depth = 2:3
+```
 
 ## Quick Mapping
 
@@ -15,12 +25,14 @@ If you are using Julia's stdlib `Sockets`, the easiest mental model is:
 | `connect(ip"127.0.0.1", port)` | `TCP.connect(TCP.loopback_addr(port))` |
 | `connect("example.com", port)` | `TCP.connect("example.com:$port")` |
 | `accept(server)` | `TCP.accept(listener)` |
+| `read!(sock, buf)` | `read!(conn, buf)` |
+| `write(sock, buf)` | `write(conn, buf)` |
 | `close(sock)` | `close(conn)` / `close(listener)` |
 | `getsockname(sock)` | `TCP.local_addr(conn)` |
 | `getpeername(sock)` | `TCP.remote_addr(conn)` |
 | external TLS wrapper | `TLS.connect`, `TLS.listen`, `TLS.client`, `TLS.server` |
 
-## 1. Simple TCP Server
+## TCP Server Shape
 
 ### `Sockets`
 
@@ -44,18 +56,12 @@ close(conn)
 close(listener)
 ```
 
-## 2. Hostname-Based Client Dial
+Read [TCP](@ref tcp-manual) for the full connection and deadline model.
 
-### `Sockets`
+## Hostname-Based Dialing
 
-```julia
-using Sockets
-
-sock = connect("example.com", 443)
-close(sock)
-```
-
-### `Reseau`
+If your old code used separate host and port arguments, the most direct Reseau
+translation is the `"host:port"` string-address surface:
 
 ```julia
 using Reseau
@@ -64,10 +70,26 @@ conn = TCP.connect("example.com:443")
 close(conn)
 ```
 
-## Deadlines Are First-Class
+If you need to control family preference, timeout budget, or custom resolution,
+read [Name Resolution](@ref name-resolution-manual).
 
-One of the biggest quality-of-life improvements over `Sockets` is that the
-deadline lives on the connection itself:
+## Standard I/O Still Applies
+
+One nice migration property is that the connection still behaves like a Julia
+stream:
+
+- `read!(conn, buf)`
+- `write(conn, buf)`
+- `close(conn)`
+
+The difference is in the transport semantics: deadlines and readiness are now
+part of the connection itself, and partial reads/writes are documented
+explicitly on the `TCP.Conn` and `TLS.Conn` APIs in [API Reference](@ref api-reference-manual).
+
+## Deadlines Become First-Class
+
+Instead of wrapping operations in ad hoc timeout tasks, set deadlines directly
+on the live connection:
 
 ```julia
 using Reseau
@@ -77,13 +99,12 @@ TCP.set_read_deadline!(conn, time_ns() + 5_000_000_000)
 close(conn)
 ```
 
-Instead of managing task-local timeout wrappers around blocking socket calls,
-the transport itself owns the timeout.
+This deadline model carries through to TLS as well.
 
-## TLS Lives in the Same Package
+## TLS Lives In The Same Stack
 
-With `Sockets`, TLS usually means adding another layer elsewhere. With Reseau,
-plain TCP and TLS share one stack:
+With `Sockets`, TLS is usually another package layered on top. With Reseau, TCP
+and TLS are sibling surfaces in one transport stack:
 
 ```julia
 using Reseau
@@ -107,27 +128,21 @@ listener = TLS.listen("tcp", "127.0.0.1:8443", cfg)
 close(listener)
 ```
 
-## One Naming Difference To Know
+Read [TLS](@ref tls-manual) for handshake behavior, config options, and lifecycle details.
 
-Full connection teardown now matches Base: use `close(conn)` and
-`close(listener)`.
+## One Naming Difference To Keep
 
-Half-close is still spelled with explicit transport helpers:
+Full teardown follows Base conventions: use `close(conn)` and `close(listener)`.
+
+Half-close remains explicit:
 
 - `closewrite(conn)`
 - `TCP.closeread(conn)`
 
-## What To Change In Real Code
+## Porting Checklist
 
 1. Replace `Sockets.connect(host, port)` with `TCP.connect("host:port")` when you want hostname resolution.
 2. Replace listen/accept loops with `TCP.listen(...)` and `TCP.accept(listener)`.
 3. Replace timeout wrappers with `TCP.set_deadline!`, `TCP.set_read_deadline!`, or `TCP.set_write_deadline!`.
-4. Move TLS setup onto `TLS.Config`, `TLS.connect`, and `TLS.listen`.
-5. Update any code that expected `Sockets.TCPSocket` internals; Reseau uses `TCP.Conn` and `TLS.Conn`.
-
-## Benefits Of Porting
-
-- Better deadline and readiness behavior
-- One TCP surface for both concrete addresses and `"host:port"` dialing
-- TLS integrated into the same transport stack
-- Clearer listener/connection types than raw `Sockets` handles
+4. Move TLS setup onto `TLS.Config`, `TLS.connect`, `TLS.listen`, `TLS.client`, and `TLS.server`.
+5. Update any code that expected `Sockets.TCPSocket` internals; Reseau exposes `TCP.Conn` and `TLS.Conn` instead.

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,101 +1,83 @@
 # API Reference
 
-Reseau keeps its public surface module-qualified. That is intentional: it makes
-the layer boundaries obvious.
+The public surface is centered on the exported `TCP` and `TLS` modules.
 
-## `Reseau.TCP`
+## `TCP`
 
-### Address constructors
+### Address Constructors
 
-- `Reseau.TCP.SocketAddrV4`
-- `Reseau.TCP.SocketAddrV6`
-- `Reseau.TCP.loopback_addr`
-- `Reseau.TCP.any_addr`
-- `Reseau.TCP.loopback_addr6`
-- `Reseau.TCP.any_addr6`
+- `TCP.SocketAddrV4`
+- `TCP.SocketAddrV6`
+- `TCP.loopback_addr`
+- `TCP.any_addr`
+- `TCP.loopback_addr6`
+- `TCP.any_addr6`
 
-### Connections and listeners
+### Connections and Listeners
 
-- `Reseau.TCP.connect`
-- `Reseau.TCP.listen`
-- `Reseau.TCP.accept!`
-- `Reseau.TCP.close!`
-- `Reseau.TCP.close_read!`
-- `Reseau.TCP.close_write!`
+- `TCP.connect`
+- `TCP.listen`
+- `TCP.accept`
+- `close(::TCP.Conn)`
+- `close(::TCP.Listener)`
 
-### Deadlines and socket options
+The string-address overloads on `TCP.connect` accept:
 
-- `Reseau.TCP.set_deadline!`
-- `Reseau.TCP.set_read_deadline!`
-- `Reseau.TCP.set_write_deadline!`
-- `Reseau.TCP.set_nodelay!`
-- `Reseau.TCP.set_keepalive!`
+- `timeout_ns`
+- `deadline_ns`
+- `local_addr`
+- `fallback_delay_ns`
+- `resolver`
+- `policy`
 
-### Address inspection
+### Deadlines, Shutdown, and Socket Options
 
-- `Reseau.TCP.local_addr`
-- `Reseau.TCP.remote_addr`
-- `Reseau.TCP.addr`
+- `TCP.set_deadline!`
+- `TCP.set_read_deadline!`
+- `TCP.set_write_deadline!`
+- `TCP.closeread`
+- `closewrite(::TCP.Conn)`
+- `TCP.set_nodelay!`
+- `TCP.set_keepalive!`
 
-## `Reseau.HostResolvers`
+### Address Inspection
 
-### Address parsing and lookup
+- `TCP.local_addr`
+- `TCP.remote_addr`
+- `TCP.addr`
 
-- `Reseau.HostResolvers.join_host_port`
-- `Reseau.HostResolvers.split_host_port`
-- `Reseau.HostResolvers.parse_port`
-- `Reseau.HostResolvers.lookup_port`
-- `Reseau.HostResolvers.resolve_tcp_addr`
-- `Reseau.HostResolvers.resolve_tcp_addrs`
+## `TLS`
 
-### Dial/listen helpers
+### Main Types
 
-- `Reseau.HostResolvers.connect`
-- `Reseau.HostResolvers.listen`
-- `Reseau.HostResolvers.HostResolver`
+- `TLS.Config`
+- `TLS.Conn`
+- `TLS.Listener`
+- `TLS.ClientAuthMode`
 
-### Resolver helpers
+### Client and Server Setup
 
-- `Reseau.HostResolvers.ResolverPolicy`
-- `Reseau.HostResolvers.SystemResolver`
-- `Reseau.HostResolvers.StaticResolver`
-- `Reseau.HostResolvers.CachingResolver`
-- `Reseau.HostResolvers.SingleflightResolver`
+- `TLS.connect`
+- `TLS.listen`
+- `TLS.client`
+- `TLS.server`
+- `TLS.accept`
+- `TLS.handshake!`
 
-## `Reseau.TLS`
+The string-address overloads on `TLS.connect` accept the same resolution and
+connect-policy keywords as `TCP.connect`, along with all `TLS.Config` keywords.
 
-### Main types
+### Lifecycle and Inspection
 
-- `Reseau.TLS.Config`
-- `Reseau.TLS.Conn`
-- `Reseau.TLS.Listener`
-- `Reseau.TLS.ClientAuthMode`
-
-### Client and server setup
-
-- `Reseau.TLS.connect`
-- `Reseau.TLS.listen`
-- `Reseau.TLS.client`
-- `Reseau.TLS.server`
-- `Reseau.TLS.accept!`
-- `Reseau.TLS.handshake!`
-
-### Lifecycle and inspection
-
-- `Reseau.TLS.close!`
-- `Reseau.TLS.addr`
+- `close(::TLS.Conn)`
+- `close(::TLS.Listener)`
+- `TLS.addr`
+- `TLS.net_conn`
+- `TLS.connection_state`
+- `closewrite(::TLS.Conn)`
 
 ### Errors
 
-- `Reseau.TLS.ConfigError`
-- `Reseau.TLS.TLSError`
-- `Reseau.TLS.TLSHandshakeTimeoutError`
-
-## Package Boundary Note
-
-HTTP-related APIs are intentionally no longer part of Reseau. Use HTTP.jl for:
-
-- request/response handling
-- HTTP clients and servers
-- WebSockets
-- HPACK and HTTP/2
+- `TLS.ConfigError`
+- `TLS.TLSError`
+- `TLS.TLSHandshakeTimeoutError`

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,83 +1,165 @@
-# API Reference
+```@meta
+CollapsedDocStrings = true
+Description = "Canonical API reference for Reseau.jl's TCP, TLS, and name-resolution surfaces."
+```
 
-The public surface is centered on the exported `TCP` and `TLS` modules.
+# [API Reference](@id api-reference-manual)
 
-## `TCP`
+This page is the canonical home for the package and module docstrings used
+throughout the rest of the manual.
 
-### Address Constructors
+```@contents
+Pages = ["reference.md"]
+Depth = 2:2
+```
 
-- `TCP.SocketAddrV4`
-- `TCP.SocketAddrV6`
-- `TCP.loopback_addr`
-- `TCP.any_addr`
-- `TCP.loopback_addr6`
-- `TCP.any_addr6`
+## Package Modules
 
-### Connections and Listeners
+```@docs
+Reseau
+Reseau.TCP
+Reseau.TLS
+```
 
-- `TCP.connect`
-- `TCP.listen`
-- `TCP.accept`
-- `close(::TCP.Conn)`
-- `close(::TCP.Listener)`
+### Internal Layers
 
-The string-address overloads on `TCP.connect` accept:
+These modules are not the primary end-user entrypoints, but they explain the
+package layering and are part of the documented rewrite architecture:
 
-- `timeout_ns`
-- `deadline_ns`
-- `local_addr`
-- `fallback_delay_ns`
-- `resolver`
-- `policy`
+```@docs
+Reseau.EventLoops
+Reseau.SocketOps
+Reseau.IOPoll
+Reseau.IOPoll.PollOp
+Reseau.HostResolvers
+```
 
-### Deadlines, Shutdown, and Socket Options
+## TCP
 
-- `TCP.set_deadline!`
-- `TCP.set_read_deadline!`
-- `TCP.set_write_deadline!`
-- `TCP.closeread`
-- `closewrite(::TCP.Conn)`
-- `TCP.set_nodelay!`
-- `TCP.set_keepalive!`
+```@meta
+CurrentModule = Reseau.TCP
+```
 
-### Address Inspection
+### Address Types and Constructors
 
-- `TCP.local_addr`
-- `TCP.remote_addr`
-- `TCP.addr`
+```@docs
+SocketAddr
+SocketAddrV4
+SocketAddrV6
+loopback_addr
+any_addr
+loopback_addr6
+any_addr6
+```
 
-## `TLS`
+### Connections and I/O
 
-### Main Types
+```@docs
+Conn
+Listener
+connect
+listen
+accept
+Base.read!(::Conn, ::Vector{UInt8})
+Base.write(::Conn, ::AbstractVector{UInt8})
+Base.close(::Conn)
+Base.close(::Listener)
+closeread
+Base.closewrite(::Conn)
+```
 
-- `TLS.Config`
-- `TLS.Conn`
-- `TLS.Listener`
-- `TLS.ClientAuthMode`
+### Deadlines, Socket Options, and Address Inspection
 
-### Client and Server Setup
+```@docs
+set_deadline!
+set_read_deadline!
+set_write_deadline!
+set_nodelay!
+set_keepalive!
+local_addr
+remote_addr
+addr
+```
 
-- `TLS.connect`
-- `TLS.listen`
-- `TLS.client`
-- `TLS.server`
-- `TLS.accept`
-- `TLS.handshake!`
+## Name Resolution
 
-The string-address overloads on `TLS.connect` accept the same resolution and
-connect-policy keywords as `TCP.connect`, along with all `TLS.Config` keywords.
+```@meta
+CurrentModule = Reseau.HostResolvers
+```
 
-### Lifecycle and Inspection
+### Policy and Resolver Types
 
-- `close(::TLS.Conn)`
-- `close(::TLS.Listener)`
-- `TLS.addr`
-- `TLS.net_conn`
-- `TLS.connection_state`
-- `closewrite(::TLS.Conn)`
+```@docs
+ResolverPolicy
+SystemResolver
+SingleflightResolver
+CachingResolver
+StaticResolver
+HostResolver
+```
 
-### Errors
+### Explicit Resolution Helpers
 
-- `TLS.ConfigError`
-- `TLS.TLSError`
-- `TLS.TLSHandshakeTimeoutError`
+```@docs
+resolve_tcp_addrs
+resolve_tcp_addr
+```
+
+## TLS
+
+```@meta
+CurrentModule = Reseau.TLS
+```
+
+### Configuration, State, and Errors
+
+```@docs
+Config
+ConnectionState
+Conn
+Listener
+ConfigError
+TLSError
+TLSHandshakeTimeoutError
+```
+
+### Client and Server Construction
+
+```@docs
+client
+server
+connect
+listen
+accept
+handshake!
+```
+
+### I/O, Lifecycle, Deadlines, and Inspection
+
+```@docs
+Base.read!(::Conn, ::Vector{UInt8})
+Base.write(::Conn, ::AbstractVector{UInt8})
+Base.close(::Conn)
+Base.close(::Listener)
+Base.closewrite(::Conn)
+set_deadline!
+set_read_deadline!
+set_write_deadline!
+local_addr
+remote_addr
+net_conn
+connection_state
+addr
+```
+
+## Docstring Index
+
+```@meta
+CurrentModule = Main
+```
+
+```@index
+Pages = ["reference.md"]
+Modules = [Reseau, Reseau.TCP, Reseau.HostResolvers, Reseau.TLS]
+Order = [:module, :type, :function]
+```

--- a/docs/src/resolution.md
+++ b/docs/src/resolution.md
@@ -1,0 +1,86 @@
+```@meta
+CurrentModule = Reseau.HostResolvers
+Description = "Host resolution, address-family policy, and resolver configuration for Reseau.jl."
+```
+
+# [Name Resolution](@id name-resolution-manual)
+
+`TCP.connect("host:port")`, `TCP.listen("host:port")`, and `TLS.connect("host:port")`
+all flow through a resolver layer that turns host/port strings into concrete
+`TCP.SocketEndpoint` values. That layer is public enough to be useful whenever
+you need custom resolution, caching, or explicit address-family policy instead
+of the default behavior.
+
+```@contents
+Pages = ["resolution.md"]
+Depth = 2:3
+```
+
+## When This Layer Matters
+
+Most users can call [`Reseau.TCP.connect`](@ref Reseau.TCP.connect) or
+[`Reseau.TLS.connect`](@ref Reseau.TLS.connect) directly and never touch the
+resolver types. Reach for this layer when you need any of the following:
+
+- explicit IPv4/IPv6 preference or filtering
+- a custom resolver backend
+- cached or deduplicated hostname lookups
+- pre-resolved address lists before dialing
+- deadline and fallback-race control packaged into one reusable dial policy
+
+## Resolver Policy
+
+`ResolverPolicy` controls how mixed-family results are filtered and ordered:
+
+```@docs; canonical=false
+ResolverPolicy
+```
+
+This is the right tool when you want a `"tcp"` dial to prefer IPv6 first,
+disable one family entirely, or otherwise steer the order of candidate
+endpoints before connect attempts begin.
+
+## Resolver Implementations
+
+Reseau ships a small stack of resolver building blocks:
+
+```@docs; canonical=false
+SystemResolver
+SingleflightResolver
+CachingResolver
+StaticResolver
+HostResolver
+```
+
+The usual default path is:
+
+1. `SystemResolver` performs platform DNS and service lookups.
+2. `SingleflightResolver` coalesces concurrent duplicate lookups.
+3. `HostResolver` packages timeout, deadline, local bind, fallback delay, and policy for a whole resolve+connect operation.
+
+Add `CachingResolver` or `StaticResolver` when you want explicit control over
+lookup reuse or deterministic test-time address mapping.
+
+## Resolving Explicitly
+
+If you want the concrete address list before dialing, use the explicit helper
+functions:
+
+```@docs; canonical=false
+resolve_tcp_addrs
+resolve_tcp_addr
+```
+
+These helpers are useful when:
+
+- you want to inspect or log the resolved candidate set
+- you want to dial multiple endpoints yourself
+- you are building higher-level connection policy on top of Reseau
+
+## Relationship To TCP And TLS
+
+- [`Reseau.TCP.connect`](@ref Reseau.TCP.connect) uses this layer for string-address dialing.
+- [`Reseau.TCP.listen`](@ref Reseau.TCP.listen) uses it for `"host:port"` listener setup.
+- [`Reseau.TLS.connect`](@ref Reseau.TLS.connect) forwards the same resolver and policy keywords before wrapping the resulting TCP transport in TLS.
+
+Read [TCP](@ref tcp-manual) and [TLS](@ref tls-manual) for the transport and handshake layers that sit on top of these resolved endpoints.

--- a/docs/src/tcp.md
+++ b/docs/src/tcp.md
@@ -1,98 +1,95 @@
-# TCP and Resolution
+# TCP
 
-Reseau splits TCP work into two layers:
+`TCP` is the main plain-transport entrypoint in Reseau. The same `TCP.connect`
+and `TCP.listen` surface supports both concrete socket addresses and
+hostname-based string addresses.
 
-- `Reseau.TCP` for concrete socket addresses
-- `Reseau.HostResolvers` for string-address parsing, host resolution, and
-  timeout-aware dialing
+## Address Constructors
 
-## `Reseau.TCP`
+Use concrete addresses when you already know the exact family and endpoint you
+want:
 
-Use `Reseau.TCP` when you already know the exact address family and endpoint you
-want.
-
-### Address Types
-
-- `Reseau.TCP.SocketAddrV4`
-- `Reseau.TCP.SocketAddrV6`
-- `Reseau.TCP.loopback_addr`
-- `Reseau.TCP.any_addr`
-- `Reseau.TCP.loopback_addr6`
-- `Reseau.TCP.any_addr6`
-
-### Connections and Listeners
+- `TCP.SocketAddrV4`
+- `TCP.SocketAddrV6`
+- `TCP.loopback_addr`
+- `TCP.any_addr`
+- `TCP.loopback_addr6`
+- `TCP.any_addr6`
 
 ```julia
 using Reseau
 
-addr = Reseau.TCP.loopback_addr(9000)
-listener = Reseau.TCP.listen(addr; backlog=128, reuseaddr=true)
-conn = Reseau.TCP.accept!(listener)
+addr = TCP.loopback_addr(9000)
+listener = TCP.listen(addr; backlog = 128, reuseaddr = true)
+conn = TCP.accept(listener)
+
+close(conn)
+close(listener)
 ```
 
-Client connections are just as direct:
+## String-Address Dialing and Listening
+
+If you prefer the `Sockets`-style `"host:port"` surface, use the same
+`TCP.connect` and `TCP.listen` entrypoints directly:
 
 ```julia
 using Reseau
 
-conn = Reseau.TCP.connect(Reseau.TCP.loopback_addr(9000))
-write(conn, collect(codeunits("hello")))
-buf = Vector{UInt8}(undef, 5)
-read!(conn, buf)
+conn = TCP.connect("example.com:443")
+close(conn)
+
+listener = TCP.listen("127.0.0.1:9000"; backlog = 64)
+close(listener)
 ```
 
-### Deadlines and Shutdown
+If you need to tune connect behavior, the string-address overloads accept:
 
-These are important differences from `Sockets`:
-
-- `Reseau.TCP.set_deadline!(conn, deadline_ns)`
-- `Reseau.TCP.set_read_deadline!(conn, deadline_ns)`
-- `Reseau.TCP.set_write_deadline!(conn, deadline_ns)`
-- `Reseau.TCP.close_read!(conn)`
-- `Reseau.TCP.close_write!(conn)`
-
-### Address Inspection
-
-- `Reseau.TCP.local_addr(conn)`
-- `Reseau.TCP.remote_addr(conn)`
-- `Reseau.TCP.addr(listener)`
-
-## `Reseau.HostResolvers`
-
-Use `HostResolvers` when you want the package to handle host parsing and
-resolution for you.
-
-### Common Entry Points
-
-- `Reseau.HostResolvers.connect("tcp", "example.com:443")`
-- `Reseau.HostResolvers.connect("example.com:443")`
-- `Reseau.HostResolvers.listen("tcp", "127.0.0.1:9000")`
-- `Reseau.HostResolvers.resolve_tcp_addr`
-- `Reseau.HostResolvers.resolve_tcp_addrs`
-- `Reseau.HostResolvers.lookup_port`
-- `Reseau.HostResolvers.join_host_port`
-- `Reseau.HostResolvers.split_host_port`
-
-### Example
+- `timeout_ns`
+- `deadline_ns`
+- `local_addr`
+- `fallback_delay_ns`
+- `resolver`
+- `policy`
 
 ```julia
 using Reseau
 
-listener = Reseau.HostResolvers.listen("tcp", "127.0.0.1:9000")
-conn = Reseau.HostResolvers.connect("tcp", "127.0.0.1:9000")
-peer = Reseau.TCP.accept!(listener)
+conn = TCP.connect(
+    "example.com:443";
+    timeout_ns = 2_000_000_000,
+    fallback_delay_ns = 100_000_000,
+)
+
+close(conn)
 ```
 
-### Resolution Policies
+## Deadlines and Shutdown
 
-`HostResolvers` also owns the higher-level resolution helpers:
+Deadlines live on the connection itself:
 
-- `ResolverPolicy`
-- `SystemResolver`
-- `StaticResolver`
-- `CachingResolver`
-- `SingleflightResolver`
-- `HostResolver`
+- `TCP.set_deadline!(conn, deadline_ns)`
+- `TCP.set_read_deadline!(conn, deadline_ns)`
+- `TCP.set_write_deadline!(conn, deadline_ns)`
 
-These are the right tools when you want to tune IPv4/IPv6 preference,
-cache lookups, or control resolution behavior explicitly.
+Full close uses Julia's standard `close(conn)` / `close(listener)` surface.
+
+Half-close remains explicit today:
+
+- `closewrite(conn)`
+- `TCP.closeread(conn)`
+
+```julia
+using Reseau
+
+conn = TCP.connect("example.com:80")
+TCP.set_read_deadline!(conn, time_ns() + 5_000_000_000)
+close(conn)
+```
+
+## Address Inspection
+
+Use these helpers to inspect the bound or connected endpoints:
+
+- `TCP.local_addr(conn)`
+- `TCP.remote_addr(conn)`
+- `TCP.addr(listener)`

--- a/docs/src/tcp.md
+++ b/docs/src/tcp.md
@@ -1,48 +1,51 @@
-# TCP
+```@meta
+CurrentModule = Reseau.TCP
+Description = "TCP connections, listeners, deadlines, socket options, and address helpers in Reseau.jl."
+```
 
-`TCP` is the main plain-transport entrypoint in Reseau. The same `TCP.connect`
-and `TCP.listen` surface supports both concrete socket addresses and
-hostname-based string addresses.
+# [TCP](@id tcp-manual)
 
-## Address Constructors
+`TCP` is the plain-transport entrypoint in Reseau. The same [`connect`](@ref)
+and [`listen`](@ref) surface supports both concrete socket addresses and
+hostname-based string addresses. Read [Name Resolution](@ref name-resolution-manual) for the resolver
+and policy objects behind the string-address overloads.
+
+```@contents
+Pages = ["tcp.md"]
+Depth = 2:3
+```
+
+## Address Model
 
 Use concrete addresses when you already know the exact family and endpoint you
-want:
+want to target. Reseau exposes both IPv4 and IPv6 address snapshots:
 
-- `TCP.SocketAddrV4`
-- `TCP.SocketAddrV6`
-- `TCP.loopback_addr`
-- `TCP.any_addr`
-- `TCP.loopback_addr6`
-- `TCP.any_addr6`
-
-```julia
-using Reseau
-
-addr = TCP.loopback_addr(9000)
-listener = TCP.listen(addr; backlog = 128, reuseaddr = true)
-conn = TCP.accept(listener)
-
-close(conn)
-close(listener)
+```@docs; canonical=false
+SocketAddr
+SocketAddrV4
+SocketAddrV6
+loopback_addr
+any_addr
+loopback_addr6
+any_addr6
 ```
 
-## String-Address Dialing and Listening
+Concrete addresses are especially useful when you want to bind explicitly to a
+family or pass a preselected local address to outbound dialing.
 
-If you prefer the `Sockets`-style `"host:port"` surface, use the same
-`TCP.connect` and `TCP.listen` entrypoints directly:
+## Connections and Listeners
 
-```julia
-using Reseau
+The core connection surface is small and intentionally transport-focused:
 
-conn = TCP.connect("example.com:443")
-close(conn)
-
-listener = TCP.listen("127.0.0.1:9000"; backlog = 64)
-close(listener)
+```@docs; canonical=false
+Conn
+Listener
+connect
+listen
+accept
 ```
 
-If you need to tune connect behavior, the string-address overloads accept:
+For `"host:port"` dialing, the string-address overloads accept:
 
 - `timeout_ns`
 - `deadline_ns`
@@ -51,45 +54,52 @@ If you need to tune connect behavior, the string-address overloads accept:
 - `resolver`
 - `policy`
 
-```julia
-using Reseau
+Those knobs feed the resolver layer described in [Name Resolution](@ref name-resolution-manual), while
+the actual socket lifecycle still lands in the same `TCP.Conn` and
+`TCP.Listener` types.
 
-conn = TCP.connect(
-    "example.com:443";
-    timeout_ns = 2_000_000_000,
-    fallback_delay_ns = 100_000_000,
-)
+## Stream I/O and Lifecycle
 
-close(conn)
+`TCP.Conn` follows Julia's standard stream conventions for `read!`, `write`,
+and `close`, while still exposing explicit half-close helpers when you need
+them:
+
+```@docs; canonical=false
+Base.read!(::Conn, ::Vector{UInt8})
+Base.write(::Conn, ::AbstractVector{UInt8})
+Base.close(::Conn)
+Base.close(::Listener)
+closeread
+Base.closewrite(::Conn)
 ```
 
-## Deadlines and Shutdown
+The important behavioral detail is that partial reads and writes are normal:
+reads return as soon as at least one byte is available, and writes retry
+through readiness waits until the requested payload has been written or an
+error/deadline interrupts the operation.
 
-Deadlines live on the connection itself:
+## Deadlines, Socket Options, and Address Inspection
 
-- `TCP.set_deadline!(conn, deadline_ns)`
-- `TCP.set_read_deadline!(conn, deadline_ns)`
-- `TCP.set_write_deadline!(conn, deadline_ns)`
+Deadline management lives on the live connection, not in helper tasks or
+external timeout wrappers:
 
-Full close uses Julia's standard `close(conn)` / `close(listener)` surface.
-
-Half-close remains explicit today:
-
-- `closewrite(conn)`
-- `TCP.closeread(conn)`
-
-```julia
-using Reseau
-
-conn = TCP.connect("example.com:80")
-TCP.set_read_deadline!(conn, time_ns() + 5_000_000_000)
-close(conn)
+```@docs; canonical=false
+set_deadline!
+set_read_deadline!
+set_write_deadline!
+set_nodelay!
+set_keepalive!
+local_addr
+remote_addr
+addr
 ```
 
-## Address Inspection
+Use absolute monotonic nanoseconds from `time_ns()` for deadline APIs. Setting
+a deadline to `0` clears it, while setting it to a time in the past makes the
+next blocking wait time out immediately.
 
-Use these helpers to inspect the bound or connected endpoints:
+## Where To Go Next
 
-- `TCP.local_addr(conn)`
-- `TCP.remote_addr(conn)`
-- `TCP.addr(listener)`
+- Read [TLS](@ref tls-manual) for the TLS wrapper layer that reuses the same transport and deadline model.
+- Read [Name Resolution](@ref name-resolution-manual) for `ResolverPolicy`, `HostResolver`, and explicit resolution helpers.
+- Read [API Reference](@ref api-reference-manual) for the canonical docstrings for the entire TCP surface.

--- a/docs/src/tls.md
+++ b/docs/src/tls.md
@@ -1,62 +1,71 @@
 # TLS
 
-`Reseau.TLS` is the TLS layer that wraps `Reseau.TCP` connections and listeners.
-It uses a Go-style split between reusable configuration and per-connection state.
+`TLS` wraps `TCP` connections and listeners with OpenSSL-backed TLS state while
+keeping deadlines and socket lifecycle aligned with the underlying transport.
 
 ## Core Types
 
-- `Reseau.TLS.Config`
-- `Reseau.TLS.Conn`
-- `Reseau.TLS.Listener`
-- `Reseau.TLS.ClientAuthMode`
+- `TLS.Config`
+- `TLS.Conn`
+- `TLS.Listener`
+- `TLS.ClientAuthMode`
 
 Important error types:
 
-- `Reseau.TLS.ConfigError`
-- `Reseau.TLS.TLSError`
-- `Reseau.TLS.TLSHandshakeTimeoutError`
+- `TLS.ConfigError`
+- `TLS.TLSError`
+- `TLS.TLSHandshakeTimeoutError`
 
 ## Client Connections
 
-The easiest path is `Reseau.TLS.connect`:
+The simplest path is `TLS.connect("host:port"; kwargs...)`:
 
 ```julia
 using Reseau
 
-conn = Reseau.TLS.connect(
-    "tcp",
-    "example.com:443";
-    verify_peer=true,
-    alpn_protocols=["h2", "http/1.1"],
+conn = TLS.connect(
+    "www.google.com:443";
+    verify_peer = true,
+    alpn_protocols = ["h2", "http/1.1"],
 )
+
+state = TLS.connection_state(conn)
+println((state.handshake_complete, state.alpn_protocol))
+close(conn)
 ```
 
-If you already have a `Reseau.TCP.Conn`, wrap it with `Reseau.TLS.client`:
+If you already have a plain `TCP.Conn`, wrap it explicitly:
 
 ```julia
 using Reseau
 
-tcp = Reseau.HostResolvers.connect("tcp", "example.com:443")
-cfg = Reseau.TLS.Config(alpn_protocols=["h2", "http/1.1"])
-tls = Reseau.TLS.client(tcp, cfg)
-Reseau.TLS.handshake!(tls)
+tcp = TCP.connect("example.com:443")
+cfg = TLS.Config(alpn_protocols = ["h2", "http/1.1"])
+tls = TLS.client(tcp, cfg)
+TLS.handshake!(tls)
+
+close(tls)
 ```
 
 ## Server Listeners
 
-Construct a reusable `Config`, then build a TLS listener:
+Construct a reusable `TLS.Config`, then build a TLS listener on top of a TCP
+listener:
 
 ```julia
 using Reseau
 
-cfg = Reseau.TLS.Config(
-    cert_file="server.crt",
-    key_file="server.key",
-    alpn_protocols=["h2", "http/1.1"],
+cfg = TLS.Config(
+    cert_file = "server.crt",
+    key_file = "server.key",
+    alpn_protocols = ["h2", "http/1.1"],
 )
 
-listener = Reseau.TLS.listen("tcp", "127.0.0.1:8443", cfg)
-conn = Reseau.TLS.accept!(listener)
+listener = TLS.listen("tcp", "127.0.0.1:8443", cfg)
+conn = TLS.accept(listener)
+
+close(conn)
+close(listener)
 ```
 
 Accepted connections are returned in lazy-handshake form, just like Go's
@@ -64,7 +73,7 @@ Accepted connections are returned in lazy-handshake form, just like Go's
 
 ## Configuration Highlights
 
-Useful `Config` keywords include:
+Useful `TLS.Config` keywords include:
 
 - `server_name`
 - `verify_peer`
@@ -78,10 +87,13 @@ Useful `Config` keywords include:
 - `min_version`
 - `max_version`
 
-## Operational Notes
+For server-side verified client-certificate auth, provide `client_ca_file`
+explicitly.
 
-- Deadline handling stays aligned with the underlying transport.
-- `server_name` is inferred from dial targets when possible.
-- ALPN is the key bridge between Reseau and HTTP.jl's HTTP/2 behavior.
-- This is the layer to configure certificates and peer verification; HTTP.jl
-  should receive an already-prepared listener or connection policy.
+## Connection Helpers
+
+- `TLS.handshake!(conn)` to complete the handshake eagerly
+- `close(conn)` / `close(listener)` for lifecycle management
+- `TLS.addr(listener)` for the local listener address
+- `TLS.net_conn(conn)` to reach the wrapped `TCP.Conn`
+- `TLS.connection_state(conn)` for a negotiated-state snapshot

--- a/docs/src/tls.md
+++ b/docs/src/tls.md
@@ -1,99 +1,106 @@
-# TLS
+```@meta
+CurrentModule = Reseau.TLS
+Description = "TLS clients, listeners, configuration, and handshake behavior in Reseau.jl."
+```
+
+# [TLS](@id tls-manual)
 
 `TLS` wraps `TCP` connections and listeners with OpenSSL-backed TLS state while
 keeping deadlines and socket lifecycle aligned with the underlying transport.
+String-address client dialing uses the same resolver/policy layer as
+[`Reseau.TCP.connect`](@ref Reseau.TCP.connect); see [Name Resolution](@ref name-resolution-manual)
+for that part of the stack.
 
-## Core Types
-
-- `TLS.Config`
-- `TLS.Conn`
-- `TLS.Listener`
-- `TLS.ClientAuthMode`
-
-Important error types:
-
-- `TLS.ConfigError`
-- `TLS.TLSError`
-- `TLS.TLSHandshakeTimeoutError`
-
-## Client Connections
-
-The simplest path is `TLS.connect("host:port"; kwargs...)`:
-
-```julia
-using Reseau
-
-conn = TLS.connect(
-    "www.google.com:443";
-    verify_peer = true,
-    alpn_protocols = ["h2", "http/1.1"],
-)
-
-state = TLS.connection_state(conn)
-println((state.handshake_complete, state.alpn_protocol))
-close(conn)
+```@contents
+Pages = ["tls.md"]
+Depth = 2:3
 ```
 
-If you already have a plain `TCP.Conn`, wrap it explicitly:
+## Configuration, Types, and Errors
 
-```julia
-using Reseau
+The main TLS building blocks are:
 
-tcp = TCP.connect("example.com:443")
-cfg = TLS.Config(alpn_protocols = ["h2", "http/1.1"])
-tls = TLS.client(tcp, cfg)
-TLS.handshake!(tls)
-
-close(tls)
+```@docs; canonical=false
+Config
+ConnectionState
+Conn
+Listener
+ConfigError
+TLSError
+TLSHandshakeTimeoutError
 ```
 
-## Server Listeners
+`ClientAuthMode` is an enum-like policy surface with the following cases:
 
-Construct a reusable `TLS.Config`, then build a TLS listener on top of a TCP
-listener:
-
-```julia
-using Reseau
-
-cfg = TLS.Config(
-    cert_file = "server.crt",
-    key_file = "server.key",
-    alpn_protocols = ["h2", "http/1.1"],
-)
-
-listener = TLS.listen("tcp", "127.0.0.1:8443", cfg)
-conn = TLS.accept(listener)
-
-close(conn)
-close(listener)
-```
-
-Accepted connections are returned in lazy-handshake form, just like Go's
-`crypto/tls`.
-
-## Configuration Highlights
-
-Useful `TLS.Config` keywords include:
-
-- `server_name`
-- `verify_peer`
-- `client_auth`
-- `cert_file`
-- `key_file`
-- `ca_file`
-- `client_ca_file`
-- `alpn_protocols`
-- `handshake_timeout_ns`
-- `min_version`
-- `max_version`
+- `TLS.ClientAuthMode.NoClientCert`
+- `TLS.ClientAuthMode.RequestClientCert`
+- `TLS.ClientAuthMode.RequireAnyClientCert`
+- `TLS.ClientAuthMode.VerifyClientCertIfGiven`
+- `TLS.ClientAuthMode.RequireAndVerifyClientCert`
 
 For server-side verified client-certificate auth, provide `client_ca_file`
-explicitly.
+explicitly in [`Config`](@ref).
 
-## Connection Helpers
+## Client and Server Construction
 
-- `TLS.handshake!(conn)` to complete the handshake eagerly
-- `close(conn)` / `close(listener)` for lifecycle management
-- `TLS.addr(listener)` for the local listener address
-- `TLS.net_conn(conn)` to reach the wrapped `TCP.Conn`
-- `TLS.connection_state(conn)` for a negotiated-state snapshot
+You can either dial and handshake a client in one step, or wrap an existing
+`TCP.Conn` manually:
+
+```@docs; canonical=false
+client
+server
+connect
+listen
+accept
+handshake!
+```
+
+Important behaviors to keep in mind:
+
+- [`connect`](@ref) returns a fully handshaken client connection.
+- [`listen`](@ref) returns a TLS listener whose accepted connections are
+  lazy-handshake wrappers.
+- [`client`](@ref) and [`server`](@ref) are the direct wrapping APIs when you
+  already control the underlying `TCP.Conn`.
+- [`handshake!`](@ref) is idempotent, so eager and lazy handshake styles can coexist safely.
+
+## I/O, Lifecycle, Deadlines, and Inspection
+
+TLS connections still behave like Julia streams, but now read and write operate
+on plaintext application data while OpenSSL handles record framing underneath:
+
+```@docs; canonical=false
+Base.read!(::Conn, ::Vector{UInt8})
+Base.write(::Conn, ::AbstractVector{UInt8})
+Base.close(::Conn)
+Base.close(::Listener)
+Base.closewrite(::Conn)
+set_deadline!
+set_read_deadline!
+set_write_deadline!
+local_addr
+remote_addr
+net_conn
+connection_state
+addr
+```
+
+Two details matter in practice:
+
+- TLS deadlines are delegated to the wrapped TCP transport, so the timeout
+  model matches [TCP](@ref tcp-manual) exactly.
+- A timed-out TLS write is treated as a permanent write failure, mirroring Go's
+  `crypto/tls` behavior where partial record emission leaves future writes
+  unsafe.
+
+## Practical Usage Notes
+
+- If `server_name` is omitted, [`connect`](@ref) derives it from the dial target when possible so SNI and certificate verification behave like Go's defaults.
+- If `ca_file` is omitted for outbound verification, Reseau falls back to `NetworkOptions.ca_roots_path()` when that path is available.
+- [`connection_state`](@ref) does not force the handshake to run; it reports the current negotiated state as-is.
+
+## Where To Go Next
+
+- Read [TCP](@ref tcp-manual) for the underlying transport model and socket lifecycle.
+- Read [Name Resolution](@ref name-resolution-manual) for resolver and address-family policy controls shared by `TCP.connect` and `TLS.connect`.
+- Read [API Reference](@ref api-reference-manual) for the canonical TLS docstrings.

--- a/src/1_eventloops.jl
+++ b/src/1_eventloops.jl
@@ -126,6 +126,13 @@ function pollwait!(waiter::PollWaiter)::PollWakeReason.T
     end
 end
 
+@inline function _merge_wake_reason(
+        current::PollWakeReason.T,
+        incoming::PollWakeReason.T,
+    )::PollWakeReason.T
+    return current == PollWakeReason.READY ? current : incoming
+end
+
 """
     pollnotify!(waiter, reason=PollWakeReason.READY)
 
@@ -138,13 +145,6 @@ behavior once readiness has already been latched.
 Throws `ArgumentError` if the waiter state machine is observed in an invalid
 state.
 """
-@inline function _merge_wake_reason(
-        current::PollWakeReason.T,
-        incoming::PollWakeReason.T,
-    )::PollWakeReason.T
-    return current == PollWakeReason.READY ? current : incoming
-end
-
 function pollnotify!(waiter::PollWaiter, reason::PollWakeReason.T = PollWakeReason.READY)::Bool
     state = @atomic :acquire waiter.state
     while true

--- a/src/2_socket_ops_darwin.jl
+++ b/src/2_socket_ops_darwin.jl
@@ -220,7 +220,7 @@ Attempt one non-blocking connect and return the raw errno-style result expected
 by the transport layer.
 
 `0` means the socket connected immediately. `EINPROGRESS` and similar values are
-not treated as exceptional here; they are returned so `TCP.connect_tcp_fd!` can
+not treated as exceptional here; they are returned so `TCP.connect` can
 switch into the poll-driven "wait writable, then inspect `SO_ERROR`" path used
 by Go as well.
 """

--- a/src/3_internal_poll.jl
+++ b/src/3_internal_poll.jl
@@ -616,7 +616,7 @@ Tear down polling state for a descriptor and deregister from `EventLoops`.
 
 Returns `nothing`.
 """
-function close!(pd::PollState)
+function Base.close(pd::PollState)
     was_pollable = false
     lock(pd.lock)
     try
@@ -670,7 +670,7 @@ Returns `nothing`.
 Throws the same exceptions as `_convert_poll_error!` if close, timeout, or
 backend error state is already visible.
 """
-function prepare_read!(pd::PollState, is_file::Bool = false)
+function prepareread(pd::PollState, is_file::Bool = false)
     _convert_poll_error!(_check_error(pd, PollOp.READ), is_file)
     return nothing
 end
@@ -680,7 +680,7 @@ Validate write path state before issuing a write syscall.
 
 Returns `nothing`.
 """
-function prepare_write!(pd::PollState, is_file::Bool = false)
+function preparewrite(pd::PollState, is_file::Bool = false)
     _convert_poll_error!(_check_error(pd, PollOp.WRITE), is_file)
     return nothing
 end
@@ -697,7 +697,7 @@ Throws:
 - `DeadlineExceededError` if the read deadline expires
 - `NotPollableError` if the backend reports a permanent readiness error
 """
-function wait_read!(pd::PollState, is_file::Bool = false)
+function waitread(pd::PollState, is_file::Bool = false)
     while true
         _convert_poll_error!(_check_error(pd, PollOp.READ), is_file)
         pollable(pd) || throw(ArgumentError("waiting for unsupported file type"))
@@ -717,7 +717,7 @@ stale before the waiter task resumes.
 
 Returns `nothing`.
 """
-function wait_write!(pd::PollState, is_file::Bool = false)
+function waitwrite(pd::PollState, is_file::Bool = false)
     while true
         _convert_poll_error!(_check_error(pd, PollOp.WRITE), is_file)
         pollable(pd) || throw(ArgumentError("waiting for unsupported file type"))
@@ -736,11 +736,11 @@ Wait for readiness in a cancellation context (used by close/deadline wake paths)
 
 Returns `nothing`.
 
-Unlike `wait_read!`/`wait_write!`, this helper intentionally does not translate
+Unlike `waitread`/`waitwrite`, this helper intentionally does not translate
 the wakeup into exceptions; callers use it when they need a best-effort park
 that can be interrupted by close/cancel machinery.
 """
-function wait_canceled!(pd::PollState, mode::PollOp.T)
+function waitcancelled(pd::PollState, mode::PollOp.T)
     pollable(pd) || return nothing
     registration = EventLoops.current_registration(pd)
     registration === nothing && return nothing
@@ -820,7 +820,7 @@ function _fd_write_unlock!(fd::FD)
 end
 
 function _destroy!(fd::FD)
-    close!(fd.pd)
+    close(fd.pd)
     if fd.sysfd >= 0
         SocketOps.close_socket_nothrow(fd.sysfd)
         fd.sysfd = Cint(-1)
@@ -836,7 +836,7 @@ Returns `nothing`.
 
 Throws `NetClosingError` or `FileClosingError` if close had already started.
 """
-function close!(fd::FD)
+function Base.close(fd::FD)
     _fdlock_incref_and_close!(fd.fdlock) || throw(_closing_error(fd.is_file))
     evict!(fd.pd)
     _fd_decref!(fd)
@@ -871,7 +871,7 @@ applied before calling this helper.
 function connect!(fd::FD, addrbuf::Vector{UInt8}, addrlen::Int32)
     _fd_write_lock!(fd)
     try
-        prepare_write!(fd.pd, fd.is_file)
+        preparewrite(fd.pd, fd.is_file)
         registration = _poll_registration(fd.pd)
         errno = EventLoops._iocp_submit_connect!(registration, addrbuf, addrlen)
         errno == Int32(0) || throw(SystemError("connectex", Int(errno)))
@@ -904,7 +904,7 @@ on `EINTR`/`ECONNABORTED`, wait on `EAGAIN`.
 function accept!(fd::FD, family::Cint, sotype::Cint)::Tuple{Cint, SocketOps.AcceptPeer}
     _fd_read_lock!(fd)
     try
-        prepare_read!(fd.pd, fd.is_file)
+        prepareread(fd.pd, fd.is_file)
         while true
             @static if Sys.iswindows()
                 registration = _poll_registration(fd.pd)
@@ -943,7 +943,7 @@ function accept!(fd::FD, family::Cint, sotype::Cint)::Tuple{Cint, SocketOps.Acce
                 return child_sysfd, peer_addr
             end
             if errno == Int32(Base.Libc.EAGAIN) && pollable(fd.pd)
-                wait_read!(fd.pd, fd.is_file)
+                waitread(fd.pd, fd.is_file)
                 continue
             end
             _is_accept_retry_errno(errno) && continue
@@ -975,7 +975,7 @@ function read!(fd::FD, p::Vector{UInt8})::Int
     _fd_read_lock!(fd)
     try
         isempty(p) && return 0
-        prepare_read!(fd.pd, fd.is_file)
+        prepareread(fd.pd, fd.is_file)
         while true
             n = GC.@preserve p SocketOps.read_once!(fd.sysfd, pointer(p), Csize_t(length(p)))
             if n >= 0
@@ -986,7 +986,7 @@ function read!(fd::FD, p::Vector{UInt8})::Int
             end
             errno = SocketOps.last_error()
             if errno == Int32(Base.Libc.EAGAIN) && pollable(fd.pd)
-                wait_read!(fd.pd, fd.is_file)
+                waitread(fd.pd, fd.is_file)
                 continue
             end
             throw(SystemError("read", Int(errno)))
@@ -1033,7 +1033,7 @@ function _write_ptr!(fd::FD, p::Ptr{UInt8}, nbytes::Int)::Int
     _fd_write_lock!(fd)
     nn = 0
     try
-        prepare_write!(fd.pd, fd.is_file)
+        preparewrite(fd.pd, fd.is_file)
         while true
             nn == nbytes && return nn
             n = SocketOps.write_once!(fd.sysfd, p + nn, Csize_t(nbytes - nn))
@@ -1044,7 +1044,7 @@ function _write_ptr!(fd::FD, p::Ptr{UInt8}, nbytes::Int)::Int
             n == 0 && throw(EOFError())
             errno = SocketOps.last_error()
             if errno == Int32(Base.Libc.EAGAIN) && pollable(fd.pd)
-                wait_write!(fd.pd, fd.is_file)
+                waitwrite(fd.pd, fd.is_file)
                 continue
             end
             throw(SystemError("write", Int(errno)))

--- a/src/4_tcp.jl
+++ b/src/4_tcp.jl
@@ -21,16 +21,18 @@ using ..Reseau.SocketOps
 """
     connect
     listen
+    accept
 
 Primary user-facing TCP entry points.
 
 This file defines the concrete-address methods like `connect(::SocketAddr)` and
-`listen(::SocketAddr)`. String/hostname-based overloads are added later by the
-`HostResolvers` module so callers can still use one unified `TCP.connect` /
-`TCP.listen` surface.
+`listen(::SocketAddr)`. String/hostname-based overloads are added later so
+callers can still use one unified `TCP.connect` / `TCP.listen` surface.
+`accept(::Listener)` completes the listener side.
 """
 function connect end
 function listen end
+function accept end
 
 """
     SocketAddr
@@ -525,7 +527,7 @@ function connect_tcp_fd!(
         _apply_default_tcp_opts!(fd)
         return fd
     catch
-        close!(fd)
+        close(fd)
         rethrow()
     end
 end
@@ -553,7 +555,7 @@ function listen_tcp_fd!(local_addr::SocketAddr; backlog::Integer = 128, reuseadd
         _set_local_addr!(fd)
         return fd
     catch
-        close!(fd)
+        close(fd)
         rethrow()
     end
 end
@@ -583,7 +585,7 @@ function accept_tcp_fd!(listener_fd::FD)::FD
         @atomic :release child.is_connected = true
         return child
     catch
-        close!(child)
+        close(child)
         rethrow()
     end
 end
@@ -614,14 +616,14 @@ function listen(local_addr::SocketAddr; backlog::Integer = 128, reuseaddr::Bool 
 end
 
 """
-    accept!(listener)
+    accept(listener)
 
 Accept a new `Conn` from `listener`.
 
 Throws `SystemError`, `IOPoll.DeadlineExceededError`, or other poll/transport
 errors if the underlying accept path fails.
 """
-function accept!(listener::Listener)::Conn
+function accept(listener::Listener)::Conn
     return Conn(accept_tcp_fd!(listener.fd))
 end
 
@@ -674,51 +676,51 @@ function Base.write(conn::Conn, buf::ByteMemory, nbytes::Integer)::Int
 end
 
 """
-    close!(conn)
+    close(conn)
 
 Close the connection. Repeated closes are treated as no-ops.
 """
-function close!(conn::Conn)
-    close!(conn.fd)
+function Base.close(conn::Conn)
+    close(conn.fd)
     return nothing
 end
 
 """
-    close!(listener)
+    close(listener)
 
 Close the listening socket. Repeated closes are treated as no-ops.
 """
-function close!(listener::Listener)
-    close!(listener.fd)
+function Base.close(listener::Listener)
+    close(listener.fd)
     return nothing
 end
 
 """
-    close_read!(conn)
+    closeread(conn)
 
 Shut down the read side of the TCP connection.
 """
-function close_read!(conn::Conn)
+function closeread(conn::Conn)
     SocketOps.shutdown_socket(conn.fd.pfd.sysfd, SocketOps.SHUT_RD)
     return nothing
 end
 
 """
-    close_write!(conn)
+    closewrite(conn)
 
 Shut down the write side of the TCP connection.
 """
-function close_write!(conn::Conn)
+function Base.closewrite(conn::Conn)
     SocketOps.shutdown_socket(conn.fd.pfd.sysfd, SocketOps.SHUT_WR)
     return nothing
 end
 
 """
-    close!(fd::FD)
+    close(fd)
 
 Close a net descriptor. Repeated closes are treated as no-op.
 """
-function close!(fd::FD)
+function Base.close(fd::FD)
     IOPoll.close!(fd.pfd)
     return nothing
 end

--- a/src/4_tcp.jl
+++ b/src/4_tcp.jl
@@ -20,18 +20,25 @@ using ..Reseau.SocketOps
 
 """
     connect
-    listen
-    accept
 
-Primary user-facing TCP entry points.
-
-This file defines the concrete-address methods like `connect(::SocketAddr)` and
-`listen(::SocketAddr)`. String/hostname-based overloads are added later so
-callers can still use one unified `TCP.connect` / `TCP.listen` surface.
-`accept(::Listener)` completes the listener side.
+Connect a TCP client using either a concrete `SocketAddr` or a string-address
+overload added later in the file load order.
 """
 function connect end
+
+"""
+    listen
+
+Create a TCP listener from either a concrete `SocketAddr` or a string-address
+overload added later in the file load order.
+"""
 function listen end
+
+"""
+    accept
+
+Accept one inbound `Conn` from a `TCP.Listener`.
+"""
 function accept end
 
 """
@@ -375,7 +382,7 @@ function _wait_connect_complete!(
                 # This mirrors Go's non-blocking connect completion path:
                 # wait for writability, then inspect `SO_ERROR` to learn whether
                 # the connection actually succeeded.
-                IOPoll.wait_write!(fd.pfd.pd)
+                IOPoll.waitwrite(fd.pfd.pd)
             catch err
                 ex = err::Exception
                 if ex isa IOPoll.DeadlineExceededError && _connect_canceled(cancel_state)
@@ -435,32 +442,23 @@ function open_tcp_fd!(; family::Cint = SocketOps.AF_INET)::FD
 end
 
 """
-    connect_tcp_fd!(remote_addr; local_addr=nothing, connect_deadline_ns=0)
+    connect(remote_addr; local_addr=nothing)
 
-Create and connect a non-blocking TCP `FD` using Go-style connect completion:
-wait write-ready, then verify with `SO_ERROR`.
+Connect a TCP connection and return `Conn`.
 
-Arguments:
-- `remote_addr`: remote endpoint to connect to
-- `local_addr`: optional source address to bind before connecting
-- `connect_deadline_ns`: absolute monotonic deadline used for the write-wait path
-- `cancel_state`: internal cancellation hook used by parallel dial racing
+This is the simplest direct-address API. For host/port strings, name
+resolution, and timeout-aware connect policy, use the `connect(network,
+address...)` overloads on the same `TCP.connect` generic.
 
-Returns the connected internal `FD`.
-
-Throws:
-- `ArgumentError` if local/remote address families do not match
-- `SystemError` for socket, bind, connect, or socket-option failures
-- `IOPoll.DeadlineExceededError` if the connect wait times out
-- `ConnectCanceledError` when a higher-level parallel dial path cancels the
-  attempt after another candidate wins
+Internal callers may also pass `connect_deadline_ns` and `cancel_state` to
+reuse the same implementation for deadline- and race-aware dial paths.
 """
-function connect_tcp_fd!(
+function connect(
         remote_addr::SocketAddr;
         local_addr::Union{Nothing, SocketAddr} = nothing,
         connect_deadline_ns::Integer = Int64(0),
         cancel_state = nothing,
-    )::FD
+    )::Conn
     family = _addr_family(remote_addr)
     if local_addr !== nothing && _addr_family(local_addr) != family
         throw(ArgumentError("local and remote address families must match"))
@@ -496,14 +494,14 @@ function connect_tcp_fd!(
                 end
             end
             _apply_default_tcp_opts!(fd)
-            return fd
+            return Conn(fd)
         end
         errno = SocketOps.connect_socket(fd.pfd.sysfd, _to_sockaddr(remote_addr))
         if errno == Int32(0) || errno == Int32(Base.Libc.EISCONN)
             IOPoll.init!(fd.pfd; net = :tcp, pollable = true)
             _finalize_connected_addrs!(fd, remote_addr)
             _apply_default_tcp_opts!(fd)
-            return fd
+            return Conn(fd)
         end
         _is_connect_pending_errno(errno) || throw(SystemError("connect", Int(errno)))
         IOPoll.init!(fd.pfd; net = :tcp, pollable = true)
@@ -525,7 +523,7 @@ function connect_tcp_fd!(
             end
         end
         _apply_default_tcp_opts!(fd)
-        return fd
+        return Conn(fd)
     catch
         close(fd)
         rethrow()
@@ -533,18 +531,14 @@ function connect_tcp_fd!(
 end
 
 """
-    listen_tcp_fd!(local_addr; backlog=128, reuseaddr=true)
+    listen(local_addr; backlog=128, reuseaddr=true)
 
-Create a listening TCP `FD` bound to `local_addr`.
+Create a TCP listener from a bound local address.
 
-Keyword arguments:
-- `backlog`: listen backlog passed to the kernel
-- `reuseaddr`: whether to enable `SO_REUSEADDR` before binding
-
-Returns an internal listening `FD`. Throws `SystemError` on bind/listen/setup
-failures.
+This is the direct-address equivalent of the `listen(network, address; ...)`
+overloads on the same `TCP.listen` generic.
 """
-function listen_tcp_fd!(local_addr::SocketAddr; backlog::Integer = 128, reuseaddr::Bool = true)::FD
+function listen(local_addr::SocketAddr; backlog::Integer = 128, reuseaddr::Bool = true)::Listener
     family = _addr_family(local_addr)
     fd = open_tcp_fd!(; family = family)
     try
@@ -553,7 +547,7 @@ function listen_tcp_fd!(local_addr::SocketAddr; backlog::Integer = 128, reuseadd
         SocketOps.listen_socket(fd.pfd.sysfd, backlog)
         IOPoll.init!(fd.pfd; net = :tcp, pollable = true)
         _set_local_addr!(fd)
-        return fd
+        return Listener(fd)
     catch
         close(fd)
         rethrow()
@@ -561,14 +555,15 @@ function listen_tcp_fd!(local_addr::SocketAddr; backlog::Integer = 128, reuseadd
 end
 
 """
-    accept_tcp_fd!(listener_fd)
+    accept(listener)
 
-Accept a child TCP connection, retrying transient accept errors with Go parity.
+Accept a new `Conn` from `listener`.
 
-The returned child descriptor is already poll-initialized and has the default
-TCP options applied, so callers can immediately wrap it in `Conn`.
+Throws `SystemError`, `IOPoll.DeadlineExceededError`, or other poll/transport
+errors if the underlying accept path fails.
 """
-function accept_tcp_fd!(listener_fd::FD)::FD
+function accept(listener::Listener)::Conn
+    listener_fd = listener.fd
     child_sysfd, peer_addr = IOPoll.accept!(listener_fd.pfd, listener_fd.family, listener_fd.sotype)
     child = _new_netfd(
         child_sysfd;
@@ -583,48 +578,11 @@ function accept_tcp_fd!(listener_fd::FD)::FD
         _set_local_addr!(child)
         _set_remote_addr_from_accept!(child, peer_addr)
         @atomic :release child.is_connected = true
-        return child
+        return Conn(child)
     catch
         close(child)
         rethrow()
     end
-end
-
-"""
-    connect(remote_addr; local_addr=nothing)
-
-Connect a TCP connection and return `Conn`.
-
-This is the simplest direct-address API. For host/port strings, name
-resolution, and timeout-aware connect policy, use the `connect(network,
-address...)` overloads on the same `TCP.connect` generic.
-"""
-function connect(remote_addr::SocketAddr; local_addr::Union{Nothing, SocketAddr} = nothing)::Conn
-    return Conn(connect_tcp_fd!(remote_addr; local_addr = local_addr))
-end
-
-"""
-    listen(local_addr; backlog=128, reuseaddr=true)
-
-Create a TCP listener from a bound local address.
-
-This is the direct-address equivalent of the `listen(network, address; ...)`
-overloads on the same `TCP.listen` generic.
-"""
-function listen(local_addr::SocketAddr; backlog::Integer = 128, reuseaddr::Bool = true)::Listener
-    return Listener(listen_tcp_fd!(local_addr; backlog = backlog, reuseaddr = reuseaddr))
-end
-
-"""
-    accept(listener)
-
-Accept a new `Conn` from `listener`.
-
-Throws `SystemError`, `IOPoll.DeadlineExceededError`, or other poll/transport
-errors if the underlying accept path fails.
-"""
-function accept(listener::Listener)::Conn
-    return Conn(accept_tcp_fd!(listener.fd))
 end
 
 """
@@ -721,7 +679,7 @@ end
 Close a net descriptor. Repeated closes are treated as no-op.
 """
 function Base.close(fd::FD)
-    IOPoll.close!(fd.pfd)
+    close(fd.pfd)
     return nothing
 end
 

--- a/src/5_host_resolvers.jl
+++ b/src/5_host_resolvers.jl
@@ -1516,13 +1516,13 @@ function _resolve_serial(
                     )
                     conn = TCP.Conn(fd)
                     if d.local_addr === nothing && _is_self_connect(conn) && attempt < max_attempts
-                        TCP.close!(conn)
+                        close(conn)
                         continue
                     end
                     if _mark_connect_done!(state)
                         return conn, nothing
                     end
-                    TCP.close!(conn)
+                    close(conn)
                     return nothing, first_err
                 catch err
                     ex = _as_exception(err)

--- a/src/5_host_resolvers.jl
+++ b/src/5_host_resolvers.jl
@@ -1508,13 +1508,12 @@ function _resolve_serial(
                     return nothing, first_err
                 end
                 try
-                    fd = TCP.connect_tcp_fd!(
+                    conn = TCP.connect(
                         remote_addr;
                         local_addr = d.local_addr,
                         connect_deadline_ns = attempt_deadline,
                         cancel_state = state,
                     )
-                    conn = TCP.Conn(fd)
                     if d.local_addr === nothing && _is_self_connect(conn) && attempt < max_attempts
                         close(conn)
                         continue

--- a/src/6_tls.jl
+++ b/src/6_tls.jl
@@ -1260,14 +1260,14 @@ end
 end
 
 """
-    close!(conn)
+    close(conn)
 
 Close the TLS connection and the underlying TCP transport.
 
 If the handshake completed, this best-effort sends a TLS `close_notify` alert before
 closing the socket. The method is idempotent and returns `nothing`.
 """
-function close!(conn::Conn)
+function Base.close(conn::Conn)
     _mark_closed!(conn) || return nothing
     if _handshake_complete(conn) && conn.ssl != C_NULL
         if _try_lock_close_path!(conn)
@@ -1281,7 +1281,7 @@ function close!(conn::Conn)
     end
     try
         # Close the transport first to unblock any in-flight waits.
-        TCP.close!(conn.tcp)
+        close(conn.tcp)
     catch
     end
     lock(conn.handshake_lock)
@@ -1298,7 +1298,7 @@ function close!(conn::Conn)
 end
 
 """
-    close_write!(conn)
+    closewrite(conn)
 
 Send TLS shutdown on the write side and mark future writes as permanently failed.
 
@@ -1309,12 +1309,12 @@ Returns `nothing`.
 
 Throws `TLSError` if the TLS shutdown path fails.
 """
-function close_write!(conn::Conn)
-    _ensure_open!(conn, "close_write")
-    _handshake_complete(conn) || throw(TLSError("close_write", Int32(0), "close_write before handshake complete", nothing))
+function Base.closewrite(conn::Conn)
+    _ensure_open!(conn, "closewrite")
+    _handshake_complete(conn) || throw(TLSError("closewrite", Int32(0), "closewrite before handshake complete", nothing))
     lock(conn.write_lock)
     try
-        _ensure_open!(conn, "close_write")
+        _ensure_open!(conn, "closewrite")
         _ssl_shutdown!(conn)
         conn.write_permanent_error === nothing && (conn.write_permanent_error = TLSError("write", Int32(0), "tls: protocol is shutdown", nothing))
         return nothing
@@ -1322,17 +1322,12 @@ function close_write!(conn::Conn)
         ex = _as_exception(err)
         ex isa TLSError && rethrow()
         if ex isa IOPoll.NetClosingError || _is_closed(conn)
-            throw(_closed_error("close_write", ex))
+            throw(_closed_error("closewrite", ex))
         end
-        throw(_wrap_tls_exception("close_write", ex))
+        throw(_wrap_tls_exception("closewrite", ex))
     finally
         unlock(conn.write_lock)
     end
-end
-
-function Base.close(conn::Conn)
-    close!(conn)
-    return nothing
 end
 
 """
@@ -1464,29 +1459,24 @@ function listen(
 end
 
 """
-    accept!(listener) -> Conn
+    accept(listener) -> Conn
 
 Accept one inbound TCP connection and wrap it in server-side TLS state.
 
 The returned `Conn` has not handshaken yet.
 """
-function accept!(listener::Listener)::Conn
-    tcp = TCP.accept!(listener.listener)
+function accept(listener::Listener)::Conn
+    tcp = TCP.accept(listener.listener)
     return server(tcp, listener.config)
 end
 
 """
-    close!(listener)
+    close(listener)
 
 Close the underlying TCP listener. Returns `nothing`.
 """
-function close!(listener::Listener)
-    TCP.close!(listener.listener)
-    return nothing
-end
-
 function Base.close(listener::Listener)
-    close!(listener)
+    close(listener.listener)
     return nothing
 end
 
@@ -1538,12 +1528,12 @@ function _connect(
         ex = _as_exception(err)
         if tls_conn !== nothing
             try
-                close!(tls_conn)
+                close(tls_conn)
             catch
             end
         else
             try
-                TCP.close!(tcp)
+                close(tcp)
             catch
             end
         end
@@ -1557,7 +1547,7 @@ end
 Connect to `address`, negotiate TLS, and return a fully handshaken client
 connection.
 
-Host-resolution keyword arguments are forwarded to `HostResolvers.HostResolver`:
+Network-resolution keyword arguments are:
 - `timeout_ns`
 - `deadline_ns`
 - `local_addr`

--- a/src/6_tls.jl
+++ b/src/6_tls.jl
@@ -917,17 +917,17 @@ function _wait_ssl_ready!(conn::Conn, ssl_err::Cint, op::AbstractString)
     # OpenSSL's nonblocking contract is the same basic model Go's tls.Conn builds on:
     # retry the operation after the underlying socket becomes readable or writable.
     if ssl_err == _SSL_ERROR_WANT_READ
-        IOPoll.wait_read!(conn.tcp.fd.pfd.pd)
+        IOPoll.waitread(conn.tcp.fd.pfd.pd)
         return true
     end
     if ssl_err == _SSL_ERROR_WANT_WRITE
-        IOPoll.wait_write!(conn.tcp.fd.pfd.pd)
+        IOPoll.waitwrite(conn.tcp.fd.pfd.pd)
         return true
     end
     if ssl_err == _SSL_ERROR_SYSCALL
         errno = SocketOps.last_error()
         if _is_socket_would_block(errno)
-            IOPoll.wait_read!(conn.tcp.fd.pfd.pd)
+            IOPoll.waitread(conn.tcp.fd.pfd.pd)
             return true
         end
         if errno == Int32(0)

--- a/src/8_precompile_workload.jl
+++ b/src/8_precompile_workload.jl
@@ -182,7 +182,7 @@ function _pc_run_tcp_workload!()
     try
         listener = NC.listen(NC.loopback_addr(0); backlog = 16)
         laddr = NC.addr(listener)
-        accept_task = errormonitor(Threads.@spawn NC.accept!(listener))
+        accept_task = errormonitor(Threads.@spawn NC.accept(listener))
         client = NC.connect(NC.loopback_addr(Int((laddr::NC.SocketAddrV4).port)))
         server = fetch(accept_task)
         payload = UInt8[0x41, 0x42, 0x43]
@@ -192,15 +192,15 @@ function _pc_run_tcp_workload!()
         _pc_read_exact!(server, recv_buf) == length(payload) || throw(EOFError())
     finally
         try
-            server === nothing || NC.close!(server)
+            server === nothing || close(server)
         catch
         end
         try
-            client === nothing || NC.close!(client)
+            client === nothing || close(client)
         catch
         end
         try
-            listener === nothing || NC.close!(listener)
+            listener === nothing || close(listener)
         catch
         end
     end
@@ -217,7 +217,7 @@ function _pc_run_host_resolvers_workload!()
         listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 16)
         laddr = NC.addr(listener)
         client = ND.connect("tcp", ND.join_host_port("127.0.0.1", Int((laddr::NC.SocketAddrV4).port)))
-        server = NC.accept!(listener)
+        server = NC.accept(listener)
         payload = UInt8[0x51, 0x52]
         written = write(client, payload)
         written == length(payload) || throw(ArgumentError("host resolver workload expected 2-byte write"))
@@ -225,15 +225,15 @@ function _pc_run_host_resolvers_workload!()
         _pc_read_exact!(server, recv_buf) == length(payload) || throw(EOFError())
     finally
         try
-            server === nothing || NC.close!(server)
+            server === nothing || close(server)
         catch
         end
         try
-            client === nothing || NC.close!(client)
+            client === nothing || close(client)
         catch
         end
         try
-            listener === nothing || NC.close!(listener)
+            listener === nothing || close(listener)
         catch
         end
     end
@@ -265,7 +265,7 @@ function _pc_run_tls_workload!()
         listener = TL.listen("tcp", "127.0.0.1:0", server_cfg; backlog = 8)
         laddr = TL.addr(listener)::NC.SocketAddrV4
         accept_task = errormonitor(Threads.@spawn begin
-            conn = TL.accept!(listener::TL.Listener)
+            conn = TL.accept(listener::TL.Listener)
             TL.handshake!(conn)
             return conn
         end)
@@ -300,15 +300,15 @@ function _pc_run_tls_workload!()
         read_count == 3 || throw(ArgumentError("TLS precompile workload expected 3-byte read"))
     finally
         try
-            server === nothing || TL.close!(server)
+            server === nothing || close(server)
         catch
         end
         try
-            client === nothing || TL.close!(client)
+            client === nothing || close(client)
         catch
         end
         try
-            listener === nothing || TL.close!(listener)
+            listener === nothing || close(listener)
         catch
         end
         EL.shutdown!()

--- a/src/8_precompile_workload.jl
+++ b/src/8_precompile_workload.jl
@@ -129,7 +129,7 @@ function _pc_run_internal_poll_workload!()
         n = IP.read!(ipfd, Vector{UInt8}(undef, 1))
         n == 1 || error("internal poll workload expected one-byte read")
     finally
-        ipfd.sysfd >= 0 && IP.close!(ipfd)
+        ipfd.sysfd >= 0 && close(ipfd)
         _pc_close_fd(fd1)
     end
     return nothing

--- a/test/eventloops_trim_safe.jl
+++ b/test/eventloops_trim_safe.jl
@@ -82,7 +82,7 @@ function run_internal_poll_trim_sample()::Nothing
             err isa IP.NoDeadlineError || rethrow(err)
         end
     finally
-        ipfd.sysfd >= 0 && IP.close!(ipfd)
+        ipfd.sysfd >= 0 && close(ipfd)
         _close_fd(fd1)
     end
     return nothing

--- a/test/host_resolvers_tests.jl
+++ b/test/host_resolvers_tests.jl
@@ -160,7 +160,7 @@ end
 function _nd_close_quiet!(x)
     x === nothing && return nothing
     try
-        NC.close!(x)
+        close(x)
     catch
     end
     return nothing
@@ -426,7 +426,7 @@ else
             try
                 listener = NC.listen("tcp", "127.0.0.1:0"; backlog = 16)
                 laddr = NC.addr(listener)
-                accept_task = errormonitor(Threads.@spawn NC.accept!(listener))
+                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
                 client = NC.connect("tcp", ND.join_host_port("127.0.0.1", Int((laddr::NC.SocketAddrV4).port)); timeout_ns = 1_000_000_000)
                 status = _nd_wait_task_done(accept_task, 2.0)
                 @test status != :timed_out
@@ -460,13 +460,13 @@ else
                         ],
                     ),
                 )
-                warm_accept = errormonitor(Threads.@spawn NC.accept!(listener))
+                warm_accept = errormonitor(Threads.@spawn NC.accept(listener))
                 warm_client = NC.connect("tcp", "dual.test:$port"; resolver = resolver, fallback_delay_ns = 1_000_000)
                 @test _nd_wait_task_done(warm_accept, 2.0) != :timed_out
                 warm_server = fetch(warm_accept)
                 _nd_close_quiet!(warm_server)
                 _nd_close_quiet!(warm_client)
-                accept_task = errormonitor(Threads.@spawn NC.accept!(listener))
+                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
                 connect_task = errormonitor(Threads.@spawn NC.connect("tcp", "dual.test:$port"; resolver = resolver, fallback_delay_ns = 5_000_000_000))
                 @test _nd_wait_task_done(connect_task, 1.5) != :timed_out
                 @test _nd_wait_task_done(accept_task, 1.5) != :timed_out
@@ -490,7 +490,7 @@ else
                 try
                     listener = NC.listen("tcp4", "127.0.0.1:0"; backlog = 4)
                     port = Int((NC.addr(listener)::NC.SocketAddrV4).port)
-                    NC.close!(listener)
+                    close(listener)
                     listener = nothing
                     resolver = ND.StaticResolver(hosts = Dict(
                         "dual-fail.test" => NC.SocketEndpoint[
@@ -527,7 +527,7 @@ else
                 try
                     listener = NC.listen("tcp6", "[::1]:0"; backlog = 16)
                     laddr = NC.addr(listener)::NC.SocketAddrV6
-                    accept_task = errormonitor(Threads.@spawn NC.accept!(listener))
+                    accept_task = errormonitor(Threads.@spawn NC.accept(listener))
                     client = NC.connect("tcp6", ND.join_host_port("::1", Int(laddr.port)); timeout_ns = 1_000_000_000)
                     @test _nd_wait_task_done(accept_task, 2.0) != :timed_out
                     server = fetch(accept_task)
@@ -623,8 +623,8 @@ else
                 resolver = _CountingResolver(0.05, NC.SocketEndpoint[NC.loopback_addr(Int(laddr.port))])
                 singleflight = ND.SingleflightResolver(resolver)
                 accept_task = errormonitor(Threads.@spawn begin
-                    conn_a = NC.accept!(listener)
-                    conn_b = NC.accept!(listener)
+                    conn_a = NC.accept(listener)
+                    conn_b = NC.accept(listener)
                     return conn_a, conn_b
                 end)
                 task1 = errormonitor(Threads.@spawn NC.connect("tcp", "same.test:$(Int(laddr.port))"; resolver = singleflight, timeout_ns = 1_000_000_000, fallback_delay_ns = -1))
@@ -773,7 +773,7 @@ else
             finally
                 if fd !== nothing
                     try
-                        NC.close!(fd)
+                        close(fd)
                     catch
                     end
                 end

--- a/test/host_resolvers_trim_safe.jl
+++ b/test/host_resolvers_trim_safe.jl
@@ -47,7 +47,7 @@ function run_host_resolvers_trim_sample()::Nothing
         laddr = NC.addr(listener)::NC.SocketAddrV4
         resolver = _TrimResolver(NC.loopback_addr(Int(laddr.port)))
         client = ND.connect("tcp", "trim.local:$(Int(laddr.port))"; resolver = resolver, fallback_delay_ns = -1)
-        server = NC.accept!(listener)
+        server = NC.accept(listener)
         payload = UInt8[0x66, 0x67, 0x68]
         recv_buf = Vector{UInt8}(undef, length(payload))
         write(client, payload) == length(payload) || error("expected full write")
@@ -56,19 +56,19 @@ function run_host_resolvers_trim_sample()::Nothing
     finally
         if server !== nothing
             try
-                NC.close!(server::NC.Conn)
+                close(server::NC.Conn)
             catch
             end
         end
         if client !== nothing
             try
-                NC.close!(client::NC.Conn)
+                close(client::NC.Conn)
             catch
             end
         end
         if listener !== nothing
             try
-                NC.close!(listener::NC.Listener)
+                close(listener::NC.Listener)
             catch
             end
         end

--- a/test/internal_poll_tests.jl
+++ b/test/internal_poll_tests.jl
@@ -56,10 +56,10 @@ else
                 end
             finally
                 if read_task isa Task && !istaskdone(read_task)
-                    IP.close!(ipfd)
+                    close(ipfd)
                 end
                 if ipfd.sysfd >= 0
-                    IP.close!(ipfd)
+                    close(ipfd)
                 end
                 _ip_close_fd(fd1)
                 EL.shutdown!()
@@ -79,7 +79,7 @@ else
                 n = IP.read!(ipfd, Vector{UInt8}(undef, 1))
                 @test n == 1
             finally
-                ipfd.sysfd >= 0 && IP.close!(ipfd)
+                ipfd.sysfd >= 0 && close(ipfd)
                 _ip_close_fd(fd1)
                 EL.shutdown!()
             end
@@ -100,7 +100,7 @@ else
                 @test n == 1
                 @test buf[1] == 0x63
             finally
-                ipfd.sysfd >= 0 && IP.close!(ipfd)
+                ipfd.sysfd >= 0 && close(ipfd)
                 _ip_close_fd(fd1)
                 EL.shutdown!()
             end
@@ -115,7 +115,7 @@ else
                 IP.init!(ipfd)
                 IP.set_read_deadline!(ipfd, time_ns() + 100_000_000)
                 wait_task = errormonitor(Threads.@spawn begin
-                    IP.wait_read!(ipfd.pd, ipfd.is_file)
+                    IP.waitread(ipfd.pd, ipfd.is_file)
                     return :ok
                 end)
                 pre = EL.timedwait(() -> istaskdone(wait_task), 0.05; pollint = 0.001)
@@ -130,9 +130,9 @@ else
                 status == :timed_out || @test fetch(wait_task) == :ok
             finally
                 if wait_task isa Task && !istaskdone(wait_task)
-                    IP.close!(ipfd)
+                    close(ipfd)
                 end
-                ipfd.sysfd >= 0 && IP.close!(ipfd)
+                ipfd.sysfd >= 0 && close(ipfd)
                 _ip_close_fd(fd1)
                 EL.shutdown!()
             end
@@ -175,7 +175,7 @@ else
                 @test IP._check_error(ipfd.pd, IP.PollOp.READ) == Int32(0)
                 @test IP._check_error(ipfd.pd, IP.PollOp.WRITE) == Int32(0)
             finally
-                ipfd.sysfd >= 0 && IP.close!(ipfd)
+                ipfd.sysfd >= 0 && close(ipfd)
                 _ip_close_fd(fd1)
                 EL.shutdown!()
             end
@@ -198,7 +198,7 @@ else
                 end)
                 pre = EL.timedwait(() -> istaskdone(read_task), 0.05; pollint = 0.001)
                 @test pre == :timed_out
-                IP.close!(ipfd)
+                close(ipfd)
                 status = EL.timedwait(() -> istaskdone(read_task), 2.0; pollint = 0.001)
                 @test status != :timed_out
                 if status != :timed_out
@@ -220,9 +220,9 @@ else
                 state = EL.POLLER[]
                 event = EL.PollEvent(ipfd.sysfd, ipfd.pd.token, EL.PollMode.READ, true)
                 EL._dispatch_ready_event!(state, event)
-                @test_throws IP.NotPollableError IP.prepare_read!(ipfd.pd)
+                @test_throws IP.NotPollableError IP.prepareread(ipfd.pd)
             finally
-                ipfd.sysfd >= 0 && IP.close!(ipfd)
+                ipfd.sysfd >= 0 && close(ipfd)
                 _ip_close_fd(fd1)
                 EL.shutdown!()
             end
@@ -236,7 +236,7 @@ else
                 IP._set_nonblocking!(ipfd.sysfd)
                 IP.init!(ipfd)
                 wait_task = errormonitor(Threads.@spawn begin
-                    IP.wait_canceled!(ipfd.pd, IP.PollOp.READ)
+                    IP.waitcancelled(ipfd.pd, IP.PollOp.READ)
                     return :ok
                 end)
                 pre = EL.timedwait(() -> istaskdone(wait_task), 0.05; pollint = 0.001)
@@ -249,9 +249,9 @@ else
                 end
             finally
                 if wait_task isa Task && !istaskdone(wait_task)
-                    IP.close!(ipfd)
+                    close(ipfd)
                 end
-                ipfd.sysfd >= 0 && IP.close!(ipfd)
+                ipfd.sysfd >= 0 && close(ipfd)
                 _ip_close_fd(fd1)
                 EL.shutdown!()
             end

--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -25,7 +25,7 @@ end
 function _close_quiet!(x)
     x === nothing && return nothing
     try
-        NC.close!(x)
+        close(x)
     catch
     end
     return nothing
@@ -48,7 +48,7 @@ else
                 laddr = NC.addr(listener)
                 @test laddr isa NC.SocketAddrV4
                 @test (laddr::NC.SocketAddrV4).port > 0
-                accept_task = errormonitor(Threads.@spawn NC.accept!(listener))
+                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
                 pre = _nc_wait_task_done(accept_task, 0.05)
                 @test pre == :timed_out
                 client = NC.connect(NC.loopback_addr(Int((laddr::NC.SocketAddrV4).port)))
@@ -96,7 +96,7 @@ else
             try
                 listener = NC.listen("tcp", "127.0.0.1:0"; backlog = 8)
                 laddr = NC.addr(listener)::NC.SocketAddrV4
-                accept_task = errormonitor(Threads.@spawn NC.accept!(listener))
+                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
                 client = NC.connect("tcp", "127.0.0.1:$(Int(laddr.port))"; local_addr = NC.loopback_addr(0))
                 @test _nc_wait_task_done(accept_task, 2.0) != :timed_out
                 server = fetch(accept_task)
@@ -128,7 +128,7 @@ else
             try
                 listener = NC.listen(NC.loopback_addr(0); backlog = 8)
                 laddr = NC.addr(listener)::NC.SocketAddrV4
-                accept_task = errormonitor(Threads.@spawn NC.accept!(listener))
+                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
                 client = NC.connect(NC.loopback_addr(Int(laddr.port)))
                 @test _nc_wait_task_done(accept_task, 2.0) != :timed_out
                 server = fetch(accept_task)
@@ -150,7 +150,7 @@ else
                 listener = NC.listen(NC.loopback_addr(0); backlog = 8)
                 laddr = NC.addr(listener)
                 port = Int((laddr::NC.SocketAddrV4).port)
-                NC.close!(listener)
+                close(listener)
                 listener = nothing
                 err = try
                     NC.connect(NC.loopback_addr(port))
@@ -175,7 +175,7 @@ else
                 listener = NC.listen(NC.loopback_addr(0); backlog = 8)
                 accept_task = errormonitor(Threads.@spawn begin
                     try
-                        NC.accept!(listener)
+                        NC.accept(listener)
                         return :ok
                     catch err
                         return err
@@ -183,7 +183,7 @@ else
                 end)
                 pre = _nc_wait_task_done(accept_task, 0.05)
                 @test pre == :timed_out
-                NC.close!(listener)
+                close(listener)
                 listener = nothing
                 status = _nc_wait_task_done(accept_task, 2.0)
                 @test status != :timed_out
@@ -204,7 +204,7 @@ else
             try
                 listener = NC.listen(NC.loopback_addr(0); backlog = 8)
                 laddr = NC.addr(listener)
-                accept_task = errormonitor(Threads.@spawn NC.accept!(listener))
+                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
                 client = NC.connect(NC.loopback_addr(Int((laddr::NC.SocketAddrV4).port)))
                 status = _nc_wait_task_done(accept_task, 2.0)
                 @test status != :timed_out
@@ -232,7 +232,7 @@ else
             try
                 listener = NC.listen(NC.loopback_addr(0); backlog = 8)
                 laddr = NC.addr(listener)
-                accept_task = errormonitor(Threads.@spawn NC.accept!(listener))
+                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
                 client = NC.connect(NC.loopback_addr(Int((laddr::NC.SocketAddrV4).port)))
                 status = _nc_wait_task_done(accept_task, 2.0)
                 @test status != :timed_out
@@ -247,16 +247,16 @@ else
                 end)
                 pre = _nc_wait_task_done(read_task, 0.05)
                 @test pre == :timed_out
-                NC.close!(server)
-                @test_throws IP.NetClosingError NC.close!(server)
+                close(server)
+                @test_throws IP.NetClosingError close(server)
                 done = _nc_wait_task_done(read_task, 2.0)
                 @test done != :timed_out
                 if done != :timed_out
                     err = fetch(read_task)
                     @test err isa IP.NetClosingError
                 end
-                NC.close!(listener)
-                @test_throws IP.NetClosingError NC.close!(listener)
+                close(listener)
+                @test_throws IP.NetClosingError close(listener)
             finally
                 _close_quiet!(server)
                 _close_quiet!(client)
@@ -273,7 +273,7 @@ else
                 sysfd_before = fd.pfd.sysfd
                 finalize(fd)
                 @test fd.pfd.sysfd == sysfd_before
-                NC.close!(fd)
+                close(fd)
                 @test fd.pfd.sysfd == Cint(-1)
             finally
                 _close_quiet!(fd)
@@ -288,7 +288,7 @@ else
             try
                 listener = NC.listen(NC.loopback_addr(0); backlog = 8)
                 laddr = NC.addr(listener)::NC.SocketAddrV4
-                accept_task = errormonitor(Threads.@spawn NC.accept!(listener))
+                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
                 client = NC.connect(NC.loopback_addr(Int(laddr.port)))
                 @test _nc_wait_task_done(accept_task, 2.0) != :timed_out
                 server = fetch(accept_task)
@@ -300,8 +300,8 @@ else
                 @test SO.get_sockopt_int(client.fd.pfd.sysfd, SO.SOL_SOCKET, SO.SO_KEEPALIVE) == 0
                 NC.set_keepalive!(client, true)
                 @test SO.get_sockopt_int(client.fd.pfd.sysfd, SO.SOL_SOCKET, SO.SO_KEEPALIVE) != 0
-                @test NC.close_read!(client) === nothing
-                NC.close_write!(client)
+                @test NC.closeread(client) === nothing
+                closewrite(client)
                 NC.set_read_deadline!(server, time_ns() + 1_000_000_000)
                 @test_throws EOFError read!(server, Vector{UInt8}(undef, 1))
             finally

--- a/test/tcp_trim_safe.jl
+++ b/test/tcp_trim_safe.jl
@@ -30,7 +30,7 @@ function run_tcp_trim_sample()::Nothing
         listener = NC.listen(NC.loopback_addr(0); backlog = 16)
         laddr = NC.addr(listener)
         client = NC.connect(NC.loopback_addr(Int((laddr::NC.SocketAddrV4).port)))
-        server = NC.accept!(listener)
+        server = NC.accept(listener)
         payload = UInt8[0x30, 0x31, 0x32, 0x33]
         recv_buf = Vector{UInt8}(undef, length(payload))
         _write_all!(client, payload)
@@ -39,19 +39,19 @@ function run_tcp_trim_sample()::Nothing
     finally
         if server !== nothing
             try
-                NC.close!(server::NC.Conn)
+                close(server::NC.Conn)
             catch
             end
         end
         if client !== nothing
             try
-                NC.close!(client::NC.Conn)
+                close(client::NC.Conn)
             catch
             end
         end
         if listener !== nothing
             try
-                NC.close!(listener::NC.Listener)
+                close(listener::NC.Listener)
             catch
             end
         end

--- a/test/tls_tests.jl
+++ b/test/tls_tests.jl
@@ -18,9 +18,9 @@ function _tls_close_quiet!(x)
     x === nothing && return nothing
     try
         if x isa TL.Conn || x isa TL.Listener
-            TL.close!(x)
+            close(x)
         elseif x isa NC.Conn || x isa NC.Listener
-            NC.close!(x)
+            close(x)
         end
     catch
     end
@@ -132,7 +132,7 @@ else
             try
                 listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 4)
                 laddr = NC.addr(listener)::NC.SocketAddrV4
-                accept_task = errormonitor(Threads.@spawn NC.accept!(listener))
+                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
                 client_tcp = ND.connect("tcp", "127.0.0.1:$(Int(laddr.port))")
                 @test _tls_wait_task_done(accept_task, 2.0) != :timed_out
                 server_tcp = fetch(accept_task)
@@ -268,7 +268,7 @@ else
                     request_listener = TL.listen("tcp", "127.0.0.1:0", request_server_cfg; backlog = 8)
                     request_addr = TL.addr(request_listener)::NC.SocketAddrV4
                     request_accept = errormonitor(Threads.@spawn begin
-                        conn = TL.accept!(request_listener)
+                        conn = TL.accept(request_listener)
                         try
                             TL.handshake!(conn)
                             return conn
@@ -299,7 +299,7 @@ else
                 listener = TL.listen("tcp", "127.0.0.1:0", strict_server_cfg; backlog = 8)
                 laddr = TL.addr(listener)::NC.SocketAddrV4
                 accept_task = errormonitor(Threads.@spawn begin
-                    conn = TL.accept!(listener)
+                    conn = TL.accept(listener)
                     try
                         TL.handshake!(conn)
                         _tls_close_quiet!(conn)
@@ -337,7 +337,7 @@ else
             try
                 listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
                 laddr = NC.addr(listener)::NC.SocketAddrV4
-                accept_task = errormonitor(Threads.@spawn NC.accept!(listener))
+                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
                 client_tcp = ND.connect("tcp", "127.0.0.1:$(Int(laddr.port))")
                 @test _tls_wait_task_done(accept_task, 2.0) != :timed_out
                 server_tcp = fetch(accept_task)
@@ -380,7 +380,7 @@ else
                 listener = TL.listen("tcp", "127.0.0.1:0", server_cfg; backlog = 8)
                 laddr = TL.addr(listener)::NC.SocketAddrV4
                 accept_task = errormonitor(Threads.@spawn begin
-                    conn = TL.accept!(listener)
+                    conn = TL.accept(listener)
                     TL.handshake!(conn)
                     return conn
                 end)
@@ -414,7 +414,7 @@ else
                 accept_task = errormonitor(Threads.@spawn begin
                     local conns = TL.Conn[]
                     for _ in 1:2
-                        conn = TL.accept!(listener)
+                        conn = TL.accept(listener)
                         TL.handshake!(conn)
                         push!(conns, conn)
                     end
@@ -469,7 +469,7 @@ else
                 laddr = TL.addr(listener)::NC.SocketAddrV4
                 accept_task = errormonitor(Threads.@spawn begin
                     try
-                        conn = TL.accept!(listener)
+                        conn = TL.accept(listener)
                         TL.handshake!(conn)
                         buf = Vector{UInt8}(undef, 4)
                         n = read!(conn, buf)
@@ -520,12 +520,12 @@ else
                 listener = TL.listen("tcp", "127.0.0.1:0", _tls_server_config(); backlog = 8)
                 laddr = TL.addr(listener)::NC.SocketAddrV4
                 close_task = errormonitor(Threads.@spawn begin
-                    conn = TL.accept!(listener)
+                    conn = TL.accept(listener)
                     try
                         TL.handshake!(conn)
                     catch
                     end
-                    TL.close!(conn)
+                    close(conn)
                     return nothing
                 end)
                 client = _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", TL.Config(
@@ -550,7 +550,7 @@ else
                 listener = TL.listen("tcp", "127.0.0.1:0", _tls_server_config(); backlog = 8)
                 laddr = TL.addr(listener)::NC.SocketAddrV4
                 accept_task = errormonitor(Threads.@spawn begin
-                    conn = TL.accept!(listener)
+                    conn = TL.accept(listener)
                     TL.handshake!(conn)
                     return conn
                 end)
@@ -560,7 +560,7 @@ else
                 ))
                 @test _tls_wait_task_done(accept_task, 2.0) != :timed_out
                 server = fetch(accept_task)
-                TL.close_write!(client)
+                closewrite(client)
                 write_err = try
                     write(client, UInt8[0x41])
                     nothing
@@ -589,7 +589,7 @@ else
             try
                 listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
                 laddr = NC.addr(listener)::NC.SocketAddrV4
-                accept_task = errormonitor(Threads.@spawn NC.accept!(listener))
+                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
                 client_tcp = ND.connect("tcp", "127.0.0.1:$(Int(laddr.port))")
                 @test _tls_wait_task_done(accept_task, 2.0) != :timed_out
                 server_tcp = fetch(accept_task)
@@ -598,7 +598,7 @@ else
                     server_name = "localhost",
                 ))
                 err = try
-                    TL.close_write!(tls_client)
+                    closewrite(tls_client)
                     nothing
                 catch ex
                     ex
@@ -625,7 +625,7 @@ else
                 laddr = TL.addr(listener)::NC.SocketAddrV4
                 accept_task = errormonitor(Threads.@spawn begin
                     try
-                        conn = TL.accept!(listener)
+                        conn = TL.accept(listener)
                         TL.handshake!(conn)
                         return conn
                     catch err
@@ -668,7 +668,7 @@ else
                 listener = TL.listen("tcp", "127.0.0.1:0", _tls_server_config(); backlog = 16)
                 laddr = TL.addr(listener)::NC.SocketAddrV4
                 accept_task = errormonitor(Threads.@spawn begin
-                    conn = TL.accept!(listener)
+                    conn = TL.accept(listener)
                     try
                         TL.handshake!(conn)
                     catch
@@ -706,7 +706,7 @@ else
                 listener = TL.listen("tcp", "127.0.0.1:0", _tls_server_config(); backlog = 16)
                 laddr = TL.addr(listener)::NC.SocketAddrV4
                 accept_task = errormonitor(Threads.@spawn begin
-                    conn = TL.accept!(listener)
+                    conn = TL.accept(listener)
                     try
                         TL.handshake!(conn)
                     catch
@@ -746,7 +746,7 @@ else
                 listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
                 laddr = NC.addr(listener)::NC.SocketAddrV4
                 accept_task = errormonitor(Threads.@spawn begin
-                    conn = NC.accept!(listener)
+                    conn = NC.accept(listener)
                     EL.sleep(1.0)
                     return conn
                 end)
@@ -789,7 +789,7 @@ else
                 listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
                 laddr = NC.addr(listener)::NC.SocketAddrV4
                 accept_task = errormonitor(Threads.@spawn begin
-                    conn = NC.accept!(listener)
+                    conn = NC.accept(listener)
                     EL.sleep(1.0)
                     return conn
                 end)
@@ -830,9 +830,9 @@ else
                 listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
                 laddr = NC.addr(listener)::NC.SocketAddrV4
                 accept_task = errormonitor(Threads.@spawn begin
-                    conn = NC.accept!(listener)
+                    conn = NC.accept(listener)
                     EL.sleep(1.2)
-                    NC.close!(conn)
+                    close(conn)
                     return nothing
                 end)
                 host_resolver = ND.HostResolver(timeout_ns = 100_000_000)
@@ -880,7 +880,7 @@ else
                 listener = TL.listen("tcp", "127.0.0.1:0", _tls_server_config(); backlog = 8)
                 laddr = TL.addr(listener)::NC.SocketAddrV4
                 accept_task = errormonitor(Threads.@spawn begin
-                    conn = TL.accept!(listener)
+                    conn = TL.accept(listener)
                     TL.handshake!(conn)
                     return conn
                 end)
@@ -890,8 +890,8 @@ else
                 ))
                 @test _tls_wait_task_done(accept_task, 2.0) != :timed_out
                 server = fetch(accept_task)
-                TL.close!(client)
-                TL.close!(client)
+                close(client)
+                close(client)
                 @test_throws TL.TLSError TL.handshake!(client)
                 @test_throws TL.TLSError read!(client, Vector{UInt8}(undef, 1))
                 @test_throws TL.TLSError write(client, UInt8[0x41])
@@ -910,10 +910,10 @@ else
                 listener = TL.listen("tcp", "127.0.0.1:0", _tls_server_config(); backlog = 8)
                 laddr = TL.addr(listener)::NC.SocketAddrV4
                 hold_task = errormonitor(Threads.@spawn begin
-                    conn = TL.accept!(listener)
+                    conn = TL.accept(listener)
                     TL.handshake!(conn)
                     EL.sleep(1.5)
-                    TL.close!(conn)
+                    close(conn)
                     return nothing
                 end)
                 client = _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", TL.Config(
@@ -960,7 +960,7 @@ else
                 listener = TL.listen("tcp", "127.0.0.1:0", _tls_server_config(); backlog = 8)
                 laddr = TL.addr(listener)::NC.SocketAddrV4
                 accept_task = errormonitor(Threads.@spawn begin
-                    conn = TL.accept!(listener)
+                    conn = TL.accept(listener)
                     TL.handshake!(conn)
                     return conn
                 end)
@@ -979,7 +979,7 @@ else
                     return :ok
                 end)
                 @test _tls_wait_task_done(read_task, 0.05) == :timed_out
-                TL.close!(client)
+                close(client)
                 @test _tls_wait_task_done(read_task, 2.0) != :timed_out
                 result = fetch(read_task)
                 @test result isa TL.TLSError

--- a/test/tls_trim_safe.jl
+++ b/test/tls_trim_safe.jl
@@ -18,7 +18,7 @@ function run_tls_trim_sample()::Nothing
         listener = NC.listen(NC.loopback_addr(0); backlog = 8)
         laddr = NC.addr(listener)::NC.SocketAddrV4
         client_tcp = NC.connect(NC.loopback_addr(Int(laddr.port)))
-        server_tcp = NC.accept!(listener)
+        server_tcp = NC.accept(listener)
         client_cfg = TL.Config(verify_peer = false, server_name = "localhost", handshake_timeout_ns = 1_000_000_000)
         server_cfg = TL.Config(
             verify_peer = false,
@@ -33,29 +33,29 @@ function run_tls_trim_sample()::Nothing
     finally
         if server_tls !== nothing
             try
-                TL.close!(server_tls::TL.Conn)
+                close(server_tls::TL.Conn)
             catch
             end
         elseif server_tcp !== nothing
             try
-                NC.close!(server_tcp::NC.Conn)
+                close(server_tcp::NC.Conn)
             catch
             end
         end
         if client_tls !== nothing
             try
-                TL.close!(client_tls::TL.Conn)
+                close(client_tls::TL.Conn)
             catch
             end
         elseif client_tcp !== nothing
             try
-                NC.close!(client_tcp::NC.Conn)
+                close(client_tcp::NC.Conn)
             catch
             end
         end
         if listener !== nothing
             try
-                NC.close!(listener::NC.Listener)
+                close(listener::NC.Listener)
             catch
             end
         end


### PR DESCRIPTION
## Summary
- align the public TCP/TLS surface with Base and Sockets expectations by using `accept`, `close`, `closewrite`, and `TCP.closeread`
- rewrite the README and docs around the exported `TCP`/`TLS` entrypoints and remove public-facing HTTP/HostResolvers guidance
- update tests and precompile/trim workloads to the renamed APIs and clean lingering coverage artifacts

## Validation
- `JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'`
- `julia --project=docs --startup-file=no --history-file=no docs/make.jl`