### PR TITLE
fix(show): compact TCP and TLS displays

### DIFF
--- a/src/4_tcp.jl
+++ b/src/4_tcp.jl
@@ -790,4 +790,32 @@ function addr(listener::Listener)::Union{Nothing, SocketAddr}
     return listener.fd.laddr
 end
 
+@inline function _show_endpoint(io::IO, endpoint::Union{Nothing, SocketAddr})
+    if endpoint === nothing
+        print(io, "?")
+    else
+        show(io, endpoint)
+    end
+    return nothing
+end
+
+@inline _show_state(conn::Conn) = conn.fd.pfd.sysfd >= 0 ? "open" : "closed"
+@inline _show_state(listener::Listener) = listener.fd.pfd.sysfd >= 0 ? "active" : "closed"
+
+function Base.show(io::IO, conn::Conn)
+    print(io, "TCP.Conn(")
+    _show_endpoint(io, local_addr(conn))
+    print(io, " => ")
+    _show_endpoint(io, remote_addr(conn))
+    print(io, ", ", _show_state(conn), ")")
+    return nothing
+end
+
+function Base.show(io::IO, listener::Listener)
+    print(io, "TCP.Listener(")
+    _show_endpoint(io, addr(listener))
+    print(io, ", ", _show_state(listener), ")")
+    return nothing
+end
+
 end

--- a/src/6_tls.jl
+++ b/src/6_tls.jl
@@ -314,6 +314,8 @@ mutable struct Conn
     @atomic handshake_complete::Bool
     @atomic closed::Bool
     write_permanent_error::Union{Nothing, TLSError}
+    negotiated_version::String
+    negotiated_alpn::Union{Nothing, String}
 end
 
 """
@@ -843,7 +845,21 @@ end
 function _new_conn(tcp::TCP.Conn, config::Config; is_server::Bool)::Conn
     ctx = _shared_ssl_ctx(config; is_server = is_server)
     ssl = _ssl_new(ctx, tcp, config; is_server = is_server)
-    return Conn(tcp, ctx, ssl, is_server, config, ReentrantLock(), ReentrantLock(), ReentrantLock(), false, false, nothing)
+    return Conn(
+        tcp,
+        ctx,
+        ssl,
+        is_server,
+        config,
+        ReentrantLock(),
+        ReentrantLock(),
+        ReentrantLock(),
+        false,
+        false,
+        nothing,
+        "",
+        nothing,
+    )
 end
 
 """
@@ -891,6 +907,8 @@ function _mark_closed!(conn::Conn)::Bool
 end
 
 function _set_handshake_complete!(conn::Conn)
+    conn.negotiated_version = _ssl_version(conn)
+    conn.negotiated_alpn = _ssl_alpn_protocol(conn)
     @atomic :release conn.handshake_complete = true
     return nothing
 end
@@ -1430,8 +1448,8 @@ This does not force a handshake; if the handshake has not yet run, the returned
 function connection_state(conn::Conn)::ConnectionState
     return ConnectionState(
         _handshake_complete(conn),
-        _ssl_version(conn),
-        _ssl_alpn_protocol(conn),
+        conn.negotiated_version,
+        conn.negotiated_alpn,
     )
 end
 
@@ -1487,6 +1505,48 @@ Return the local listening address for the wrapped TCP listener.
 """
 function addr(listener::Listener)
     return TCP.addr(listener.listener)
+end
+
+@inline function _show_endpoint(io::IO, endpoint::Union{Nothing, TCP.SocketAddr})
+    if endpoint === nothing
+        print(io, "?")
+    else
+        show(io, endpoint)
+    end
+    return nothing
+end
+
+@inline _show_role(conn::Conn) = conn.is_server ? "server" : "client"
+@inline _show_state(listener::Listener) = listener.listener.fd.pfd.sysfd >= 0 ? "active" : "closed"
+@inline _show_closed(conn::Conn) = _is_closed(conn) || conn.ssl == C_NULL || conn.tcp.fd.pfd.sysfd < 0
+
+function Base.show(io::IO, conn::Conn)
+    print(io, "TLS.Conn(")
+    _show_endpoint(io, local_addr(conn))
+    print(io, " => ")
+    _show_endpoint(io, remote_addr(conn))
+    print(io, ", ", _show_role(conn))
+    if _show_closed(conn)
+        print(io, ", closed")
+    elseif !_handshake_complete(conn)
+        print(io, ", handshake pending")
+    else
+        if isempty(conn.negotiated_version)
+            print(io, ", handshake complete")
+        else
+            print(io, ", ", conn.negotiated_version)
+        end
+        conn.negotiated_alpn === nothing || print(io, ", ", conn.negotiated_alpn)
+    end
+    print(io, ")")
+    return nothing
+end
+
+function Base.show(io::IO, listener::Listener)
+    print(io, "TLS.Listener(")
+    _show_endpoint(io, addr(listener))
+    print(io, ", ", _show_state(listener), ")")
+    return nothing
 end
 
 function _prepare_connect_config(config::Config, address::AbstractString)::Config

--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -120,6 +120,42 @@ else
                 EL.shutdown!()
             end
         end
+        @testset "show methods summarize TCP endpoints" begin
+            EL.shutdown!()
+            listener = nothing
+            client = nothing
+            server = nothing
+            try
+                listener = NC.listen(NC.loopback_addr(0); backlog = 8)
+                laddr = NC.addr(listener)
+                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
+                client = NC.connect(NC.loopback_addr(Int((laddr::NC.SocketAddrV4).port)))
+                @test _nc_wait_task_done(accept_task, 2.0) != :timed_out
+                server = fetch(accept_task)
+
+                client_local = NC.local_addr(client)
+                client_remote = NC.remote_addr(client)
+                server_local = NC.local_addr(server)
+                server_remote = NC.remote_addr(server)
+
+                @test repr(listener) == "TCP.Listener($(repr(laddr)), active)"
+                @test repr(client) == "TCP.Conn($(repr(client_local)) => $(repr(client_remote)), open)"
+                @test repr(server) == "TCP.Conn($(repr(server_local)) => $(repr(server_remote)), open)"
+
+                close(client)
+                close(server)
+                close(listener)
+
+                @test repr(client) == "TCP.Conn($(repr(client_local)) => $(repr(client_remote)), closed)"
+                @test repr(server) == "TCP.Conn($(repr(server_local)) => $(repr(server_remote)), closed)"
+                @test repr(listener) == "TCP.Listener($(repr(laddr)), closed)"
+            finally
+                _close_quiet!(server)
+                _close_quiet!(client)
+                _close_quiet!(listener)
+                EL.shutdown!()
+            end
+        end
         @testset "connected sockets set TCP_NODELAY and SO_KEEPALIVE defaults" begin
             EL.shutdown!()
             listener = nothing

--- a/test/tls_tests.jl
+++ b/test/tls_tests.jl
@@ -401,6 +401,79 @@ else
                 EL.shutdown!()
             end
         end
+        @testset "show methods summarize TLS endpoints and handshake state" begin
+            EL.shutdown!()
+            tls_listener = nothing
+            tcp_listener = nothing
+            client_tcp = nothing
+            server_tcp = nothing
+            client_tls = nothing
+            server_tls = nothing
+            try
+                listener_cfg = _tls_server_config()
+                tls_listener = TL.listen("tcp", "127.0.0.1:0", listener_cfg; backlog = 8)
+                tls_laddr = TL.addr(tls_listener)
+                @test repr(tls_listener) == "TLS.Listener($(repr(tls_laddr)), active)"
+                close(tls_listener)
+                @test repr(tls_listener) == "TLS.Listener($(repr(tls_laddr)), closed)"
+                tls_listener = nothing
+
+                tcp_listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 8)
+                tcp_laddr = NC.addr(tcp_listener)::NC.SocketAddrV4
+                accept_task = errormonitor(Threads.@spawn NC.accept(tcp_listener))
+                client_tcp = ND.connect("tcp", "127.0.0.1:$(Int(tcp_laddr.port))")
+                @test _tls_wait_task_done(accept_task, 2.0) != :timed_out
+                server_tcp = fetch(accept_task)
+
+                server_cfg = TL.Config(
+                    verify_peer = false,
+                    cert_file = _TLS_CERT_PATH,
+                    key_file = _TLS_KEY_PATH,
+                    alpn_protocols = ["h2", "http/1.1"],
+                )
+                client_cfg = TL.Config(
+                    verify_peer = false,
+                    server_name = "localhost",
+                    alpn_protocols = ["h2", "http/1.1"],
+                )
+                client_tls = TL.client(client_tcp, client_cfg)
+                server_tls = TL.server(server_tcp, server_cfg)
+
+                client_local = TL.local_addr(client_tls)
+                client_remote = TL.remote_addr(client_tls)
+                server_local = TL.local_addr(server_tls)
+                server_remote = TL.remote_addr(server_tls)
+
+                @test repr(client_tls) == "TLS.Conn($(repr(client_local)) => $(repr(client_remote)), client, handshake pending)"
+                @test repr(server_tls) == "TLS.Conn($(repr(server_local)) => $(repr(server_remote)), server, handshake pending)"
+
+                server_task = errormonitor(Threads.@spawn TL.handshake!(server_tls))
+                TL.handshake!(client_tls)
+                @test _tls_wait_task_done(server_task, 2.0) != :timed_out
+                fetch(server_task)
+
+                client_state = TL.connection_state(client_tls)
+                server_state = TL.connection_state(server_tls)
+                @test client_state.alpn_protocol == "h2"
+                @test server_state.alpn_protocol == "h2"
+                @test repr(client_tls) == "TLS.Conn($(repr(client_local)) => $(repr(client_remote)), client, $(client_state.version), $(client_state.alpn_protocol))"
+                @test repr(server_tls) == "TLS.Conn($(repr(server_local)) => $(repr(server_remote)), server, $(server_state.version), $(server_state.alpn_protocol))"
+
+                close(client_tls)
+                close(server_tls)
+
+                @test repr(client_tls) == "TLS.Conn($(repr(client_local)) => $(repr(client_remote)), client, closed)"
+                @test repr(server_tls) == "TLS.Conn($(repr(server_local)) => $(repr(server_remote)), server, closed)"
+            finally
+                _tls_close_quiet!(server_tls)
+                _tls_close_quiet!(client_tls)
+                _tls_close_quiet!(server_tcp)
+                _tls_close_quiet!(client_tcp)
+                _tls_close_quiet!(tcp_listener)
+                _tls_close_quiet!(tls_listener)
+                EL.shutdown!()
+            end
+        end
         @testset "SSL_CTX is reused for equivalent client configs" begin
             EL.shutdown!()
             listener = nothing


### PR DESCRIPTION
## Summary
- add concise one-line `show` methods for `TCP.Conn` and `TCP.Listener`
- add concise one-line `show` methods for `TLS.Conn` and `TLS.Listener`
- cache negotiated TLS version and ALPN at handshake completion so display stays safe after close
- add regression coverage for pending, negotiated, active, and closed display states

## Verification
- `JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'`
- `JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=tcp_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
- `JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=tls_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl`
