### PR TITLE
ci(workflows): align rolling Julia CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,41 +9,29 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ matrix.timeout_minutes }}
+    timeout-minutes: ${{ matrix.os == 'windows-latest' && 20 || 15 }}
     env:
       JULIA_NUM_THREADS: 1
-      RESEAU_RUN_TLS_TESTS: ${{ matrix.run_tls_tests }}
-      RESEAU_RUN_NETWORK_TESTS: ${{ matrix.run_network_tests }}
+      RESEAU_RUN_TLS_TESTS: '1'
+      RESEAU_RUN_NETWORK_TESTS: '1'
       RESEAU_TRIM_EXE_TIMEOUT_S: "60.0"
-      RESEAU_TRIM_BUNDLE: ${{ matrix.trim_bundle }}
+      RESEAU_TRIM_BUNDLE: ${{ matrix.os == 'windows-latest' && '1' || '0' }}
     strategy:
       fail-fast: false
       matrix:
+        version:
+          - '1'   # latest stable Julia 1.x
+          - 'min' # minimum Julia version from Project.toml compat
+          - 'pre' # latest pre-release Julia
+        os:
+          - ubuntu-latest
+          - windows-latest
+        arch:
+          - x64
         include:
-          - os: ubuntu-latest
-            arch: x64
-            version: '1.10'
-            timeout_minutes: 15
-            run_tls_tests: '1'
-            run_network_tests: '1'
-            trim_bundle: '0'
-            coverage: '1'
           - os: macOS-latest
             arch: aarch64
-            version: '1.10'
-            timeout_minutes: 15
-            run_tls_tests: '1'
-            run_network_tests: '1'
-            trim_bundle: '0'
-            coverage: '0'
-          - os: windows-latest
-            arch: x64
-            version: '1.10'
-            timeout_minutes: 20
-            run_tls_tests: '1'
-            run_network_tests: '1'
-            trim_bundle: '1'
-            coverage: '0'
+            version: '1'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
@@ -53,9 +41,9 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-      - if: matrix.coverage == '1'
+      - if: matrix.os == 'ubuntu-latest' && matrix.arch == 'x64' && matrix.version == '1'
         uses: julia-actions/julia-processcoverage@v1
-      - if: matrix.coverage == '1'
+      - if: matrix.os == 'ubuntu-latest' && matrix.arch == 'x64' && matrix.version == '1'
         uses: codecov/codecov-action@v5
         with:
           files: lcov.info
@@ -72,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1.12'
+          version: '1'
       - uses: julia-actions/cache@v2
       - name: Install docs dependencies
         run: |

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -11,6 +11,7 @@ else
 end
 
 const _TRIM_SUPPORTED = VERSION >= v"1.12.0-rc1"
+const _TRIM_PRE_RELEASE = !isempty(VERSION.prerelease)
 const _JULIAC_ENTRYPOINT_EXPR = "using JuliaC; if isdefined(JuliaC, :main); JuliaC.main(ARGS); else JuliaC._main_cli(ARGS); end"
 
 function _run_trim_compile(project_path::String, script_path::String, output_name::String; timeout_s::Float64 = 120.0, bundle_dir::Union{Nothing, String} = nothing)
@@ -167,6 +168,9 @@ end
 @testset "Trim compile" begin
     if !_TRIM_SUPPORTED
         println("[trim] skip Julia < 1.12: JuliaC trim compilation is unavailable")
+        @test true
+    elseif _TRIM_PRE_RELEASE
+        println("[trim] skip prerelease Julia: trim verifier behavior is not stable yet")
         @test true
     else
         project_path = normpath(joinpath(@__DIR__, ".."))


### PR DESCRIPTION
## Summary
- align the CI matrix with the rolling Julia version policy used in JSON.jl (`1`, `min`, `pre`)
- keep the stable macOS leg and move the docs job onto latest stable Julia
- skip trim compile verification on prerelease Julia where `--trim=safe` verifier behavior is not yet stable

## Validation
- prior equivalent branch-head CI passed in workflow_dispatch run 23162367010
