### PR TITLE
ci(repro): isolate windows compiler bug workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
     branches: [main, master]
     tags: ["*"]
   pull_request:
+    paths-ignore:
+      - '.github/workflows/ci.yml'
+      - '.github/workflows/windows-compiler-bug.yml'
+      - 'test/windows-compiler-bug.jl'
   workflow_dispatch:
 jobs:
   test:

--- a/.github/workflows/windows-compiler-bug.yml
+++ b/.github/workflows/windows-compiler-bug.yml
@@ -28,8 +28,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          julia --project=. --startup-file=no --history-file=no test/windows-compiler-bug.jl 2>&1 | tee compiler-bug.log
+          set +e
+          timeout 120s julia --project=. --startup-file=no --history-file=no test/windows-compiler-bug.jl 2>&1 | tee compiler-bug.log
+          julia_status=${PIPESTATUS[0]}
+          set -e
           if grep -Eq 'Internal error: during type inference of|BoundsError\(a=Array\{Base\.Compiler\.TryCatchFrame' compiler-bug.log; then
             echo 'Windows compiler bug reproduced'
             exit 1
           fi
+          if [ "${julia_status}" -eq 124 ]; then
+            echo 'Windows compiler bug timed out'
+            exit 1
+          fi
+          exit "${julia_status}"

--- a/.github/workflows/windows-compiler-bug.yml
+++ b/.github/workflows/windows-compiler-bug.yml
@@ -1,0 +1,35 @@
+name: Windows Compiler Bug
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/ci.yml'
+      - '.github/workflows/windows-compiler-bug.yml'
+      - 'test/windows-compiler-bug.jl'
+  workflow_dispatch:
+
+jobs:
+  repro:
+    name: Julia 1 - windows-latest - x64 - t2 - compiler-bug
+    runs-on: windows-latest
+    timeout-minutes: 20
+    env:
+      JULIA_NUM_THREADS: '2'
+      RESEAU_RUN_TLS_TESTS: '1'
+      RESEAU_RUN_NETWORK_TESTS: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+          arch: x64
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - name: Run windows compiler bug reproducer
+        shell: bash
+        run: |
+          set -euo pipefail
+          julia --project=. --startup-file=no --history-file=no test/windows-compiler-bug.jl 2>&1 | tee compiler-bug.log
+          if grep -Eq 'Internal error: during type inference of|BoundsError\(a=Array\{Base\.Compiler\.TryCatchFrame' compiler-bug.log; then
+            echo 'Windows compiler bug reproduced'
+            exit 1
+          fi

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -891,6 +891,7 @@ const _FIONBIO = reinterpret(Int32, _FIONBIO_BITS)
 const _WSA_FLAG_OVERLAPPED = UInt32(0x01)
 const _WSA_FLAG_NO_HANDLE_INHERIT = UInt32(0x80)
 const _HANDLE_FLAG_INHERIT = UInt32(0x00000001)
+const _ACCEPT_ADDRBUF_LEN = 128
 const _ERROR_IO_PENDING = Int32(997)
 const _ERROR_OPERATION_ABORTED = Int32(995)
 const _ERROR_NETNAME_DELETED = UInt32(64)
@@ -940,6 +941,10 @@ const _ERRNO_ESHUTDOWN = @static isdefined(Base.Libc, :ESHUTDOWN) ? Int32(getfie
 const _ERRNO_EHOSTDOWN = @static isdefined(Base.Libc, :EHOSTDOWN) ? Int32(getfield(Base.Libc, :EHOSTDOWN)) : Int32(Base.Libc.EHOSTUNREACH)
 const _ERRNO_ECANCELED = @static isdefined(Base.Libc, :ECANCELED) ? Int32(getfield(Base.Libc, :ECANCELED)) : Int32(Base.Libc.EINTR)
 
+struct _SockAddrHeader
+    sa_family::UInt16
+end
+
 struct SockAddrIn
     sin_family::UInt16
     sin_port::UInt16
@@ -983,23 +988,27 @@ struct _WSAData
 end
 
 @inline function _hton16(v::UInt16)::UInt16
-    Base.ENDIAN_BOM == 0x04030201 && return bswap(v)
+    _is_little_endian() && return bswap(v)
     return v
 end
 
 @inline function _ntoh16(v::UInt16)::UInt16
-    Base.ENDIAN_BOM == 0x04030201 && return bswap(v)
+    _is_little_endian() && return bswap(v)
     return v
 end
 
 @inline function _hton32(v::UInt32)::UInt32
-    Base.ENDIAN_BOM == 0x04030201 && return bswap(v)
+    _is_little_endian() && return bswap(v)
     return v
 end
 
 @inline function _ntoh32(v::UInt32)::UInt32
-    Base.ENDIAN_BOM == 0x04030201 && return bswap(v)
+    _is_little_endian() && return bswap(v)
     return v
+end
+
+@inline function _is_little_endian()::Bool
+    return Base.ENDIAN_BOM == 0x04030201
 end
 
 @inline function _port_u16(port::Integer)::UInt16
@@ -1084,6 +1093,14 @@ end
 
 function _throw_errno(op::AbstractString, errno::Int32)
     throw(SystemError(op, Int(errno)))
+end
+
+@inline function _throw_enosys(op::AbstractString)
+    throw(SystemError(op, Int(Base.Libc.ENOSYS)))
+end
+
+@inline function _errno_i32()::Int32
+    return last_error()
 end
 
 const _winsock_lock = ReentrantLock()
@@ -1342,9 +1359,9 @@ end
         return bytes
     end
 
-    function sockaddr_bytes(addr::SockAddrIn6)::Vector{UInt8}
-        bytes = Vector{UInt8}(undef, sizeof(SockAddrIn6))
-        addr_ref = Ref(addr)
+function sockaddr_bytes(addr::SockAddrIn6)::Vector{UInt8}
+    bytes = Vector{UInt8}(undef, sizeof(SockAddrIn6))
+    addr_ref = Ref(addr)
         GC.@preserve addr_ref bytes begin
             unsafe_copyto!(
                 pointer(bytes),
@@ -1375,6 +1392,19 @@ else
         GC.@preserve bytes addr unsafe_store!(Ptr{SockAddrIn6}(pointer(bytes)), addr)
         return bytes
     end
+end
+
+@inline function _decode_accept_peer(addrptr::Ptr{UInt8}, addrlen::SockLen)::AcceptPeer
+    Int(addrlen) < sizeof(_SockAddrHeader) && return nothing
+    header = unsafe_load(Ptr{_SockAddrHeader}(addrptr))
+    family = Int32(header.sa_family)
+    if family == AF_INET && Int(addrlen) >= sizeof(SockAddrIn)
+        return unsafe_load(Ptr{SockAddrIn}(addrptr))
+    end
+    if family == AF_INET6 && Int(addrlen) >= sizeof(SockAddrIn6)
+        return unsafe_load(Ptr{SockAddrIn6}(addrptr))
+    end
+    return nothing
 end
 
 shutdown_socket(fd::Int32, how::Integer) = nothing

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -612,6 +612,8 @@ function _iocp_cancel_mode!(registration::Registration, mode::PollMode.T)::Bool
 end
 
 function connect!(fd::FD, addrbuf::Vector{UInt8}, addrlen::Int32)
+    println("[windows-compiler-bug] enter IOPoll.connect!")
+    flush(stdout)
     _fd_write_lock!(fd)
     try
         preparewrite(fd.pd, fd.is_file)
@@ -858,6 +860,8 @@ function _wait_connect_complete!(
         remote_addr::SocketAddr,
         cancel_state = nothing,
     )
+    println("[windows-compiler-bug] enter _wait_connect_complete!")
+    flush(stdout)
     _connect_wait_register!(cancel_state, fd)
     try
         @static if Sys.iswindows()
@@ -925,23 +929,39 @@ function _connect_socketaddr_impl(
     println("[windows-compiler-bug] enter _connect_socketaddr_impl")
     flush(stdout)
     family = _addr_family(remote_addr)
+    println("[windows-compiler-bug] computed family")
+    flush(stdout)
     if local_addr !== nothing && _addr_family(local_addr) != family
         throw(ArgumentError("local and remote address families must match"))
     end
+    println("[windows-compiler-bug] local family check done")
+    flush(stdout)
     fd = open_tcp_fd!(; family = family)
+    println("[windows-compiler-bug] opened tcp fd")
+    flush(stdout)
     try
         if local_addr !== nothing
             SocketOps.bind_socket(fd.pfd.sysfd, _to_sockaddr(local_addr))
         elseif Sys.iswindows()
             _bind_connectex_local!(fd, family)
         end
+        println("[windows-compiler-bug] local bind step done")
+        flush(stdout)
         SocketOps.set_nonblocking!(fd.pfd.sysfd, true)
+        println("[windows-compiler-bug] set nonblocking")
+        flush(stdout)
         @static if Sys.iswindows()
             IOPoll.register!(fd.pfd)
+            println("[windows-compiler-bug] registered with iopoll")
+            flush(stdout)
             if attempt_deadline != 0
                 IOPoll.set_write_deadline!(fd.pfd, attempt_deadline)
+                println("[windows-compiler-bug] set write deadline")
+                flush(stdout)
             end
             try
+                println("[windows-compiler-bug] before _wait_connect_complete!")
+                flush(stdout)
                 _wait_connect_complete!(fd, remote_addr, state)
             finally
                 if attempt_deadline != 0

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -5082,7 +5082,12 @@ function _run_full_split_extracted_package_subprocess()::Nothing
         _write_full_split_extracted_package(dir, name)
         depot = joinpath(dir, "depot")
         mkpath(depot)
-        script = """
+        precompile_script = """
+        pushfirst!(LOAD_PATH, @__DIR__)
+        using $name
+        nothing
+        """
+        probe_script = """
         pushfirst!(LOAD_PATH, @__DIR__)
         using $name
         const TCP = $name.TCP
@@ -5112,10 +5117,15 @@ function _run_full_split_extracted_package_subprocess()::Nothing
         end
         nothing
         """
-        script_path = joinpath(dir, "fresh-process-probe.jl")
-        write(script_path, script)
-        cmd = `$(Base.julia_cmd()) --project=$(dir) --startup-file=no --history-file=no $(script_path)`
-        run(setenv(cmd, "JULIA_DEPOT_PATH" => depot))
+        precompile_path = joinpath(dir, "fresh-process-precompile.jl")
+        probe_path = joinpath(dir, "fresh-process-probe.jl")
+        write(precompile_path, precompile_script)
+        write(probe_path, probe_script)
+        precompile_cmd = `$(Base.julia_cmd()) --project=$(dir) --startup-file=no --history-file=no $(precompile_path)`
+        probe_cmd = `$(Base.julia_cmd()) --project=$(dir) --startup-file=no --history-file=no $(probe_path)`
+        env = ("JULIA_DEPOT_PATH" => depot,)
+        run(setenv(precompile_cmd, env...))
+        run(setenv(probe_cmd, env...))
     end
     return nothing
 end

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -217,6 +217,14 @@ function _connect_socketaddr_impl(
     end
 end
 
+function connect(remote_addr::SocketAddr)::Conn
+    return _connect_socketaddr_impl(remote_addr, nothing, Int64(0), nothing)
+end
+
+function connect(remote_addr::SocketAddr, local_addr::Union{Nothing, SocketAddr})::Conn
+    return _connect_socketaddr_impl(remote_addr, local_addr, Int64(0), nothing)
+end
+
 end
 
 Base.close(fd::TCP.FD) = nothing

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -661,6 +661,7 @@ module SocketOps
 
 export AF_INET, AF_INET6, SOCK_STREAM, IPPROTO_TCP, TCP_NODELAY, SOL_SOCKET, SO_KEEPALIVE, SO_ERROR, SockAddrIn, SockAddrIn6, open_socket, bind_socket, connect_socket, set_nonblocking!, set_sockopt_int, get_socket_error, update_connect_context!, sockaddr_in, sockaddr_in_any, sockaddr_in6, sockaddr_in6_any, sockaddr_bytes
 
+const SockLen = Int32
 const AF_INET = Int32(2)
 const AF_INET6 = Int32(23)
 const SOCK_STREAM = Int32(1)
@@ -669,6 +670,64 @@ const TCP_NODELAY = Int32(1)
 const SOL_SOCKET = Int32(0xffff)
 const SO_KEEPALIVE = Int32(0x0008)
 const SO_ERROR = Int32(0x1007)
+
+const _WS2_32 = "Ws2_32"
+const _KERNEL32 = "Kernel32"
+const _INVALID_SOCKET = UInt(typemax(UInt))
+const _SOCKET_ERROR = Int32(-1)
+const _FIONBIO_BITS = UInt32(0x8004667e)
+const _FIONBIO = reinterpret(Int32, _FIONBIO_BITS)
+const _WSA_FLAG_OVERLAPPED = UInt32(0x01)
+const _WSA_FLAG_NO_HANDLE_INHERIT = UInt32(0x80)
+const _HANDLE_FLAG_INHERIT = UInt32(0x00000001)
+const _ERROR_IO_PENDING = Int32(997)
+const _ERROR_OPERATION_ABORTED = Int32(995)
+const _ERROR_NETNAME_DELETED = UInt32(64)
+const _ERROR_INVALID_PARAMETER = UInt32(87)
+const _ERROR_NOT_ENOUGH_MEMORY = UInt32(8)
+const _ERROR_INVALID_HANDLE = UInt32(6)
+const _ERROR_NOT_SUPPORTED = UInt32(50)
+const _SO_UPDATE_CONNECT_CONTEXT = Int32(0x7010)
+const _WSAEINTR = Int32(10004)
+const _WSAEBADF = Int32(10009)
+const _WSAEACCES = Int32(10013)
+const _WSAEFAULT = Int32(10014)
+const _WSAEINVAL = Int32(10022)
+const _WSAEMFILE = Int32(10024)
+const _WSAEWOULDBLOCK = Int32(10035)
+const _WSAEINPROGRESS = Int32(10036)
+const _WSAEALREADY = Int32(10037)
+const _WSAENOTSOCK = Int32(10038)
+const _WSAEDESTADDRREQ = Int32(10039)
+const _WSAEMSGSIZE = Int32(10040)
+const _WSAEPROTOTYPE = Int32(10041)
+const _WSAENOPROTOOPT = Int32(10042)
+const _WSAEPROTONOSUPPORT = Int32(10043)
+const _WSAESOCKTNOSUPPORT = Int32(10044)
+const _WSAEOPNOTSUPP = Int32(10045)
+const _WSAEPFNOSUPPORT = Int32(10046)
+const _WSAEAFNOSUPPORT = Int32(10047)
+const _WSAEADDRINUSE = Int32(10048)
+const _WSAEADDRNOTAVAIL = Int32(10049)
+const _WSAENETDOWN = Int32(10050)
+const _WSAENETUNREACH = Int32(10051)
+const _WSAENETRESET = Int32(10052)
+const _WSAECONNABORTED = Int32(10053)
+const _WSAECONNRESET = Int32(10054)
+const _WSAENOBUFS = Int32(10055)
+const _WSAEISCONN = Int32(10056)
+const _WSAENOTCONN = Int32(10057)
+const _WSAESHUTDOWN = Int32(10058)
+const _WSAETIMEDOUT = Int32(10060)
+const _WSAECONNREFUSED = Int32(10061)
+const _WSAEHOSTDOWN = Int32(10064)
+const _WSAEHOSTUNREACH = Int32(10065)
+const _WSADATA_DESC_ZERO = ntuple(_ -> UInt8(0), 257)
+const _WSADATA_STATUS_ZERO = ntuple(_ -> UInt8(0), 129)
+const _ERRNO_ESOCKTNOSUPPORT = @static isdefined(Base.Libc, :ESOCKTNOSUPPORT) ? Int32(getfield(Base.Libc, :ESOCKTNOSUPPORT)) : Int32(Base.Libc.EPROTONOSUPPORT)
+const _ERRNO_ESHUTDOWN = @static isdefined(Base.Libc, :ESHUTDOWN) ? Int32(getfield(Base.Libc, :ESHUTDOWN)) : Int32(Base.Libc.ENOTCONN)
+const _ERRNO_EHOSTDOWN = @static isdefined(Base.Libc, :EHOSTDOWN) ? Int32(getfield(Base.Libc, :EHOSTDOWN)) : Int32(Base.Libc.EHOSTUNREACH)
+const _ERRNO_ECANCELED = @static isdefined(Base.Libc, :ECANCELED) ? Int32(getfield(Base.Libc, :ECANCELED)) : Int32(Base.Libc.EINTR)
 
 struct SockAddrIn
     sin_family::UInt16
@@ -683,6 +742,16 @@ struct SockAddrIn6
     sin6_flowinfo::UInt32
     sin6_addr::NTuple{16, UInt8}
     sin6_scope_id::UInt32
+end
+
+struct _WSAData
+    wVersion::UInt16
+    wHighVersion::UInt16
+    szDescription::NTuple{257, UInt8}
+    szSystemStatus::NTuple{129, UInt8}
+    iMaxSockets::UInt16
+    iMaxUdpDg::UInt16
+    lpVendorInfo::Ptr{UInt8}
 end
 
 @inline function _hton16(v::UInt16)::UInt16
@@ -700,17 +769,375 @@ end
     return UInt16(port)
 end
 
+@inline function _byte_u8(v::Integer)::UInt8
+    (v < 0 || v > 0xff) && throw(ArgumentError("byte must be in [0, 255]"))
+    return UInt8(v)
+end
+
 @inline function _ipv4_u32(ip::NTuple{4, UInt8})::UInt32
     return (UInt32(ip[1]) << 24) | (UInt32(ip[2]) << 16) | (UInt32(ip[3]) << 8) | UInt32(ip[4])
 end
 
-open_socket(family::Int32, sotype::Int32) = Int32(1)
-bind_socket(sysfd::Int32, sockaddr::Union{SockAddrIn, SockAddrIn6}) = nothing
-connect_socket(sysfd::Int32, sockaddr::Union{SockAddrIn, SockAddrIn6}) = Int32(0)
-set_nonblocking!(sysfd::Int32, enabled::Bool) = nothing
-set_sockopt_int(fd::Int32, level::Int32, optname::Int32, value::Integer) = nothing
-get_socket_error(fd::Int32)::Int32 = Int32(0)
-update_connect_context!(fd::Int32) = nothing
+@inline function _socket_value(fd::Int32)::UInt
+    return UInt(reinterpret(UInt32, fd))
+end
+
+@inline function _socket_handle(fd::Int32)::Ptr{Cvoid}
+    return Ptr{Cvoid}(_socket_value(fd))
+end
+
+@inline function _wsa_get_last_error()::Int32
+    return Int32(ccall((:WSAGetLastError, _WS2_32), Int32, ()))
+end
+
+@inline function _win_get_last_error()::UInt32
+    return ccall((:GetLastError, _KERNEL32), UInt32, ())
+end
+
+@inline function _map_win32_errno(err::UInt32)::Int32
+    err == _ERROR_INVALID_HANDLE && return Int32(Base.Libc.EBADF)
+    err == _ERROR_INVALID_PARAMETER && return Int32(Base.Libc.EINVAL)
+    err == _ERROR_NOT_ENOUGH_MEMORY && return Int32(Base.Libc.ENOMEM)
+    err == _ERROR_NOT_SUPPORTED && return Int32(Base.Libc.ENOSYS)
+    err == _ERROR_NETNAME_DELETED && return Int32(Base.Libc.ECONNRESET)
+    return Int32(Base.Libc.EIO)
+end
+
+@inline function _map_wsa_errno(err::Int32)::Int32
+    err == Int32(0) && return Int32(0)
+    err == _ERROR_IO_PENDING && return Int32(Base.Libc.EINPROGRESS)
+    err == _ERROR_OPERATION_ABORTED && return _ERRNO_ECANCELED
+    err == _WSAEINTR && return Int32(Base.Libc.EINTR)
+    err == _WSAEBADF && return Int32(Base.Libc.EBADF)
+    err == _WSAEACCES && return Int32(Base.Libc.EACCES)
+    err == _WSAEFAULT && return Int32(Base.Libc.EFAULT)
+    err == _WSAEINVAL && return Int32(Base.Libc.EINVAL)
+    err == _WSAEMFILE && return Int32(Base.Libc.EMFILE)
+    err == _WSAEWOULDBLOCK && return Int32(Base.Libc.EAGAIN)
+    err == _WSAEINPROGRESS && return Int32(Base.Libc.EINPROGRESS)
+    err == _WSAEALREADY && return Int32(Base.Libc.EALREADY)
+    err == _WSAENOTSOCK && return Int32(Base.Libc.EBADF)
+    err == _WSAEDESTADDRREQ && return Int32(Base.Libc.EDESTADDRREQ)
+    err == _WSAEMSGSIZE && return Int32(Base.Libc.EMSGSIZE)
+    err == _WSAEPROTOTYPE && return Int32(Base.Libc.EPROTOTYPE)
+    err == _WSAENOPROTOOPT && return Int32(Base.Libc.ENOPROTOOPT)
+    err == _WSAEPROTONOSUPPORT && return Int32(Base.Libc.EPROTONOSUPPORT)
+    err == _WSAESOCKTNOSUPPORT && return _ERRNO_ESOCKTNOSUPPORT
+    err == _WSAEOPNOTSUPP && return Int32(Base.Libc.EOPNOTSUPP)
+    err == _WSAEPFNOSUPPORT && return Int32(Base.Libc.EAFNOSUPPORT)
+    err == _WSAEAFNOSUPPORT && return Int32(Base.Libc.EAFNOSUPPORT)
+    err == _WSAEADDRINUSE && return Int32(Base.Libc.EADDRINUSE)
+    err == _WSAEADDRNOTAVAIL && return Int32(Base.Libc.EADDRNOTAVAIL)
+    err == _WSAENETDOWN && return Int32(Base.Libc.ENETDOWN)
+    err == _WSAENETUNREACH && return Int32(Base.Libc.ENETUNREACH)
+    err == _WSAENETRESET && return Int32(Base.Libc.ENETRESET)
+    err == _WSAECONNABORTED && return Int32(Base.Libc.ECONNABORTED)
+    err == _WSAECONNRESET && return Int32(Base.Libc.ECONNRESET)
+    err == _WSAENOBUFS && return Int32(Base.Libc.ENOBUFS)
+    err == _WSAEISCONN && return Int32(Base.Libc.EISCONN)
+    err == _WSAENOTCONN && return Int32(Base.Libc.ENOTCONN)
+    err == _WSAESHUTDOWN && return _ERRNO_ESHUTDOWN
+    err == _WSAETIMEDOUT && return Int32(Base.Libc.ETIMEDOUT)
+    err == _WSAECONNREFUSED && return Int32(Base.Libc.ECONNREFUSED)
+    err == _WSAEHOSTDOWN && return _ERRNO_EHOSTDOWN
+    err == _WSAEHOSTUNREACH && return Int32(Base.Libc.EHOSTUNREACH)
+    return Int32(Base.Libc.EIO)
+end
+
+function _throw_errno(op::AbstractString, errno::Int32)
+    throw(SystemError(op, Int(errno)))
+end
+
+const _winsock_lock = ReentrantLock()
+const _winsock_initialized = Ref{Bool}(false)
+const _winsock_init_pid = Ref{Int}(0)
+const _fd_state_lock = ReentrantLock()
+const _fd_nonblocking_state = Dict{Int32, Bool}()
+
+function _set_fd_nonblocking_state!(fd::Int32, enabled::Bool)
+    lock(_fd_state_lock)
+    try
+        _fd_nonblocking_state[fd] = enabled
+    finally
+        unlock(_fd_state_lock)
+    end
+    return nothing
+end
+
+function _clear_fd_state!(fd::Int32)
+    lock(_fd_state_lock)
+    try
+        delete!(_fd_nonblocking_state, fd)
+    finally
+        unlock(_fd_state_lock)
+    end
+    return nothing
+end
+
+@static if Sys.iswindows()
+    function ensure_winsock!()
+        pid = Base.getpid()
+        if _winsock_initialized[] && _winsock_init_pid[] == pid
+            return nothing
+        end
+        lock(_winsock_lock)
+        try
+            if _winsock_initialized[] && _winsock_init_pid[] == pid
+                return nothing
+            end
+            wsa_data = Ref(_WSAData(
+                UInt16(0),
+                UInt16(0),
+                _WSADATA_DESC_ZERO,
+                _WSADATA_STATUS_ZERO,
+                UInt16(0),
+                UInt16(0),
+                C_NULL,
+            ))
+            rc = ccall(
+                (:WSAStartup, _WS2_32),
+                Int32,
+                (UInt16, Ref{_WSAData}),
+                UInt16(0x0202),
+                wsa_data,
+            )
+            rc == 0 || _throw_errno("WSAStartup", _map_wsa_errno(Int32(rc)))
+            _winsock_initialized[] = true
+            _winsock_init_pid[] = pid
+        finally
+            unlock(_winsock_lock)
+        end
+        return nothing
+    end
+
+    function set_close_on_exec!(fd::Int32)
+        ok = ccall(
+            (:SetHandleInformation, _KERNEL32),
+            Int32,
+            (Ptr{Cvoid}, UInt32, UInt32),
+            _socket_handle(fd),
+            _HANDLE_FLAG_INHERIT,
+            UInt32(0),
+        )
+        ok == 0 && _throw_errno("SetHandleInformation", _map_win32_errno(_win_get_last_error()))
+        return nothing
+    end
+
+    function set_nonblocking!(fd::Int32, enabled::Bool = true)
+        ensure_winsock!()
+        arg = Ref{UInt32}(enabled ? UInt32(1) : UInt32(0))
+        ret = ccall((:ioctlsocket, _WS2_32), Int32, (UInt, Clong, Ref{UInt32}), _socket_value(fd), Clong(_FIONBIO), arg)
+        ret == 0 || _throw_errno("ioctlsocket(FIONBIO)", _map_wsa_errno(_wsa_get_last_error()))
+        _set_fd_nonblocking_state!(fd, enabled)
+        return nothing
+    end
+
+    function close_socket_nothrow(fd::Int32)::Int32
+        _clear_fd_state!(fd)
+        ret = ccall((:closesocket, _WS2_32), Int32, (UInt,), _socket_value(fd))
+        ret == 0 && return Int32(0)
+        errno = _map_wsa_errno(_wsa_get_last_error())
+        errno == Int32(Base.Libc.EBADF) && return errno
+        return Int32(0)
+    end
+
+    function open_socket(family::Int32, sotype::Int32, proto::Int32 = Int32(0))::Int32
+        ensure_winsock!()
+        raw_type = Int32(sotype)
+        flags = UInt32(_WSA_FLAG_OVERLAPPED | _WSA_FLAG_NO_HANDLE_INHERIT)
+        sock = ccall(
+            (:WSASocketW, _WS2_32),
+            UInt,
+            (Int32, Int32, Int32, Ptr{Cvoid}, UInt32, UInt32),
+            Int32(family),
+            raw_type,
+            Int32(proto),
+            C_NULL,
+            UInt32(0),
+            flags,
+        )
+        if sock == _INVALID_SOCKET
+            errno = _wsa_get_last_error()
+            if errno == _WSAEINVAL
+                sock = ccall(
+                    (:WSASocketW, _WS2_32),
+                    UInt,
+                    (Int32, Int32, Int32, Ptr{Cvoid}, UInt32, UInt32),
+                    Int32(family),
+                    raw_type,
+                    Int32(proto),
+                    C_NULL,
+                    UInt32(0),
+                    _WSA_FLAG_OVERLAPPED,
+                )
+                sock == _INVALID_SOCKET && _throw_errno("socket", _map_wsa_errno(_wsa_get_last_error()))
+                fd_fallback = Int32(UInt32(sock))
+                try
+                    set_close_on_exec!(fd_fallback)
+                    set_nonblocking!(fd_fallback, true)
+                catch
+                    close_socket_nothrow(fd_fallback)
+                    rethrow()
+                end
+                return fd_fallback
+            end
+            _throw_errno("socket", _map_wsa_errno(errno))
+        end
+        fd = Int32(UInt32(sock))
+        try
+            set_nonblocking!(fd, true)
+        catch
+            close_socket_nothrow(fd)
+            rethrow()
+        end
+        return fd
+    end
+
+    function bind_socket(fd::Int32, addr::SockAddrIn)
+        addr_ref = Ref(addr)
+        GC.@preserve addr_ref begin
+            bind_socket(fd, Base.unsafe_convert(Ptr{Cvoid}, addr_ref), SockLen(sizeof(SockAddrIn)))
+        end
+        return nothing
+    end
+
+    function bind_socket(fd::Int32, addr::SockAddrIn6)
+        addr_ref = Ref(addr)
+        GC.@preserve addr_ref begin
+            bind_socket(fd, Base.unsafe_convert(Ptr{Cvoid}, addr_ref), SockLen(sizeof(SockAddrIn6)))
+        end
+        return nothing
+    end
+
+    function bind_socket(fd::Int32, addr::Ptr{Cvoid}, addrlen::SockLen)
+        ret = ccall(
+            (:bind, _WS2_32),
+            Int32,
+            (UInt, Ptr{Cvoid}, Int32),
+            _socket_value(fd),
+            addr,
+            Int32(addrlen),
+        )
+        ret == 0 && return nothing
+        _throw_errno("bind", _map_wsa_errno(_wsa_get_last_error()))
+    end
+
+    function set_sockopt_int(fd::Int32, level::Int32, optname::Int32, value::Integer)
+        raw = Ref{Int32}(Int32(value))
+        ret = GC.@preserve raw begin
+            ccall(
+                (:setsockopt, _WS2_32),
+                Int32,
+                (UInt, Int32, Int32, Ptr{UInt8}, Int32),
+                _socket_value(fd),
+                level,
+                optname,
+                Ptr{UInt8}(Base.unsafe_convert(Ptr{Int32}, raw)),
+                Int32(sizeof(Int32)),
+            )
+        end
+        ret == 0 && return nothing
+        _throw_errno("setsockopt", _map_wsa_errno(_wsa_get_last_error()))
+    end
+
+    function get_sockopt_int(fd::Int32, level::Int32, optname::Int32)::Int32
+        value = Ref{Int32}(0)
+        optlen = Ref{Int32}(Int32(sizeof(Int32)))
+        ret = GC.@preserve value begin
+            ccall(
+                (:getsockopt, _WS2_32),
+                Int32,
+                (UInt, Int32, Int32, Ptr{UInt8}, Ref{Int32}),
+                _socket_value(fd),
+                level,
+                optname,
+                Ptr{UInt8}(Base.unsafe_convert(Ptr{Int32}, value)),
+                optlen,
+            )
+        end
+        ret == 0 && return Int32(value[])
+        _throw_errno("getsockopt", _map_wsa_errno(_wsa_get_last_error()))
+    end
+
+    function get_socket_error(fd::Int32)::Int32
+        return get_sockopt_int(fd, SOL_SOCKET, SO_ERROR)
+    end
+
+    function _set_sockopt_ptr!(fd::Int32, optname::Int32, ptr::Ptr{UInt8}, optlen::Integer)
+        ret = ccall(
+            (:setsockopt, _WS2_32),
+            Int32,
+            (UInt, Int32, Int32, Ptr{UInt8}, Int32),
+            _socket_value(fd),
+            SOL_SOCKET,
+            optname,
+            ptr,
+            Int32(optlen),
+        )
+        ret == 0 && return nothing
+        _throw_errno("setsockopt", _map_wsa_errno(_wsa_get_last_error()))
+    end
+
+    function update_connect_context!(fd::Int32)
+        handle_ref = Ref{UInt}(_socket_value(fd))
+        GC.@preserve handle_ref begin
+            _set_sockopt_ptr!(
+                fd,
+                _SO_UPDATE_CONNECT_CONTEXT,
+                Ptr{UInt8}(Base.unsafe_convert(Ptr{UInt}, handle_ref)),
+                sizeof(UInt),
+            )
+        end
+        return nothing
+    end
+
+    function sockaddr_bytes(addr::SockAddrIn)::Vector{UInt8}
+        bytes = Vector{UInt8}(undef, sizeof(SockAddrIn))
+        addr_ref = Ref(addr)
+        GC.@preserve addr_ref bytes begin
+            unsafe_copyto!(
+                pointer(bytes),
+                Ptr{UInt8}(Base.unsafe_convert(Ptr{SockAddrIn}, addr_ref)),
+                sizeof(SockAddrIn),
+            )
+        end
+        return bytes
+    end
+
+    function sockaddr_bytes(addr::SockAddrIn6)::Vector{UInt8}
+        bytes = Vector{UInt8}(undef, sizeof(SockAddrIn6))
+        addr_ref = Ref(addr)
+        GC.@preserve addr_ref bytes begin
+            unsafe_copyto!(
+                pointer(bytes),
+                Ptr{UInt8}(Base.unsafe_convert(Ptr{SockAddrIn6}, addr_ref)),
+                sizeof(SockAddrIn6),
+            )
+        end
+        return bytes
+    end
+else
+    open_socket(family::Int32, sotype::Int32, proto::Int32 = Int32(0)) = Int32(1)
+    bind_socket(sysfd::Int32, sockaddr::Union{SockAddrIn, SockAddrIn6}) = nothing
+    bind_socket(sysfd::Int32, addr::Ptr{Cvoid}, addrlen::SockLen) = nothing
+    connect_socket(sysfd::Int32, sockaddr::Union{SockAddrIn, SockAddrIn6}) = Int32(0)
+    set_nonblocking!(sysfd::Int32, enabled::Bool) = nothing
+    set_sockopt_int(fd::Int32, level::Int32, optname::Int32, value::Integer) = nothing
+    get_socket_error(fd::Int32)::Int32 = Int32(0)
+    update_connect_context!(fd::Int32) = nothing
+
+    function sockaddr_bytes(addr::SockAddrIn)::Vector{UInt8}
+        bytes = Vector{UInt8}(undef, sizeof(SockAddrIn))
+        GC.@preserve bytes addr unsafe_store!(Ptr{SockAddrIn}(pointer(bytes)), addr)
+        return bytes
+    end
+
+    function sockaddr_bytes(addr::SockAddrIn6)::Vector{UInt8}
+        bytes = Vector{UInt8}(undef, sizeof(SockAddrIn6))
+        GC.@preserve bytes addr unsafe_store!(Ptr{SockAddrIn6}(pointer(bytes)), addr)
+        return bytes
+    end
+end
 
 function sockaddr_in(ip::NTuple{4, UInt8}, port::Integer)::SockAddrIn
     return SockAddrIn(
@@ -719,6 +1146,10 @@ function sockaddr_in(ip::NTuple{4, UInt8}, port::Integer)::SockAddrIn
         _hton32(_ipv4_u32(ip)),
         ntuple(_ -> UInt8(0), 8),
     )
+end
+
+function sockaddr_in(ip::NTuple{4, <:Integer}, port::Integer)::SockAddrIn
+    return sockaddr_in((_byte_u8(ip[1]), _byte_u8(ip[2]), _byte_u8(ip[3]), _byte_u8(ip[4])), port)
 end
 
 function sockaddr_in_any(port::Integer)::SockAddrIn
@@ -740,20 +1171,26 @@ function sockaddr_in6(
     )
 end
 
+function sockaddr_in6(
+        ip::NTuple{16, <:Integer},
+        port::Integer;
+        flowinfo::Integer = 0,
+        scope_id::Integer = 0,
+    )::SockAddrIn6
+    return sockaddr_in6((
+            _byte_u8(ip[1]), _byte_u8(ip[2]), _byte_u8(ip[3]), _byte_u8(ip[4]),
+            _byte_u8(ip[5]), _byte_u8(ip[6]), _byte_u8(ip[7]), _byte_u8(ip[8]),
+            _byte_u8(ip[9]), _byte_u8(ip[10]), _byte_u8(ip[11]), _byte_u8(ip[12]),
+            _byte_u8(ip[13]), _byte_u8(ip[14]), _byte_u8(ip[15]), _byte_u8(ip[16]),
+        ),
+        port;
+        flowinfo = flowinfo,
+        scope_id = scope_id,
+    )
+end
+
 function sockaddr_in6_any(port::Integer; scope_id::Integer = 0)::SockAddrIn6
     return sockaddr_in6(ntuple(_ -> UInt8(0), 16), port; scope_id = scope_id)
-end
-
-function sockaddr_bytes(addr::SockAddrIn)::Vector{UInt8}
-    bytes = Vector{UInt8}(undef, sizeof(SockAddrIn))
-    GC.@preserve bytes addr unsafe_store!(Ptr{SockAddrIn}(pointer(bytes)), addr)
-    return bytes
-end
-
-function sockaddr_bytes(addr::SockAddrIn6)::Vector{UInt8}
-    bytes = Vector{UInt8}(undef, sizeof(SockAddrIn6))
-    GC.@preserve bytes addr unsafe_store!(Ptr{SockAddrIn6}(pointer(bytes)), addr)
-    return bytes
 end
 
 end

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -1,10 +1,362 @@
 using Test
-using Reseau
 
-const NC = Reseau.TCP
+module IOPoll
 
-println("[windows-compiler-bug] loaded Reseau")
-println("[windows-compiler-bug] julia threads: $(Threads.nthreads())")
+export DeadlineExceededError
+
+struct DeadlineExceededError <: Exception end
+
+end
+
+module TCP
+
+export connect, SocketAddr, SocketAddrV4, SocketAddrV6, SocketEndpoint, Conn, ConnectCanceledError, loopback_addr, loopback_addr6, _connect_socketaddr_impl
+
+function connect end
+
+abstract type SocketAddr end
+
+struct SocketAddrV4 <: SocketAddr
+    ip::NTuple{4, UInt8}
+    port::UInt16
+end
+
+struct SocketAddrV6 <: SocketAddr
+    ip::NTuple{16, UInt8}
+    port::UInt16
+    scope_id::UInt32
+end
+
+const SocketEndpoint = Union{SocketAddrV4, SocketAddrV6}
+
+struct Conn end
+
+struct ConnectCanceledError <: Exception end
+
+function loopback_addr(port::Integer)::SocketAddrV4
+    return SocketAddrV4((UInt8(127), UInt8(0), UInt8(0), UInt8(1)), UInt16(port))
+end
+
+function loopback_addr6(port::Integer; scope_id::Integer = 0)::SocketAddrV6
+    return SocketAddrV6((
+            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+            UInt8(0), UInt8(0), UInt8(0), UInt8(1),
+        ),
+        UInt16(port),
+        UInt32(scope_id),
+    )
+end
+
+function _connect_socketaddr_impl(
+        remote_addr::SocketAddr,
+        local_addr::Union{Nothing, SocketAddr},
+        attempt_deadline::Int64,
+        state,
+    )::Conn
+    _ = attempt_deadline
+    _ = state
+    if local_addr isa SocketAddrV6 && remote_addr isa SocketAddrV4
+        throw(ArgumentError("address family mismatch"))
+    end
+    throw(ArgumentError("connect failed"))
+end
+
+end
+
+Base.close(::TCP.Conn) = nothing
+
+module HostResolvers
+
+using ..IOPoll
+using ..TCP
+import ..TCP: connect
+
+struct AddressError <: Exception
+    err::String
+    addr::String
+end
+
+struct DNSTimeoutError <: Exception
+    address::String
+end
+
+struct DNSOpError <: Exception
+    op::String
+    net::String
+    source::Union{Nothing, TCP.SocketEndpoint}
+    addr::Union{Nothing, TCP.SocketEndpoint}
+    err::Exception
+end
+
+abstract type AbstractResolver end
+
+struct SystemResolver <: AbstractResolver end
+
+struct SingleflightResolver{R <: AbstractResolver} <: AbstractResolver
+    parent::R
+end
+
+SingleflightResolver(parent::R) where {R <: AbstractResolver} = SingleflightResolver{R}(parent)
+
+struct ResolverPolicy
+    prefer_ipv6::Bool
+    allow_ipv4::Bool
+    allow_ipv6::Bool
+end
+
+function ResolverPolicy(; prefer_ipv6::Bool = false, allow_ipv4::Bool = true, allow_ipv6::Bool = true)
+    (!allow_ipv4 && !allow_ipv6) && throw(ArgumentError("resolver policy must allow at least one address family"))
+    return ResolverPolicy(prefer_ipv6, allow_ipv4, allow_ipv6)
+end
+
+const DEFAULT_RESOLVER = SystemResolver()
+
+mutable struct DNSRaceState
+    @atomic done::Bool
+    function DNSRaceState()
+        return new(false)
+    end
+end
+
+struct HostResolver{R <: AbstractResolver}
+    timeout_ns::Int64
+    deadline_ns::Int64
+    local_addr::Union{Nothing, TCP.SocketEndpoint}
+    fallback_delay_ns::Int64
+    resolver::R
+    policy::ResolverPolicy
+end
+
+function HostResolver(;
+        timeout_ns::Integer = Int64(0),
+        deadline_ns::Integer = Int64(0),
+        local_addr::Union{Nothing, TCP.SocketEndpoint} = nothing,
+        fallback_delay_ns::Integer = Int64(300_000_000),
+        resolver::AbstractResolver = DEFAULT_RESOLVER,
+        policy::ResolverPolicy = ResolverPolicy(),
+    )
+    wrapped = resolver isa SingleflightResolver ? resolver : SingleflightResolver(resolver)
+    return HostResolver{typeof(wrapped)}(
+        Int64(timeout_ns),
+        Int64(deadline_ns),
+        local_addr,
+        Int64(fallback_delay_ns),
+        wrapped,
+        policy,
+    )
+end
+
+@inline function _min_nonzero(a::Int64, b::Int64)::Int64
+    a == 0 && return b
+    b == 0 && return a
+    return min(a, b)
+end
+
+function _connect_deadline_ns(d::HostResolver)::Int64
+    now = Int64(time_ns())
+    timeout_deadline = d.timeout_ns == 0 ? Int64(0) : now + d.timeout_ns
+    return _min_nonzero(timeout_deadline, d.deadline_ns)
+end
+
+@inline function _use_parallel_race(
+        d::HostResolver,
+        kind::Symbol,
+        fallbacks::Vector{TCP.SocketEndpoint},
+    )::Bool
+    _ = d
+    _ = kind
+    return !isempty(fallbacks)
+end
+
+function _resolve_with_deadline(
+        d::HostResolver,
+        network::AbstractString,
+        address::AbstractString,
+        deadline_ns::Int64,
+    )::Vector{TCP.SocketEndpoint}
+    _ = d
+    _ = network
+    _ = address
+    _ = deadline_ns
+    return TCP.SocketEndpoint[TCP.loopback_addr(1)]
+end
+
+function _partial_deadline_ns(now_ns::Int64, deadline_ns::Int64, addrs_remaining::Int)::Int64
+    deadline_ns == 0 && return Int64(0)
+    time_remaining = deadline_ns - now_ns
+    time_remaining <= 0 && throw(DNSTimeoutError(""))
+    timeout = time_remaining ÷ addrs_remaining
+    sane_min = Int64(2_000_000_000)
+    if timeout < sane_min
+        timeout = time_remaining < sane_min ? time_remaining : sane_min
+    end
+    return now_ns + timeout
+end
+
+function _partition_addrs(addrs::Vector{TCP.SocketEndpoint})::Tuple{Vector{TCP.SocketEndpoint}, Vector{TCP.SocketEndpoint}}
+    return addrs, TCP.SocketEndpoint[]
+end
+
+@inline function _prefer_ipv4_first!(addrs::Vector{TCP.SocketEndpoint}, policy::ResolverPolicy)
+    _ = addrs
+    _ = policy
+    return nothing
+end
+
+@inline function _wrap_op_error(
+        op::AbstractString,
+        net::AbstractString,
+        source::Union{Nothing, TCP.SocketEndpoint},
+        addr::Union{Nothing, TCP.SocketEndpoint},
+        err::Exception,
+    )::DNSOpError
+    return DNSOpError(String(op), String(net), source, addr, err)
+end
+
+@inline function _as_exception(err)::Exception
+    return err::Exception
+end
+
+@inline _is_self_connect(conn::TCP.Conn)::Bool = false
+@inline _network_kind(network::AbstractString)::Symbol = Symbol(network)
+
+function _mark_connect_done!(state::DNSRaceState)
+    while true
+        current = @atomic :acquire state.done
+        current && return false
+        _, ok = @atomicreplace(state.done, current => true)
+        ok || continue
+        return true
+    end
+end
+
+function _resolve_serial(
+        d::HostResolver,
+        network::AbstractString,
+        address::AbstractString,
+        addrs::Vector{TCP.SocketEndpoint},
+        deadline_ns::Int64,
+        state::DNSRaceState,
+    )::Tuple{Union{Nothing, TCP.Conn}, Union{Nothing, Exception}}
+    _ = network
+    first_err::Union{Nothing, Exception} = nothing
+    for (i, remote_addr) in pairs(addrs)
+        if @atomic :acquire state.done
+            return nothing, first_err
+        end
+        now_ns = Int64(time_ns())
+        if deadline_ns != 0 && now_ns >= deadline_ns
+            return nothing, DNSTimeoutError(String(address))
+        end
+        attempt_deadline = try
+            _partial_deadline_ns(now_ns, deadline_ns, length(addrs) - i + 1)
+        catch err
+            err isa DNSTimeoutError || rethrow(err)
+            return nothing, DNSTimeoutError(String(address))
+        end
+        try
+            max_attempts = d.local_addr === nothing ? 3 : 1
+            for attempt in 1:max_attempts
+                if @atomic :acquire state.done
+                    return nothing, first_err
+                end
+                try
+                    conn = TCP._connect_socketaddr_impl(remote_addr, d.local_addr, attempt_deadline, state)
+                    if d.local_addr === nothing && _is_self_connect(conn) && attempt < max_attempts
+                        close(conn)
+                        continue
+                    end
+                    if _mark_connect_done!(state)
+                        return conn, nothing
+                    end
+                    close(conn)
+                    return nothing, first_err
+                catch err
+                    ex = _as_exception(err)
+                    if ex isa TCP.ConnectCanceledError && (@atomic :acquire state.done)
+                        return nothing, first_err
+                    end
+                    if d.local_addr === nothing &&
+                       ex isa SystemError &&
+                       (ex::SystemError).errnum == Int(Base.Libc.EADDRNOTAVAIL) &&
+                       attempt < max_attempts
+                        continue
+                    end
+                    mapped = ex isa IOPoll.DeadlineExceededError ? DNSTimeoutError(String(address)) : ex
+                    first_err === nothing && (first_err = mapped)
+                    break
+                end
+            end
+        catch err
+            ex = _as_exception(err)
+            first_err === nothing && (first_err = ex)
+        end
+    end
+    first_err === nothing && (first_err = AddressError("missing address", String(address)))
+    return nothing, first_err::Exception
+end
+
+function connect(
+        d::HostResolver,
+        network::AbstractString,
+        address::AbstractString,
+    )::TCP.Conn
+    deadline_ns = _connect_deadline_ns(d)
+    if deadline_ns != 0 && Int64(time_ns()) >= deadline_ns
+        throw(_wrap_op_error("connect", network, d.local_addr, nothing, DNSTimeoutError(String(address))))
+    end
+    kind = try
+        _network_kind(network)
+    catch err
+        throw(_wrap_op_error("connect", network, d.local_addr, nothing, _as_exception(err)))
+    end
+    addrs = try
+        _resolve_with_deadline(d, network, address, deadline_ns)
+    catch err
+        throw(_wrap_op_error("connect", network, d.local_addr, nothing, _as_exception(err)))
+    end
+    if deadline_ns != 0 && Int64(time_ns()) >= deadline_ns
+        throw(_wrap_op_error("connect", network, d.local_addr, nothing, DNSTimeoutError(String(address))))
+    end
+    _prefer_ipv4_first!(addrs, d.policy)
+    primaries, fallbacks = _partition_addrs(addrs)
+    conn = nothing
+    err = nothing
+    if _use_parallel_race(d, kind, fallbacks)
+        error("parallel race should not be used in this reproducer")
+    else
+        state = DNSRaceState()
+        conn, err = _resolve_serial(d, network, address, addrs, deadline_ns, state)
+    end
+    conn !== nothing && return conn
+    throw(_wrap_op_error(
+        "connect",
+        network,
+        d.local_addr,
+        isempty(addrs) ? nothing : addrs[1],
+        err === nothing ? AddressError("missing address", String(address)) : err::Exception,
+    ))
+end
+
+function connect(
+        network::AbstractString,
+        address::AbstractString;
+        kwargs...,
+    )::TCP.Conn
+    resolver = isempty(kwargs) ? HostResolver() : HostResolver(; kwargs...)
+    return connect(resolver, network, address)
+end
+
+function connect(
+        address::AbstractString;
+        kwargs...,
+    )::TCP.Conn
+    return connect("tcp", address; kwargs...)
+end
+
+end
 
 function _probe(f, label::AbstractString)
     println("[windows-compiler-bug] probe start: $(label)")
@@ -17,15 +369,14 @@ function _probe(f, label::AbstractString)
     return nothing
 end
 
-@test Reseau.TCP === TCP
-@test Reseau.TLS === TLS
+println("[windows-compiler-bug] julia threads: $(Threads.nthreads())")
 
 _probe("tcp kwcall local_addr v4") do
-    NC.connect("tcp", "127.0.0.1:1"; local_addr = NC.loopback_addr(0))
+    TCP.connect("tcp", "127.0.0.1:1"; local_addr = TCP.loopback_addr(0))
 end
 
 _probe("tcp kwcall local_addr v6 mismatch") do
-    NC.connect("tcp", "127.0.0.1:1"; local_addr = NC.loopback_addr6(0))
+    TCP.connect("tcp", "127.0.0.1:1"; local_addr = TCP.loopback_addr6(0))
 end
 
 @test true

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -862,21 +862,27 @@ end
 
 module SocketOps
 
-export AF_INET, AF_INET6, SOCK_STREAM, IPPROTO_TCP, TCP_NODELAY, SOL_SOCKET, SO_KEEPALIVE, SO_ERROR, SockAddrIn, SockAddrIn6, AcceptPeer, open_socket, bind_socket, connect_socket, set_nonblocking!, set_sockopt_int, get_socket_error, update_connect_context!, sockaddr_in, sockaddr_in_any, sockaddr_in6, sockaddr_in6_any, sockaddr_bytes
+export AF_UNIX, AF_INET, AF_INET6, SOCK_STREAM, SOCK_DGRAM, IPPROTO_TCP, TCP_NODELAY, SOL_SOCKET, SO_KEEPALIVE, SO_ERROR, SO_REUSEADDR, MSG_PEEK, SockAddrIn, SockAddrIn6, AcceptPeer, IOVec, MsgHdr, open_socket, bind_socket, connect_socket, set_nonblocking!, set_sockopt_int, get_socket_error, update_connect_context!, sockaddr_in, sockaddr_in_any, sockaddr_in6, sockaddr_in6_any, sockaddr_bytes
 
 const SockLen = Int32
+const AF_UNIX = Int32(1)
 const AF_INET = Int32(2)
 const AF_INET6 = Int32(23)
 const SOCK_STREAM = Int32(1)
+const SOCK_DGRAM = Int32(2)
 const IPPROTO_TCP = Int32(6)
 const TCP_NODELAY = Int32(1)
 const SOL_SOCKET = Int32(0xffff)
 const SO_KEEPALIVE = Int32(0x0008)
 const SO_ERROR = Int32(0x1007)
+const SO_REUSEADDR = Int32(0x0004)
 const SHUT_RD = Int32(0)
 const SHUT_WR = Int32(1)
+const SHUT_RDWR = Int32(2)
+const MSG_PEEK = Int32(0x02)
 
 const _WS2_32 = "Ws2_32"
+const _MSWSOCK = "Mswsock"
 const _KERNEL32 = "Kernel32"
 const _INVALID_SOCKET = UInt(typemax(UInt))
 const _SOCKET_ERROR = Int32(-1)
@@ -951,6 +957,21 @@ end
 
 const AcceptPeer = Union{SockAddrIn, SockAddrIn6}
 
+struct IOVec
+    iov_base::Ptr{Cvoid}
+    iov_len::Csize_t
+end
+
+struct MsgHdr
+    msg_name::Ptr{Cvoid}
+    msg_namelen::SockLen
+    msg_iov::Ptr{IOVec}
+    msg_iovlen::Int32
+    msg_control::Ptr{Cvoid}
+    msg_controllen::SockLen
+    msg_flags::Int32
+end
+
 struct _WSAData
     wVersion::UInt16
     wHighVersion::UInt16
@@ -966,7 +987,17 @@ end
     return v
 end
 
+@inline function _ntoh16(v::UInt16)::UInt16
+    Base.ENDIAN_BOM == 0x04030201 && return bswap(v)
+    return v
+end
+
 @inline function _hton32(v::UInt32)::UInt32
+    Base.ENDIAN_BOM == 0x04030201 && return bswap(v)
+    return v
+end
+
+@inline function _ntoh32(v::UInt32)::UInt32
     Base.ENDIAN_BOM == 0x04030201 && return bswap(v)
     return v
 end
@@ -1365,6 +1396,10 @@ function sockaddr_in_any(port::Integer)::SockAddrIn
     return sockaddr_in((UInt8(0), UInt8(0), UInt8(0), UInt8(0)), port)
 end
 
+function sockaddr_in_loopback(port::Integer)::SockAddrIn
+    return sockaddr_in((UInt8(127), UInt8(0), UInt8(0), UInt8(1)), port)
+end
+
 function sockaddr_in6(
         ip::NTuple{16, UInt8},
         port::Integer;
@@ -1402,6 +1437,18 @@ function sockaddr_in6_any(port::Integer; scope_id::Integer = 0)::SockAddrIn6
     return sockaddr_in6(ntuple(_ -> UInt8(0), 16), port; scope_id = scope_id)
 end
 
+function sockaddr_in6_loopback(port::Integer; scope_id::Integer = 0)::SockAddrIn6
+    return sockaddr_in6((
+            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+            UInt8(0), UInt8(0), UInt8(0), UInt8(1),
+        ),
+        port;
+        scope_id = scope_id,
+    )
+end
+
 @inline function sockaddr_in_ip(addr::SockAddrIn)::NTuple{4, UInt8}
     ip = _hton32(addr.sin_addr)
     return (
@@ -1413,12 +1460,12 @@ end
 end
 
 @inline function sockaddr_in_port(addr::SockAddrIn)::UInt16
-    return _hton16(addr.sin_port)
+    return _ntoh16(addr.sin_port)
 end
 
 @inline sockaddr_in6_ip(addr::SockAddrIn6)::NTuple{16, UInt8} = addr.sin6_addr
 @inline function sockaddr_in6_port(addr::SockAddrIn6)::UInt16
-    return _hton16(addr.sin6_port)
+    return _ntoh16(addr.sin6_port)
 end
 @inline sockaddr_in6_scopeid(addr::SockAddrIn6)::UInt32 = addr.sin6_scope_id
 
@@ -1432,8 +1479,18 @@ get_peer_name_in6(fd::Int32)::SockAddrIn6 = sockaddr_in6((
         UInt8(0), UInt8(0), UInt8(0), UInt8(0),
         UInt8(0), UInt8(0), UInt8(0), UInt8(1),
     ), 1)
+fd_is_cloexec(fd::Int32)::Bool = true
+fd_is_nonblocking(fd::Int32)::Bool = true
 last_error() = Int32(Base.Libc.EAGAIN)
 recv_from!(fd::Int32, ptr::Ptr{UInt8}, nbytes, flags)::Int = 0
+read_once!(fd::Int32, ptr::Ptr{UInt8}, nbytes::Csize_t) = 0
+write_once!(fd::Int32, ptr::Ptr{UInt8}, nbytes::Csize_t) = nbytes
+send_to!(fd::Int32, ptr::Ptr{UInt8}, nbytes::Csize_t, flags::Int32, addr::Ptr{Cvoid}, addrlen::SockLen) = nbytes
+recv_msg!(fd::Int32, msg::Ref{MsgHdr}, flags::Int32 = Int32(0)) = 0
+send_msg!(fd::Int32, msg::Ref{MsgHdr}, flags::Int32 = Int32(0)) = 0
+try_accept_socket(fd::Int32)::Tuple{Int32, AcceptPeer, Int32} = (Int32(3), sockaddr_in_loopback(1), Int32(0))
+accept_socket(fd::Int32)::Int32 = Int32(3)
+close_socket(fd::Int32) = nothing
 
 end
 

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -118,16 +118,93 @@ end
 
 module SocketOps
 
-export AF_INET, AF_INET6, SOCK_STREAM, open_socket, bind_socket, set_nonblocking!, sockaddr_bytes
+export AF_INET, AF_INET6, SOCK_STREAM, SockAddrIn, SockAddrIn6, open_socket, bind_socket, set_nonblocking!, sockaddr_in, sockaddr_in_any, sockaddr_in6, sockaddr_in6_any, sockaddr_bytes
 
 const AF_INET = Int32(2)
 const AF_INET6 = Int32(23)
 const SOCK_STREAM = Int32(1)
 
+struct SockAddrIn
+    sin_family::UInt16
+    sin_port::UInt16
+    sin_addr::UInt32
+    sin_zero::NTuple{8, UInt8}
+end
+
+struct SockAddrIn6
+    sin6_family::UInt16
+    sin6_port::UInt16
+    sin6_flowinfo::UInt32
+    sin6_addr::NTuple{16, UInt8}
+    sin6_scope_id::UInt32
+end
+
+@inline function _hton16(v::UInt16)::UInt16
+    Base.ENDIAN_BOM == 0x04030201 && return bswap(v)
+    return v
+end
+
+@inline function _hton32(v::UInt32)::UInt32
+    Base.ENDIAN_BOM == 0x04030201 && return bswap(v)
+    return v
+end
+
+@inline function _port_u16(port::Integer)::UInt16
+    (port < 0 || port > 0xffff) && throw(ArgumentError("port must be in [0, 65535]"))
+    return UInt16(port)
+end
+
+@inline function _ipv4_u32(ip::NTuple{4, UInt8})::UInt32
+    return (UInt32(ip[1]) << 24) | (UInt32(ip[2]) << 16) | (UInt32(ip[3]) << 8) | UInt32(ip[4])
+end
+
 open_socket(family::Int32, sotype::Int32) = Int32(1)
-bind_socket(sysfd::Int32, sockaddr) = nothing
+bind_socket(sysfd::Int32, sockaddr::Union{SockAddrIn, SockAddrIn6}) = nothing
 set_nonblocking!(sysfd::Int32, enabled::Bool) = nothing
-sockaddr_bytes(sockaddr) = UInt8[0x00]
+
+function sockaddr_in(ip::NTuple{4, UInt8}, port::Integer)::SockAddrIn
+    return SockAddrIn(
+        UInt16(AF_INET),
+        _hton16(_port_u16(port)),
+        _hton32(_ipv4_u32(ip)),
+        ntuple(_ -> UInt8(0), 8),
+    )
+end
+
+function sockaddr_in_any(port::Integer)::SockAddrIn
+    return sockaddr_in((UInt8(0), UInt8(0), UInt8(0), UInt8(0)), port)
+end
+
+function sockaddr_in6(
+        ip::NTuple{16, UInt8},
+        port::Integer;
+        flowinfo::Integer = 0,
+        scope_id::Integer = 0,
+    )::SockAddrIn6
+    return SockAddrIn6(
+        UInt16(AF_INET6),
+        _hton16(_port_u16(port)),
+        _hton32(UInt32(flowinfo)),
+        ip,
+        UInt32(scope_id),
+    )
+end
+
+function sockaddr_in6_any(port::Integer; scope_id::Integer = 0)::SockAddrIn6
+    return sockaddr_in6(ntuple(_ -> UInt8(0), 16), port; scope_id = scope_id)
+end
+
+function sockaddr_bytes(addr::SockAddrIn)::Vector{UInt8}
+    bytes = Vector{UInt8}(undef, sizeof(SockAddrIn))
+    GC.@preserve bytes addr unsafe_store!(Ptr{SockAddrIn}(pointer(bytes)), addr)
+    return bytes
+end
+
+function sockaddr_bytes(addr::SockAddrIn6)::Vector{UInt8}
+    bytes = Vector{UInt8}(undef, sizeof(SockAddrIn6))
+    GC.@preserve bytes addr unsafe_store!(Ptr{SockAddrIn6}(pointer(bytes)), addr)
+    return bytes
+end
 
 end
 
@@ -193,7 +270,13 @@ end
 @inline _connect_wait_unregister!(::Any, ::FD) = nothing
 @inline _addr_family(::SocketAddrV4)::Int32 = SocketOps.AF_INET
 @inline _addr_family(::SocketAddrV6)::Int32 = SocketOps.AF_INET6
-@inline _to_sockaddr(addr::SocketAddr) = addr
+@inline function _to_sockaddr(addr::SocketAddrV4)::SocketOps.SockAddrIn
+    return SocketOps.sockaddr_in(addr.ip, Int(addr.port))
+end
+
+@inline function _to_sockaddr(addr::SocketAddrV6)::SocketOps.SockAddrIn6
+    return SocketOps.sockaddr_in6(addr.ip, Int(addr.port); scope_id = Int(addr.scope_id))
+end
 
 function _new_netfd(
         sysfd::Int32;
@@ -223,7 +306,7 @@ function _wait_connect_complete!(
         @static if Sys.iswindows()
             sockaddr = _to_sockaddr(remote_addr)
             addrbuf = SocketOps.sockaddr_bytes(sockaddr)
-            addrlen = Int32(1)
+            addrlen = Int32(sizeof(typeof(sockaddr)))
             while true
                 if _connect_canceled(cancel_state)
                     throw(ConnectCanceledError())
@@ -263,8 +346,11 @@ function _wait_connect_complete!(
 end
 
 @inline function _bind_connectex_local!(fd::FD, family::Int32)
-    _ = fd
-    _ = family
+    if family == SocketOps.AF_INET6
+        SocketOps.bind_socket(fd.pfd.sysfd, SocketOps.sockaddr_in6_any(0))
+        return nothing
+    end
+    SocketOps.bind_socket(fd.pfd.sysfd, SocketOps.sockaddr_in_any(0))
     return nothing
 end
 

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -1201,11 +1201,7 @@ function _fd_read_unlock!(fd::FD)
 end
 
 function _fd_write_lock!(fd::FD)
-    println("[windows-compiler-bug] enter _fd_write_lock!")
-    flush(stdout)
     _fdlock_rwlock!(fd.fdlock, false, true) || throw(_closing_error(fd.is_file))
-    println("[windows-compiler-bug] acquired _fd_write_lock!")
-    flush(stdout)
     return nothing
 end
 
@@ -1517,25 +1513,13 @@ function _finish_iocp_mode!(registration::Registration, mode::PollMode.T)::Int32
 end
 
 function connect!(fd::FD, addrbuf::Vector{UInt8}, addrlen::Int32)
-    println("[windows-compiler-bug] enter IOPoll.connect!")
-    flush(stdout)
     _fd_write_lock!(fd)
-    println("[windows-compiler-bug] after _fd_write_lock!")
-    flush(stdout)
     try
         preparewrite(fd.pd, fd.is_file)
-        println("[windows-compiler-bug] after preparewrite")
-        flush(stdout)
         registration = _poll_registration(fd.pd)
-        println("[windows-compiler-bug] after _poll_registration")
-        flush(stdout)
         errno = _iocp_submit_connect!(registration, addrbuf, addrlen)
-        println("[windows-compiler-bug] after _iocp_submit_connect!")
-        flush(stdout)
         errno == Int32(0) || throw(SystemError("connectex", Int(errno)))
         try
-            println("[windows-compiler-bug] before pollwait! write")
-            flush(stdout)
             pollwait!(registration.write_waiter)
             _convert_poll_error!(_check_error(fd.pd, PollMode.WRITE), fd.is_file)
         catch err
@@ -2720,8 +2704,6 @@ function _wait_connect_complete!(
         remote_addr::SocketAddr,
         cancel_state = nothing,
     )
-    println("[windows-compiler-bug] enter _wait_connect_complete!")
-    flush(stdout)
     _connect_wait_register!(cancel_state, fd)
     try
         @static if Sys.iswindows()
@@ -2786,42 +2768,24 @@ function _connect_socketaddr_impl(
         attempt_deadline::Int64,
         state,
     )::Conn
-    println("[windows-compiler-bug] enter _connect_socketaddr_impl")
-    flush(stdout)
     family = _addr_family(remote_addr)
-    println("[windows-compiler-bug] computed family")
-    flush(stdout)
     if local_addr !== nothing && _addr_family(local_addr) != family
         throw(ArgumentError("local and remote address families must match"))
     end
-    println("[windows-compiler-bug] local family check done")
-    flush(stdout)
     fd = open_tcp_fd!(; family = family)
-    println("[windows-compiler-bug] opened tcp fd")
-    flush(stdout)
     try
         if local_addr !== nothing
             SocketOps.bind_socket(fd.pfd.sysfd, _to_sockaddr(local_addr))
         elseif Sys.iswindows()
             _bind_connectex_local!(fd, family)
         end
-        println("[windows-compiler-bug] local bind step done")
-        flush(stdout)
         SocketOps.set_nonblocking!(fd.pfd.sysfd, true)
-        println("[windows-compiler-bug] set nonblocking")
-        flush(stdout)
         @static if Sys.iswindows()
             IOPoll.register!(fd.pfd)
-            println("[windows-compiler-bug] registered with iopoll")
-            flush(stdout)
             if attempt_deadline != 0
                 IOPoll.set_write_deadline!(fd.pfd, attempt_deadline)
-                println("[windows-compiler-bug] set write deadline")
-                flush(stdout)
             end
             try
-                println("[windows-compiler-bug] before _wait_connect_complete!")
-                flush(stdout)
                 _wait_connect_complete!(fd, remote_addr, state)
             finally
                 if attempt_deadline != 0
@@ -4326,8 +4290,6 @@ function _resolve_serial(
         deadline_ns::Int64,
         state::DNSRaceState,
     )::Tuple{Union{Nothing, TCP.Conn}, Union{Nothing, Exception}}
-    println("[windows-compiler-bug] enter _resolve_serial")
-    flush(stdout)
     _ = network
     first_err::Union{Nothing, Exception} = nothing
     for (i, remote_addr) in pairs(addrs)
@@ -4351,8 +4313,6 @@ function _resolve_serial(
                     return nothing, first_err
                 end
                 try
-                    println("[windows-compiler-bug] before _connect_socketaddr_impl")
-                    flush(stdout)
                     conn = TCP._connect_socketaddr_impl(remote_addr, d.local_addr, attempt_deadline, state)
                     if d.local_addr === nothing && _is_self_connect(conn) && attempt < max_attempts
                         close(conn)
@@ -4476,8 +4436,6 @@ function connect(
         network::AbstractString,
         address::AbstractString,
     )::TCP.Conn
-    println("[windows-compiler-bug] enter HostResolvers.connect")
-    flush(stdout)
     deadline_ns = _connect_deadline_ns(d)
     if deadline_ns != 0 && Int64(time_ns()) >= deadline_ns
         throw(_wrap_op_error("connect", network, d.local_addr, nothing, DNSTimeoutError(String(address))))
@@ -4492,8 +4450,6 @@ function connect(
     catch err
         throw(_wrap_op_error("connect", network, d.local_addr, nothing, _as_exception(err)))
     end
-    println("[windows-compiler-bug] resolved addrs")
-    flush(stdout)
     if deadline_ns != 0 && Int64(time_ns()) >= deadline_ns
         throw(_wrap_op_error("connect", network, d.local_addr, nothing, DNSTimeoutError(String(address))))
     end

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -262,6 +262,14 @@ abstract type AbstractResolver end
 
 struct SystemResolver <: AbstractResolver end
 
+mutable struct CachingResolver{R <: AbstractResolver} <: AbstractResolver
+    parent::R
+end
+
+struct StaticResolver <: AbstractResolver
+    fallback::Union{Nothing, AbstractResolver}
+end
+
 mutable struct _LookupFlight
     lock::ReentrantLock
     cond::Threads.Condition
@@ -414,6 +422,12 @@ function lookup_port(resolver::AbstractResolver, network::AbstractString, servic
     return parse(Int, service)
 end
 
+lookup_port(resolver::SingleflightResolver, network::AbstractString, service::AbstractString)::Int =
+    lookup_port((resolver::SingleflightResolver).parent, network, service)
+
+lookup_port(resolver::CachingResolver, network::AbstractString, service::AbstractString)::Int =
+    lookup_port((resolver::CachingResolver).parent, network, service)
+
 function _with_port(addr::TCP.SocketAddrV4, port::Int)::TCP.SocketAddrV4
     return TCP.SocketAddrV4(addr.ip, UInt16(port))
 end
@@ -422,13 +436,7 @@ function _with_port(addr::TCP.SocketAddrV6, port::Int)::TCP.SocketAddrV6
     return TCP.SocketAddrV6(addr.ip, UInt16(port), addr.scope_id)
 end
 
-function _resolve_host_ips(
-        resolver::AbstractResolver,
-        network::AbstractString,
-        host::AbstractString,
-    )::Vector{TCP.SocketEndpoint}
-    _ = resolver
-    _ = network
+function _resolve_system_host(host::AbstractString)::Vector{TCP.SocketEndpoint}
     h = String(host)
     if h == "127.0.0.1"
         return TCP.SocketEndpoint[TCP.loopback_addr(0)]
@@ -437,6 +445,110 @@ function _resolve_host_ips(
         return TCP.SocketEndpoint[TCP.loopback_addr6(0)]
     end
     throw(AddressError("lookup failed", h))
+end
+
+function _resolve_static_host(
+        resolver::StaticResolver,
+        network::AbstractString,
+        host::AbstractString,
+    )::Vector{TCP.SocketEndpoint}
+    resolver.fallback === nothing && throw(AddressError("lookup failed", String(host)))
+    return _resolve_host_ips(resolver.fallback::AbstractResolver, network, host)
+end
+
+@inline function _normalize_lookup_host(host::AbstractString)::String
+    normalized = lowercase(String(host))
+    while !isempty(normalized) && last(normalized) == '.'
+        normalized = normalized[1:prevind(normalized, lastindex(normalized))]
+    end
+    return normalized
+end
+
+@inline function _lookup_key(network::AbstractString, host::AbstractString)::Tuple{String, String}
+    return lowercase(String(network)), _normalize_lookup_host(host)
+end
+
+function _resolve_singleflight_host(
+        resolver::SingleflightResolver,
+        network::AbstractString,
+        host::AbstractString,
+    )::Vector{TCP.SocketEndpoint}
+    h = String(host)
+    key = _lookup_key(network, h)
+    flight = nothing
+    leader = false
+    lock(resolver.lock)
+    try
+        existing = get(() -> nothing, resolver.inflight, key)
+        if existing === nothing
+            flight = _LookupFlight()
+            resolver.inflight[key] = flight::_LookupFlight
+            @atomic :acquire_release resolver.actual_lookups += 1
+            leader = true
+        else
+            flight = existing::_LookupFlight
+            @atomic :acquire_release resolver.shared_hits += 1
+        end
+    finally
+        unlock(resolver.lock)
+    end
+    if leader
+        result = nothing
+        err = nothing
+        try
+            result = _resolve_host_ips(resolver.parent, network, h)
+        catch ex
+            err = ex::Exception
+        end
+        lock((flight::_LookupFlight).lock)
+        try
+            flight.result = result === nothing ? nothing : copy(result::Vector{TCP.SocketEndpoint})
+            flight.err = err
+            @atomic :release flight.done = true
+            notify(flight.cond; all = true)
+        finally
+            unlock(flight.lock)
+        end
+        lock(resolver.lock)
+        try
+            current = get(() -> nothing, resolver.inflight, key)
+            current === flight && delete!(resolver.inflight, key)
+        finally
+            unlock(resolver.lock)
+        end
+        err === nothing || throw(err::Exception)
+        return result::Vector{TCP.SocketEndpoint}
+    end
+    lock((flight::_LookupFlight).lock)
+    try
+        while !(@atomic :acquire flight.done)
+            wait(flight.cond)
+        end
+        flight.err === nothing || throw(flight.err::Exception)
+        return copy(flight.result::Vector{TCP.SocketEndpoint})
+    finally
+        unlock(flight.lock)
+    end
+end
+
+function _resolve_host_ips(
+        resolver::AbstractResolver,
+        network::AbstractString,
+        host::AbstractString,
+    )::Vector{TCP.SocketEndpoint}
+    if resolver isa SingleflightResolver
+        return _resolve_singleflight_host(resolver::SingleflightResolver, network, host)
+    end
+    if resolver isa CachingResolver
+        return _resolve_host_ips((resolver::CachingResolver).parent, network, host)
+    end
+    if resolver isa SystemResolver
+        return _resolve_system_host(host)
+    end
+    if resolver isa StaticResolver
+        return _resolve_static_host(resolver::StaticResolver, network, host)
+    end
+    return _resolve_system_host(host)
 end
 
 function _apply_policy_and_network(

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -1400,6 +1400,19 @@ function sockaddr_in6_any(port::Integer; scope_id::Integer = 0)::SockAddrIn6
     return sockaddr_in6(ntuple(_ -> UInt8(0), 16), port; scope_id = scope_id)
 end
 
+@inline function sockaddr_in_ip(addr::SockAddrIn)::NTuple{4, UInt8}
+    ip = _hton32(addr.sin_addr)
+    return (
+        UInt8((ip >> 24) & 0xff),
+        UInt8((ip >> 16) & 0xff),
+        UInt8((ip >> 8) & 0xff),
+        UInt8(ip & 0xff),
+    )
+end
+
+@inline sockaddr_in6_ip(addr::SockAddrIn6)::NTuple{16, UInt8} = addr.sin6_addr
+@inline sockaddr_in6_scopeid(addr::SockAddrIn6)::UInt32 = addr.sin6_scope_id
+
 end
 
 module TCP
@@ -1865,6 +1878,7 @@ end
 module HostResolvers
 
 using ..IOPoll
+using ..SocketOps
 using ..TCP
 import ..TCP: connect, listen
 
@@ -1895,10 +1909,68 @@ struct SystemResolver <: AbstractResolver end
 
 mutable struct CachingResolver{R <: AbstractResolver} <: AbstractResolver
     parent::R
+    ttl_ns::Int64
+    stale_ttl_ns::Int64
+    negative_ttl_ns::Int64
+    max_hosts::Int
+    lock::ReentrantLock
+    entries::Dict{Tuple{String, String}, Any}
+    @atomic cache_hits::Int
+    @atomic stale_hits::Int
+    @atomic negative_hits::Int
+    @atomic misses::Int
 end
 
 struct StaticResolver <: AbstractResolver
+    hosts::Dict{String, Vector{TCP.SocketEndpoint}}
+    services_tcp::Dict{String, Int}
+    services_udp::Dict{String, Int}
     fallback::Union{Nothing, AbstractResolver}
+end
+
+function CachingResolver(
+        parent::R;
+        ttl_ns::Integer = Int64(5_000_000_000),
+        stale_ttl_ns::Integer = Int64(0),
+        negative_ttl_ns::Integer = Int64(0),
+        max_hosts::Integer = 1024,
+    ) where {R <: AbstractResolver}
+    ttl_ns >= 0 || throw(ArgumentError("ttl_ns must be >= 0"))
+    stale_ttl_ns >= 0 || throw(ArgumentError("stale_ttl_ns must be >= 0"))
+    negative_ttl_ns >= 0 || throw(ArgumentError("negative_ttl_ns must be >= 0"))
+    max_hosts > 0 || throw(ArgumentError("max_hosts must be > 0"))
+    return CachingResolver{R}(
+        parent,
+        Int64(ttl_ns),
+        Int64(stale_ttl_ns),
+        Int64(negative_ttl_ns),
+        Int(max_hosts),
+        ReentrantLock(),
+        Dict{Tuple{String, String}, Any}(),
+        0,
+        0,
+        0,
+        0,
+    )
+end
+
+function CachingResolver(;
+        parent::AbstractResolver = SystemResolver(),
+        ttl_ns::Integer = Int64(5_000_000_000),
+        stale_ttl_ns::Integer = Int64(0),
+        negative_ttl_ns::Integer = Int64(0),
+        max_hosts::Integer = 1024,
+    )
+    return CachingResolver(parent; ttl_ns = ttl_ns, stale_ttl_ns = stale_ttl_ns, negative_ttl_ns = negative_ttl_ns, max_hosts = max_hosts)
+end
+
+function StaticResolver(;
+        hosts::Dict{String, Vector{TCP.SocketEndpoint}} = Dict{String, Vector{TCP.SocketEndpoint}}(),
+        services_tcp::Dict{String, Int} = Dict{String, Int}(),
+        services_udp::Dict{String, Int} = Dict{String, Int}(),
+        fallback::Union{Nothing, AbstractResolver} = nothing,
+    )
+    return StaticResolver(copy(hosts), copy(services_tcp), copy(services_udp), fallback)
 end
 
 mutable struct _LookupFlight
@@ -1925,6 +1997,15 @@ function SingleflightResolver(parent::R) where {R <: AbstractResolver}
     return SingleflightResolver{R}(parent, ReentrantLock(), Dict{Tuple{String, String}, _LookupFlight}(), 0, 0)
 end
 
+mutable struct _LookupCacheEntry
+    result::Union{Nothing, Vector{TCP.SocketEndpoint}}
+    err::Union{Nothing, Exception}
+    expires_ns::Int64
+    stale_expires_ns::Int64
+    last_access_ns::Int64
+    refreshing::Bool
+end
+
 struct ResolverPolicy
     prefer_ipv6::Bool
     allow_ipv4::Bool
@@ -1938,6 +2019,88 @@ end
 
 const DEFAULT_RESOLVER = SystemResolver()
 const _SERVICE_TCP = Dict{String, Int}("http" => 80, "https" => 443, "ssh" => 22)
+const _SERVICE_UDP = Dict{String, Int}("domain" => 53)
+const _SERVICE_LOCK = ReentrantLock()
+const _SERVICES_LOADED = Ref(false)
+
+function _load_system_services!()
+    path = "/etc/services"
+    isfile(path) || return nothing
+    for raw in eachline(path)
+        line = strip(raw)
+        isempty(line) && continue
+        startswith(line, '#') && continue
+        hash_i = findfirst(==('#'), line)
+        if hash_i !== nothing
+            if hash_i == firstindex(line)
+                continue
+            end
+            line = strip(line[firstindex(line):prevind(line, hash_i)])
+            isempty(line) && continue
+        end
+        fields = split(line)
+        length(fields) < 2 && continue
+        portnet = fields[2]
+        slash_i = findfirst(==('/'), portnet)
+        slash_i === nothing && continue
+        slash_i == firstindex(portnet) && continue
+        slash_i == lastindex(portnet) && continue
+        port_str = portnet[firstindex(portnet):prevind(portnet, slash_i)]
+        proto = lowercase(portnet[nextind(portnet, slash_i):lastindex(portnet)])
+        port = tryparse(Int, port_str)
+        port === nothing && continue
+        (port <= 0 || port > 65535) && continue
+        table = if proto == "tcp"
+            _SERVICE_TCP
+        elseif proto == "udp"
+            _SERVICE_UDP
+        else
+            nothing
+        end
+        table === nothing && continue
+        for (idx, name) in pairs(fields)
+            idx == 2 && continue
+            table[lowercase(name)] = port
+        end
+    end
+    return nothing
+end
+
+function _ensure_system_services_loaded!()
+    _SERVICES_LOADED[] && return nothing
+    lock(_SERVICE_LOCK)
+    try
+        _SERVICES_LOADED[] && return nothing
+        _load_system_services!()
+        _SERVICES_LOADED[] = true
+    finally
+        unlock(_SERVICE_LOCK)
+    end
+    return nothing
+end
+
+struct _AddrInfo
+    ai_flags::Int32
+    ai_family::Int32
+    ai_socktype::Int32
+    ai_protocol::Int32
+    ai_addrlen::UInt32
+    ai_canonname::Ptr{UInt8}
+    ai_addr::Ptr{Cvoid}
+    ai_next::Ptr{_AddrInfo}
+end
+
+const _AI_ALL = Int32(0x0010)
+const _AI_V4MAPPED = Int32(0x0008)
+const _AF_UNSPEC = Int32(0)
+const _SOCK_STREAM = Int32(1)
+const _HR_AF_INET = SocketOps.AF_INET
+const _HR_AF_INET6 = SocketOps.AF_INET6
+const _WSAHOST_NOT_FOUND = Int32(11001)
+const _WSATRY_AGAIN = Int32(11002)
+const _WSATYPE_NOT_FOUND = Int32(10109)
+const _DNS_ERROR_RCODE_NAME_ERROR = Int32(9003)
+const _DNS_INFO_NO_RECORDS = Int32(9501)
 
 mutable struct DNSRaceState
     @atomic done::Bool
@@ -2095,6 +2258,92 @@ function _scope_id_from_zone(zone::AbstractString)::UInt32
     throw(AddressError("unknown interface zone", z))
 end
 
+@inline function _utf16_ptr_string(ptr::Ptr{UInt16})::String
+    ptr == C_NULL && return ""
+    len = 0
+    while unsafe_load(ptr, len + 1) != UInt16(0)
+        len += 1
+    end
+    return transcode(String, unsafe_wrap(Vector{UInt16}, ptr, len))
+end
+
+@inline function _gai_error_string(code::Int32)::String
+    code == _WSAHOST_NOT_FOUND && return "no such host"
+    code == _DNS_ERROR_RCODE_NAME_ERROR && return "no such host"
+    code == _DNS_INFO_NO_RECORDS && return "no DNS records"
+    code == _WSATRY_AGAIN && return "temporary failure in name resolution"
+    code == _WSATYPE_NOT_FOUND && return "unknown service"
+    return "getaddrinfo error code $code"
+end
+
+function _native_getaddrinfo(hostname::AbstractString; flags::Int32 = Int32(0))::Vector{TCP.SocketEndpoint}
+    SocketOps.ensure_winsock!()
+    addresses = TCP.SocketEndpoint[]
+    hostname_s = String(hostname)
+    null_service = Ptr{UInt8}(C_NULL)
+    hints = Ref{_AddrInfo}()
+    hints_ptr = Base.unsafe_convert(Ptr{_AddrInfo}, hints)
+    Base.Libc.memset(hints_ptr, 0, sizeof(_AddrInfo))
+    hints_bytes = Ptr{UInt8}(hints_ptr)
+    GC.@preserve hints begin
+        unsafe_store!(Ptr{Int32}(hints_bytes + fieldoffset(_AddrInfo, 1)), flags)
+        unsafe_store!(Ptr{Int32}(hints_bytes + fieldoffset(_AddrInfo, 2)), _AF_UNSPEC)
+        unsafe_store!(Ptr{Int32}(hints_bytes + fieldoffset(_AddrInfo, 3)), _SOCK_STREAM)
+    end
+    result_ptr = Ref{Ptr{_AddrInfo}}(C_NULL)
+    ret = @static if Sys.iswindows()
+        @threadcall((:getaddrinfo, "Ws2_32"), Int32,
+            (Cstring, Cstring, Ptr{_AddrInfo}, Ptr{Ptr{_AddrInfo}}),
+            hostname_s,
+            null_service,
+            hints,
+            result_ptr,
+        )
+    else
+        @threadcall(:getaddrinfo, Int32,
+            (Cstring, Cstring, Ptr{_AddrInfo}, Ptr{Ptr{_AddrInfo}}),
+            hostname_s,
+            null_service,
+            hints,
+            result_ptr,
+        )
+    end
+    ret == 0 || _addr_error("lookup failed: $(_gai_error_string(ret))", hostname_s)
+    try
+        current = result_ptr[]
+        while current != C_NULL
+            ai = unsafe_load(current)
+            if ai.ai_addr != C_NULL
+                if ai.ai_family == _HR_AF_INET && Int(ai.ai_addrlen) >= sizeof(SocketOps.SockAddrIn)
+                    sa = unsafe_load(Ptr{SocketOps.SockAddrIn}(ai.ai_addr))
+                    push!(addresses, TCP.SocketAddrV4(SocketOps.sockaddr_in_ip(sa), 0))
+                elseif ai.ai_family == _HR_AF_INET6 && Int(ai.ai_addrlen) >= sizeof(SocketOps.SockAddrIn6)
+                    sa = unsafe_load(Ptr{SocketOps.SockAddrIn6}(ai.ai_addr))
+                    push!(addresses, TCP.SocketAddrV6(
+                        SocketOps.sockaddr_in6_ip(sa),
+                        0;
+                        scope_id = Int(SocketOps.sockaddr_in6_scopeid(sa)),
+                    ))
+                end
+            end
+            current = ai.ai_next
+        end
+    finally
+        if result_ptr[] != C_NULL
+            @static if Sys.iswindows()
+                ccall((:freeaddrinfo, "Ws2_32"), Cvoid, (Ptr{_AddrInfo},), result_ptr[])
+            else
+                ccall(:freeaddrinfo, Cvoid, (Ptr{_AddrInfo},), result_ptr[])
+            end
+        end
+    end
+    return addresses
+end
+
+function _addr_error(err::AbstractString, addr::AbstractString)
+    throw(AddressError(String(err), String(addr)))
+end
+
 function _literal_host_addr(host::AbstractString)::Union{Nothing, TCP.SocketEndpoint}
     h = String(host)
     isempty(h) && return nothing
@@ -2157,6 +2406,19 @@ function split_host_port(hostport::AbstractString)::Tuple{String, String}
     port_start = nextind(s, i)
     port = String(SubString(s, port_start, last_i))
     return host, port
+end
+
+function join_host_port(host::AbstractString, port::AbstractString)::String
+    host_s = String(host)
+    port_s = String(port)
+    if occursin(':', host_s)
+        return "[$host_s]:$port_s"
+    end
+    return "$host_s:$port_s"
+end
+
+function join_host_port(host::AbstractString, port::Integer)::String
+    return join_host_port(host, string(port))
 end
 
 function lookup_port(resolver::AbstractResolver, network::AbstractString, service::AbstractString)::Int
@@ -2223,14 +2485,53 @@ end
 function lookup_port(::SystemResolver, network::AbstractString, service::AbstractString)::Int
     port, needs_lookup = parse_port(service)
     if needs_lookup
+        _ensure_system_services_loaded!()
         n = String(network)
-        if n == "tcp" || n == "tcp4" || n == "tcp6"
+        if n == "ip" || isempty(n)
+            try
+                port = _parse_port_table(_SERVICE_TCP, "ip", service)
+            catch
+                port = _parse_port_table(_SERVICE_UDP, "ip", service)
+            end
+        elseif n == "tcp" || n == "tcp4" || n == "tcp6"
             port = _parse_port_table(_SERVICE_TCP, n, service)
+        elseif n == "udp" || n == "udp4" || n == "udp6"
+            port = _parse_port_table(_SERVICE_UDP, n, service)
         else
-            throw(UnknownNetworkError(n))
+            _addr_error("unknown network", n)
         end
     end
-    (port < 0 || port > 65535) && throw(AddressError("invalid port", String(service)))
+    (port < 0 || port > 65535) && _addr_error("invalid port", service)
+    return port
+end
+
+function lookup_port(resolver::StaticResolver, network::AbstractString, service::AbstractString)::Int
+    port, needs_lookup = parse_port(service)
+    if needs_lookup
+        n = String(network)
+        if n == "tcp" || n == "tcp4" || n == "tcp6" || n == "" || n == "ip"
+            p = get(() -> nothing, resolver.services_tcp, lowercase(String(service)))
+            if p !== nothing
+                port = p::Int
+            elseif resolver.fallback !== nothing
+                return lookup_port(resolver.fallback::AbstractResolver, network, service)
+            else
+                port = _parse_port_table(_SERVICE_TCP, n, service)
+            end
+        elseif n == "udp" || n == "udp4" || n == "udp6"
+            p = get(() -> nothing, resolver.services_udp, lowercase(String(service)))
+            if p !== nothing
+                port = p::Int
+            elseif resolver.fallback !== nothing
+                return lookup_port(resolver.fallback::AbstractResolver, network, service)
+            else
+                port = _parse_port_table(_SERVICE_UDP, n, service)
+            end
+        else
+            _addr_error("unknown network", n)
+        end
+    end
+    (port < 0 || port > 65535) && _addr_error("invalid port", service)
     return port
 end
 
@@ -2246,7 +2547,31 @@ function _resolve_system_host(host::AbstractString)::Vector{TCP.SocketEndpoint}
     h = String(host)
     literal = _literal_host_addr(h)
     literal === nothing || return TCP.SocketEndpoint[literal]
-    throw(AddressError("lookup failed", h))
+    flags = _AI_ALL | _AI_V4MAPPED
+    ips = _native_getaddrinfo(h; flags = flags)
+    out = TCP.SocketEndpoint[]
+    seen4 = Set{NTuple{4, UInt8}}()
+    seen6 = Set{Tuple{NTuple{16, UInt8}, UInt32}}()
+    for endpoint in ips
+        if endpoint isa TCP.SocketAddrV4
+            ip4 = (endpoint::TCP.SocketAddrV4).ip
+            in(ip4, seen4) && continue
+            push!(seen4, ip4)
+            push!(out, endpoint::TCP.SocketAddrV4)
+            continue
+        end
+        endpoint isa TCP.SocketAddrV6 || continue
+        v6 = endpoint::TCP.SocketAddrV6
+        key = (v6.ip, v6.scope_id)
+        in(key, seen6) && continue
+        push!(seen6, key)
+        push!(out, v6)
+    end
+    return out
+end
+
+function _resolve_static_host(resolver::StaticResolver, host::AbstractString)::Vector{TCP.SocketEndpoint}
+    return _resolve_static_host(resolver, "tcp", host)
 end
 
 function _resolve_static_host(
@@ -2254,8 +2579,13 @@ function _resolve_static_host(
         network::AbstractString,
         host::AbstractString,
     )::Vector{TCP.SocketEndpoint}
-    resolver.fallback === nothing && throw(AddressError("lookup failed", String(host)))
-    return _resolve_host_ips(resolver.fallback::AbstractResolver, network, host)
+    h = String(host)
+    literal = _literal_host_addr(h)
+    literal === nothing || return TCP.SocketEndpoint[literal]
+    mapped = get(() -> nothing, resolver.hosts, lowercase(h))
+    mapped === nothing || return copy(mapped::Vector{TCP.SocketEndpoint})
+    resolver.fallback === nothing && _addr_error("no suitable address", h)
+    return _resolve_host_ips(resolver.fallback::AbstractResolver, network, h)
 end
 
 @inline function _normalize_lookup_host(host::AbstractString)::String
@@ -2276,6 +2606,8 @@ function _resolve_singleflight_host(
         host::AbstractString,
     )::Vector{TCP.SocketEndpoint}
     h = String(host)
+    literal = _literal_host_addr(h)
+    literal === nothing || return TCP.SocketEndpoint[literal]
     key = _lookup_key(network, h)
     flight = nothing
     leader = false
@@ -2333,6 +2665,148 @@ function _resolve_singleflight_host(
     end
 end
 
+function _evict_cache_if_needed_locked!(resolver::CachingResolver)
+    length(resolver.entries) <= resolver.max_hosts && return nothing
+    oldest_key = nothing
+    oldest_access = typemax(Int64)
+    for (key, entry) in resolver.entries
+        if entry.last_access_ns < oldest_access
+            oldest_access = entry.last_access_ns
+            oldest_key = key
+        end
+    end
+    oldest_key === nothing || delete!(resolver.entries, oldest_key)
+    return nothing
+end
+
+function _store_cache_entry_locked!(
+        resolver::CachingResolver,
+        key::Tuple{String, String},
+        result::Union{Nothing, Vector{TCP.SocketEndpoint}},
+        err::Union{Nothing, Exception},
+        now_ns::Int64,
+    )
+    expires_ns = now_ns
+    stale_expires_ns = now_ns
+    if err === nothing
+        expires_ns += resolver.ttl_ns
+        stale_expires_ns = expires_ns + resolver.stale_ttl_ns
+    else
+        expires_ns += resolver.negative_ttl_ns
+        stale_expires_ns = expires_ns
+    end
+    resolver.entries[key] = _LookupCacheEntry(
+        result === nothing ? nothing : copy(result::Vector{TCP.SocketEndpoint}),
+        err,
+        expires_ns,
+        stale_expires_ns,
+        now_ns,
+        false,
+    )
+    _evict_cache_if_needed_locked!(resolver)
+    return nothing
+end
+
+function _refresh_cached_host!(
+        resolver::CachingResolver,
+        key::Tuple{String, String},
+        network::String,
+        host::String,
+    )
+    result = nothing
+    err = nothing
+    try
+        result = _resolve_host_ips(resolver.parent, network, host)
+    catch ex
+        err = ex::Exception
+    end
+    now_ns = Int64(time_ns())
+    lock(resolver.lock)
+    try
+        entry = get(() -> nothing, resolver.entries, key)
+        entry === nothing && return nothing
+        if err === nothing
+            _store_cache_entry_locked!(resolver, key, result::Vector{TCP.SocketEndpoint}, nothing, now_ns)
+            return nothing
+        end
+        entry.refreshing = false
+        if err isa AddressError && resolver.negative_ttl_ns > 0
+            _store_cache_entry_locked!(resolver, key, nothing, err, now_ns)
+        end
+    finally
+        unlock(resolver.lock)
+    end
+    return nothing
+end
+
+function _resolve_cached_host(
+        resolver::CachingResolver,
+        network::AbstractString,
+        host::AbstractString,
+    )::Vector{TCP.SocketEndpoint}
+    h = String(host)
+    literal = _literal_host_addr(h)
+    literal === nothing || return TCP.SocketEndpoint[literal]
+    key = _lookup_key(network, h)
+    now_ns = Int64(time_ns())
+    stale_result = nothing
+    refresh_needed = false
+    lock(resolver.lock)
+    try
+        entry = get(() -> nothing, resolver.entries, key)
+        if entry !== nothing
+            entry.last_access_ns = now_ns
+            if now_ns <= entry.expires_ns
+                if entry.err === nothing
+                    @atomic :acquire_release resolver.cache_hits += 1
+                    return copy(entry.result::Vector{TCP.SocketEndpoint})
+                end
+                @atomic :acquire_release resolver.negative_hits += 1
+                throw(entry.err::Exception)
+            end
+            if entry.err === nothing && now_ns <= entry.stale_expires_ns
+                @atomic :acquire_release resolver.stale_hits += 1
+                stale_result = copy(entry.result::Vector{TCP.SocketEndpoint})
+                if !entry.refreshing
+                    entry.refreshing = true
+                    refresh_needed = true
+                end
+            else
+                delete!(resolver.entries, key)
+            end
+        end
+        stale_result === nothing && (@atomic :acquire_release resolver.misses += 1)
+    finally
+        unlock(resolver.lock)
+    end
+    if stale_result !== nothing
+        if refresh_needed
+            errormonitor(Threads.@spawn _refresh_cached_host!(resolver, key, String(network), h))
+        end
+        return stale_result::Vector{TCP.SocketEndpoint}
+    end
+    result = nothing
+    err = nothing
+    try
+        result = _resolve_host_ips(resolver.parent, network, h)
+    catch ex
+        err = ex::Exception
+    end
+    now_ns = Int64(time_ns())
+    lock(resolver.lock)
+    try
+        if err === nothing
+            _store_cache_entry_locked!(resolver, key, result::Vector{TCP.SocketEndpoint}, nothing, now_ns)
+        elseif err isa AddressError && resolver.negative_ttl_ns > 0
+            _store_cache_entry_locked!(resolver, key, nothing, err, now_ns)
+        end
+    finally
+        unlock(resolver.lock)
+    end
+    err === nothing || throw(err::Exception)
+    return result::Vector{TCP.SocketEndpoint}
+end
+
 function _resolve_host_ips(
         resolver::AbstractResolver,
         network::AbstractString,
@@ -2342,7 +2816,7 @@ function _resolve_host_ips(
         return _resolve_singleflight_host(resolver::SingleflightResolver, network, host)
     end
     if resolver isa CachingResolver
-        return _resolve_host_ips((resolver::CachingResolver).parent, network, host)
+        return _resolve_cached_host(resolver::CachingResolver, network, host)
     end
     if resolver isa SystemResolver
         return _resolve_system_host(host)
@@ -2350,7 +2824,24 @@ function _resolve_host_ips(
     if resolver isa StaticResolver
         return _resolve_static_host(resolver::StaticResolver, network, host)
     end
-    return _resolve_system_host(host)
+    resolved = resolve_tcp_addrs(
+        resolver,
+        network,
+        join_host_port(host, 0);
+        op = :resolve,
+        policy = ResolverPolicy(),
+    )
+    ips = TCP.SocketEndpoint[]
+    for addr in resolved
+        if addr isa TCP.SocketAddrV4
+            v4 = addr::TCP.SocketAddrV4
+            push!(ips, TCP.SocketAddrV4(v4.ip, 0))
+        else
+            v6 = addr::TCP.SocketAddrV6
+            push!(ips, TCP.SocketAddrV6(v6.ip, 0; scope_id = Int(v6.scope_id)))
+        end
+    end
+    return ips
 end
 
 function _resolve_host_ips(resolver::AbstractResolver, host::AbstractString)::Vector{TCP.SocketEndpoint}
@@ -2370,17 +2861,27 @@ function _apply_policy_and_network(
         if kind == :tcp6 && !(addr isa TCP.SocketAddrV6)
             continue
         end
-        if addr isa TCP.SocketAddrV4
-            policy.allow_ipv4 || continue
-        else
-            policy.allow_ipv6 || continue
-        end
+        _policy_accepts(policy, addr) || continue
         push!(out, addr)
     end
     if policy.prefer_ipv6 && kind == :tcp
         sort!(out; by = a -> a isa TCP.SocketAddrV6 ? 0 : 1)
     end
     return out
+end
+
+@inline function _policy_accepts(policy::ResolverPolicy, addr::TCP.SocketEndpoint)::Bool
+    if addr isa TCP.SocketAddrV4
+        return policy.allow_ipv4
+    end
+    return policy.allow_ipv6
+end
+
+@inline function _wildcard_addrs(kind::Symbol, op::Symbol)::Vector{TCP.SocketEndpoint}
+    if kind == :tcp && op == :listen
+        return TCP.SocketEndpoint[TCP.any_addr6(0), TCP.any_addr(0)]
+    end
+    return TCP.SocketEndpoint[TCP.any_addr(0), TCP.any_addr6(0)]
 end
 
 function resolve_tcp_addrs(
@@ -2395,7 +2896,11 @@ function resolve_tcp_addrs(
     op == :connect && isempty(addr) && throw(AddressError("missing address", addr))
     host, service = split_host_port(addr)
     port = lookup_port(resolver, network, service)
-    ips = _resolve_host_ips(resolver, network, host)
+    ips = if isempty(host)
+        _wildcard_addrs(kind, op)
+    else
+        _resolve_host_ips(resolver, network, host)
+    end
     filtered = _apply_policy_and_network(ips, kind, policy)
     isempty(filtered) && throw(AddressError("no suitable address", host))
     out = TCP.SocketEndpoint[]
@@ -2403,6 +2908,24 @@ function resolve_tcp_addrs(
         push!(out, _with_port(ipaddr, port))
     end
     return out
+end
+
+function resolve_tcp_addrs(network::AbstractString, address::AbstractString)::Vector{TCP.SocketEndpoint}
+    return resolve_tcp_addrs(DEFAULT_RESOLVER, network, address)
+end
+
+function resolve_tcp_addr(
+        resolver::AbstractResolver,
+        network::AbstractString,
+        address::AbstractString;
+        policy::ResolverPolicy = ResolverPolicy(),
+    )::TCP.SocketEndpoint
+    addrs = resolve_tcp_addrs(resolver, network, address; op = :resolve, policy = policy)
+    return addrs[1]
+end
+
+function resolve_tcp_addr(network::AbstractString, address::AbstractString)::TCP.SocketEndpoint
+    return resolve_tcp_addr(DEFAULT_RESOLVER, network, address)
 end
 
 function _spawn_timer_task(f::F, deadline_ns::Int64) where {F}

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -4913,6 +4913,14 @@ function _rewrite_extracted_block(str::String, name::AbstractString)::String
     return str
 end
 
+function _extract_tail_block(src::String, start_marker::String, stop_marker::String)::String
+    start_rng = findfirst(start_marker, src)
+    stop_rng = findfirst(stop_marker, src)
+    start_rng === nothing && error("start marker not found: $start_marker")
+    stop_rng === nothing && error("stop marker not found: $stop_marker")
+    return src[first(start_rng):prevind(src, first(stop_rng))]
+end
+
 function _with_extracted_package(f::F) where {F}
     mktempdir() do dir
         name = "StandalonePkg"
@@ -4995,6 +5003,74 @@ function _with_split_extracted_package(f::F) where {F}
     end
 end
 
+function _with_full_split_extracted_package(f::F) where {F}
+    src = read(@__FILE__, String)
+    mktempdir() do dir
+        name = "StandalonePkgSplitFull"
+        uuid = uuid4()
+        pkgid = Base.PkgId(uuid, name)
+        compat = """
+        const ByteMemory = Vector{UInt8}
+        bytememory(n::Integer)::ByteMemory = Vector{UInt8}(undef, Int(n))
+        const HAS_CCALL_GCSAFE = false
+        macro gcsafe_ccall(expr)
+            return esc(expr)
+        end
+        """
+        root = """
+        module $name
+        export TCP, TLS
+        include("0_compat.jl")
+        include("1_socket_ops.jl")
+        include("2_iopoll.jl")
+        include("3_tcp.jl")
+        include("4_host_resolvers.jl")
+        include("5_tls.jl")
+        include("6_precompile_workload.jl")
+        end
+        """
+        helpers = _rewrite_extracted_block(
+            _extract_tail_block(src, "const IP = IOPoll", "end # module Reseau"),
+            name,
+        )
+        write(
+            joinpath(dir, "Project.toml"),
+            "name = \"$name\"\nuuid = \"$(string(uuid))\"\nversion = \"0.1.0\"\n",
+        )
+        mkpath(joinpath(dir, "src"))
+        write(joinpath(dir, "src", "$name.jl"), root)
+        write(joinpath(dir, "src", "0_compat.jl"), compat)
+        write(
+            joinpath(dir, "src", "1_socket_ops.jl"),
+            _rewrite_extracted_block(_extract_block(src, "module SocketOps", "module TCP"), name),
+        )
+        write(
+            joinpath(dir, "src", "2_iopoll.jl"),
+            _rewrite_extracted_block(_extract_block(src, "module IOPoll", "module SocketOps"), name),
+        )
+        write(
+            joinpath(dir, "src", "3_tcp.jl"),
+            _rewrite_extracted_block(_extract_block(src, "module TCP", "module HostResolvers"), name),
+        )
+        write(
+            joinpath(dir, "src", "4_host_resolvers.jl"),
+            _rewrite_extracted_block(_extract_block(src, "module HostResolvers", "module TLS"), name),
+        )
+        write(
+            joinpath(dir, "src", "5_tls.jl"),
+            _rewrite_extracted_block(_extract_block(src, "module TLS", "const IP = IOPoll"), name),
+        )
+        write(joinpath(dir, "src", "6_precompile_workload.jl"), helpers)
+        pushfirst!(LOAD_PATH, dir)
+        try
+            mod = Base.require(pkgid)
+            return f(mod)
+        finally
+            popfirst!(LOAD_PATH)
+        end
+    end
+end
+
 println("[windows-compiler-bug] julia threads: $(Threads.nthreads())")
 
 @test Reseau.TCP === TCP
@@ -5035,6 +5111,39 @@ end
 
 _probe("split package kwcall + runtime") do
     _with_split_extracted_package() do mod
+        c = getproperty(mod, :TCP)
+        kwtt_v4 = (
+            NamedTuple{(:local_addr,), Tuple{getproperty(c, :SocketAddrV4)}},
+            typeof(getproperty(c, :connect)),
+            String,
+            String,
+        )
+        kwtt_v6 = (
+            NamedTuple{(:local_addr,), Tuple{getproperty(c, :SocketAddrV6)}},
+            typeof(getproperty(c, :connect)),
+            String,
+            String,
+        )
+        Base.precompile(Tuple{typeof(Core.kwcall), kwtt_v4...})
+        Base.code_typed(Core.kwcall, kwtt_v4)
+        Base.precompile(Tuple{typeof(Core.kwcall), kwtt_v6...})
+        Base.code_typed(Core.kwcall, kwtt_v6)
+        local_v4 = Base.invokelatest(getproperty(c, :loopback_addr), 0)
+        local_v6 = Base.invokelatest(getproperty(c, :loopback_addr6), 0)
+        try
+            Base.invokelatest(getproperty(c, :connect), "tcp", "127.0.0.1:1"; local_addr = local_v4)
+        catch
+        end
+        try
+            Base.invokelatest(getproperty(c, :connect), "tcp", "127.0.0.1:1"; local_addr = local_v6)
+        catch
+        end
+        return nothing
+    end
+end
+
+_probe("full split package kwcall + runtime") do
+    _with_full_split_extracted_package() do mod
         c = getproperty(mod, :TCP)
         kwtt_v4 = (
             NamedTuple{(:local_addr,), Tuple{getproperty(c, :SocketAddrV4)}},

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -5003,64 +5003,69 @@ function _with_split_extracted_package(f::F) where {F}
     end
 end
 
-function _with_full_split_extracted_package(f::F) where {F}
+function _write_full_split_extracted_package(dir::AbstractString, name::AbstractString)::Base.PkgId
     src = read(@__FILE__, String)
+    uuid = uuid4()
+    pkgid = Base.PkgId(uuid, name)
+    compat = """
+    const ByteMemory = Vector{UInt8}
+    bytememory(n::Integer)::ByteMemory = Vector{UInt8}(undef, Int(n))
+    const HAS_CCALL_GCSAFE = false
+    macro gcsafe_ccall(expr)
+        return esc(expr)
+    end
+    """
+    root = """
+    module $name
+    export TCP, TLS
+    include("0_compat.jl")
+    include("1_socket_ops.jl")
+    include("2_iopoll.jl")
+    include("3_tcp.jl")
+    include("4_host_resolvers.jl")
+    include("5_tls.jl")
+    include("6_precompile_workload.jl")
+    end
+    """
+    helpers = _rewrite_extracted_block(
+        _extract_tail_block(src, "const IP = IOPoll", "end # module Reseau"),
+        name,
+    )
+    write(
+        joinpath(dir, "Project.toml"),
+        "name = \"$name\"\nuuid = \"$(string(uuid))\"\nversion = \"0.1.0\"\n",
+    )
+    mkpath(joinpath(dir, "src"))
+    write(joinpath(dir, "src", "$name.jl"), root)
+    write(joinpath(dir, "src", "0_compat.jl"), compat)
+    write(
+        joinpath(dir, "src", "1_socket_ops.jl"),
+        _rewrite_extracted_block(_extract_block(src, "module SocketOps", "module TCP"), name),
+    )
+    write(
+        joinpath(dir, "src", "2_iopoll.jl"),
+        _rewrite_extracted_block(_extract_block(src, "module IOPoll", "module SocketOps"), name),
+    )
+    write(
+        joinpath(dir, "src", "3_tcp.jl"),
+        _rewrite_extracted_block(_extract_block(src, "module TCP", "module HostResolvers"), name),
+    )
+    write(
+        joinpath(dir, "src", "4_host_resolvers.jl"),
+        _rewrite_extracted_block(_extract_block(src, "module HostResolvers", "module TLS"), name),
+    )
+    write(
+        joinpath(dir, "src", "5_tls.jl"),
+        _rewrite_extracted_block(_extract_block(src, "module TLS", "const IP = IOPoll"), name),
+    )
+    write(joinpath(dir, "src", "6_precompile_workload.jl"), helpers)
+    return pkgid
+end
+
+function _with_full_split_extracted_package(f::F) where {F}
     mktempdir() do dir
         name = "StandalonePkgSplitFull"
-        uuid = uuid4()
-        pkgid = Base.PkgId(uuid, name)
-        compat = """
-        const ByteMemory = Vector{UInt8}
-        bytememory(n::Integer)::ByteMemory = Vector{UInt8}(undef, Int(n))
-        const HAS_CCALL_GCSAFE = false
-        macro gcsafe_ccall(expr)
-            return esc(expr)
-        end
-        """
-        root = """
-        module $name
-        export TCP, TLS
-        include("0_compat.jl")
-        include("1_socket_ops.jl")
-        include("2_iopoll.jl")
-        include("3_tcp.jl")
-        include("4_host_resolvers.jl")
-        include("5_tls.jl")
-        include("6_precompile_workload.jl")
-        end
-        """
-        helpers = _rewrite_extracted_block(
-            _extract_tail_block(src, "const IP = IOPoll", "end # module Reseau"),
-            name,
-        )
-        write(
-            joinpath(dir, "Project.toml"),
-            "name = \"$name\"\nuuid = \"$(string(uuid))\"\nversion = \"0.1.0\"\n",
-        )
-        mkpath(joinpath(dir, "src"))
-        write(joinpath(dir, "src", "$name.jl"), root)
-        write(joinpath(dir, "src", "0_compat.jl"), compat)
-        write(
-            joinpath(dir, "src", "1_socket_ops.jl"),
-            _rewrite_extracted_block(_extract_block(src, "module SocketOps", "module TCP"), name),
-        )
-        write(
-            joinpath(dir, "src", "2_iopoll.jl"),
-            _rewrite_extracted_block(_extract_block(src, "module IOPoll", "module SocketOps"), name),
-        )
-        write(
-            joinpath(dir, "src", "3_tcp.jl"),
-            _rewrite_extracted_block(_extract_block(src, "module TCP", "module HostResolvers"), name),
-        )
-        write(
-            joinpath(dir, "src", "4_host_resolvers.jl"),
-            _rewrite_extracted_block(_extract_block(src, "module HostResolvers", "module TLS"), name),
-        )
-        write(
-            joinpath(dir, "src", "5_tls.jl"),
-            _rewrite_extracted_block(_extract_block(src, "module TLS", "const IP = IOPoll"), name),
-        )
-        write(joinpath(dir, "src", "6_precompile_workload.jl"), helpers)
+        pkgid = _write_full_split_extracted_package(dir, name)
         pushfirst!(LOAD_PATH, dir)
         try
             mod = Base.require(pkgid)
@@ -5069,6 +5074,50 @@ function _with_full_split_extracted_package(f::F) where {F}
             popfirst!(LOAD_PATH)
         end
     end
+end
+
+function _run_full_split_extracted_package_subprocess()::Nothing
+    mktempdir() do dir
+        name = "StandalonePkgSplitFullFresh"
+        _write_full_split_extracted_package(dir, name)
+        depot = joinpath(dir, "depot")
+        mkpath(depot)
+        script = """
+        pushfirst!(LOAD_PATH, @__DIR__)
+        using $name
+        const TCP = $name.TCP
+        kwtt_v4 = (
+            NamedTuple{(:local_addr,), Tuple{TCP.SocketAddrV4}},
+            typeof(TCP.connect),
+            String,
+            String,
+        )
+        kwtt_v6 = (
+            NamedTuple{(:local_addr,), Tuple{TCP.SocketAddrV6}},
+            typeof(TCP.connect),
+            String,
+            String,
+        )
+        Base.precompile(Tuple{typeof(Core.kwcall), kwtt_v4...})
+        Base.code_typed(Core.kwcall, kwtt_v4)
+        Base.precompile(Tuple{typeof(Core.kwcall), kwtt_v6...})
+        Base.code_typed(Core.kwcall, kwtt_v6)
+        try
+            TCP.connect("tcp", "127.0.0.1:1"; local_addr = TCP.loopback_addr(0))
+        catch
+        end
+        try
+            TCP.connect("tcp", "127.0.0.1:1"; local_addr = TCP.loopback_addr6(0))
+        catch
+        end
+        nothing
+        """
+        script_path = joinpath(dir, "fresh-process-probe.jl")
+        write(script_path, script)
+        cmd = `$(Base.julia_cmd()) --project=$(dir) --startup-file=no --history-file=no $(script_path)`
+        run(setenv(cmd, "JULIA_DEPOT_PATH" => depot))
+    end
+    return nothing
 end
 
 println("[windows-compiler-bug] julia threads: $(Threads.nthreads())")
@@ -5174,6 +5223,10 @@ _probe("full split package kwcall + runtime") do
         return nothing
     end
 end
+
+println("[windows-compiler-bug] fresh child process probe start")
+_run_full_split_extracted_package_subprocess()
+println("[windows-compiler-bug] fresh child process probe done")
 
 _probe("kwsort infer local_addr v4") do
     tt = (NamedTuple{(:local_addr,), Tuple{NC.SocketAddrV4}}, typeof(NC.connect), String, String)

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -2,6 +2,8 @@ using Test
 
 module Reseau
 
+export TCP, TLS
+
 module IOPoll
 
 export DeadlineExceededError, FD, TimerState, schedule_timer!, waittimer, _close_timer!, sleep
@@ -1275,7 +1277,15 @@ end
 
 end
 
+module TLS
+end
+
 end # module Reseau
+
+using .Reseau: TCP, TLS
+
+const NC = Reseau.TCP
+const TL = Reseau.TLS
 
 function _probe(f, label::AbstractString)
     println("[windows-compiler-bug] probe start: $(label)")
@@ -1290,12 +1300,15 @@ end
 
 println("[windows-compiler-bug] julia threads: $(Threads.nthreads())")
 
+@test Reseau.TCP === TCP
+@test Reseau.TLS === TLS
+
 _probe("tcp kwcall local_addr v4") do
-    Reseau.TCP.connect("tcp", "127.0.0.1:1"; local_addr = Reseau.TCP.loopback_addr(0))
+    NC.connect("tcp", "127.0.0.1:1"; local_addr = NC.loopback_addr(0))
 end
 
 _probe("tcp kwcall local_addr v6 mismatch") do
-    Reseau.TCP.connect("tcp", "127.0.0.1:1"; local_addr = Reseau.TCP.loopback_addr6(0))
+    NC.connect("tcp", "127.0.0.1:1"; local_addr = NC.loopback_addr6(0))
 end
 
 @test true

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -4,7 +4,7 @@ module Reseau
 
 module IOPoll
 
-export DeadlineExceededError, FD
+export DeadlineExceededError, FD, TimerState, schedule_timer!, waittimer, _close_timer!, sleep
 
 struct DeadlineExceededError <: Exception end
 
@@ -12,10 +12,22 @@ mutable struct FD
     sysfd::Int32
 end
 
+mutable struct TimerState
+    deadline_ns::Int64
+    interval_ns::Int64
+    function TimerState(deadline_ns::Int64 = Int64(0), interval_ns::Int64 = Int64(0))
+        return new(deadline_ns, interval_ns)
+    end
+end
+
 register!(pfd) = nothing
 set_write_deadline!(pfd, deadline_ns::Int64) = nothing
 connect!(pfd, addrbuf, addrlen) = nothing
 waitwrite(pd) = nothing
+schedule_timer!(timer::TimerState, deadline_ns::Int64) = true
+waittimer(timer::TimerState) = false
+_close_timer!(timer::TimerState) = nothing
+sleep(seconds::Real) = nothing
 
 end
 
@@ -388,14 +400,26 @@ function _connect_deadline_ns(d::HostResolver)::Int64
     return _min_nonzero(timeout_deadline, d.deadline_ns)
 end
 
+@inline function _dual_stack_enabled(d::HostResolver)::Bool
+    return d.fallback_delay_ns >= 0
+end
+
+@inline function _effective_fallback_delay_ns(d::HostResolver)::Int64
+    if d.fallback_delay_ns > 0
+        return d.fallback_delay_ns
+    end
+    return Int64(300_000_000)
+end
+
 @inline function _use_parallel_race(
         d::HostResolver,
         kind::Symbol,
         fallbacks::Vector{TCP.SocketEndpoint},
     )::Bool
-    _ = d
-    _ = kind
-    return !isempty(fallbacks)
+    _dual_stack_enabled(d) || return false
+    kind == :tcp || return false
+    isempty(fallbacks) && return false
+    return true
 end
 
 @inline function _is_ipv4(addr::TCP.SocketEndpoint)::Bool
@@ -583,6 +607,28 @@ function resolve_tcp_addrs(
     return out
 end
 
+function _spawn_timer_task(f::F, deadline_ns::Int64) where {F}
+    timer = IOPoll.TimerState(deadline_ns, Int64(0))
+    IOPoll.schedule_timer!(timer, deadline_ns) || return nothing, nothing
+    task = errormonitor(Threads.@spawn begin
+        IOPoll.waittimer(timer) || return nothing
+        f()
+        return nothing
+    end)
+    return timer, task
+end
+
+function _close_timer_task!(
+        timer::Union{Nothing, IOPoll.TimerState},
+        task::Union{Nothing, Task},
+    )
+    timer === nothing && return nothing
+    IOPoll._close_timer!(timer)
+    task === nothing && return nothing
+    wait(task)
+    return nothing
+end
+
 function _resolve_with_deadline(
         d::HostResolver,
         network::AbstractString,
@@ -590,7 +636,56 @@ function _resolve_with_deadline(
         deadline_ns::Int64,
     )::Vector{TCP.SocketEndpoint}
     deadline_ns == 0 && return resolve_tcp_addrs(d.resolver, network, address; op = :connect, policy = d.policy)
-    return resolve_tcp_addrs(d.resolver, network, address; op = :connect, policy = d.policy)
+    now_ns = Int64(time_ns())
+    now_ns >= deadline_ns && throw(DNSTimeoutError(String(address)))
+    mtx = ReentrantLock()
+    condition = Threads.Condition(mtx)
+    done = Ref(false)
+    timed_out = Ref(false)
+    result_ref = Ref{Union{Nothing, Vector{TCP.SocketEndpoint}, Exception}}(nothing)
+    timer, timer_task = _spawn_timer_task(deadline_ns) do
+        lock(mtx)
+        try
+            done[] && return nothing
+            timed_out[] = true
+            done[] = true
+            notify(condition)
+        finally
+            unlock(mtx)
+        end
+        return nothing
+    end
+    errormonitor(Threads.@spawn begin
+        result = try
+            resolve_tcp_addrs(d.resolver, network, address; op = :connect, policy = d.policy)
+        catch err
+            _as_exception(err)
+        end
+        lock(mtx)
+        try
+            done[] && return nothing
+            result_ref[] = result
+            done[] = true
+            notify(condition)
+        finally
+            unlock(mtx)
+        end
+        return nothing
+    end)
+    lock(mtx)
+    try
+        while !done[]
+            wait(condition)
+        end
+    finally
+        unlock(mtx)
+        _close_timer_task!(timer, timer_task)
+    end
+    timed_out[] && throw(DNSTimeoutError(String(address)))
+    result = result_ref[]
+    result === nothing && throw(DNSTimeoutError(String(address)))
+    result isa Exception && throw(result)
+    return result::Vector{TCP.SocketEndpoint}
 end
 
 function _partial_deadline_ns(now_ns::Int64, deadline_ns::Int64, addrs_remaining::Int)::Int64
@@ -606,7 +701,18 @@ function _partial_deadline_ns(now_ns::Int64, deadline_ns::Int64, addrs_remaining
 end
 
 function _partition_addrs(addrs::Vector{TCP.SocketEndpoint})::Tuple{Vector{TCP.SocketEndpoint}, Vector{TCP.SocketEndpoint}}
-    return addrs, TCP.SocketEndpoint[]
+    isempty(addrs) && return TCP.SocketEndpoint[], TCP.SocketEndpoint[]
+    primary_is_v4 = _is_ipv4(addrs[1])
+    primaries = TCP.SocketEndpoint[]
+    fallbacks = TCP.SocketEndpoint[]
+    for addr in addrs
+        if _is_ipv4(addr) == primary_is_v4
+            push!(primaries, addr)
+        else
+            push!(fallbacks, addr)
+        end
+    end
+    return primaries, fallbacks
 end
 
 @inline function _prefer_ipv4_first!(addrs::Vector{TCP.SocketEndpoint}, policy::ResolverPolicy)
@@ -654,6 +760,12 @@ function _mark_connect_done!(state::DNSRaceState)
         end
         return true
     end
+end
+
+struct DNSParallelResult
+    primary::Bool
+    conn::Union{Nothing, TCP.Conn}
+    err::Union{Nothing, Exception}
 end
 
 function _resolve_serial(
@@ -722,6 +834,89 @@ function _resolve_serial(
     return nothing, first_err::Exception
 end
 
+function _resolve_parallel(
+        d::HostResolver,
+        network::AbstractString,
+        address::AbstractString,
+        primaries::Vector{TCP.SocketEndpoint},
+        fallbacks::Vector{TCP.SocketEndpoint},
+        deadline_ns::Int64,
+    )::Tuple{Union{Nothing, TCP.Conn}, Union{Nothing, Exception}}
+    state = DNSRaceState()
+    events = Channel{Union{DNSParallelResult, Symbol}}(4)
+    @inline function _emit_event!(event::Union{DNSParallelResult, Symbol})
+        try
+            put!(events, event)
+        catch err
+            ex = _as_exception(err)
+            ex isa InvalidStateException || rethrow(err)
+        end
+        return nothing
+    end
+    function _start_racer(primary::Bool, addrs::Vector{TCP.SocketEndpoint})
+        return errormonitor(Threads.@spawn begin
+            conn, err = _resolve_serial(d, network, address, addrs, deadline_ns, state)
+            _emit_event!(DNSParallelResult(primary, conn, err))
+            return nothing
+        end)
+    end
+    _start_racer(true, primaries)
+    delay_ns = _effective_fallback_delay_ns(d)
+    fallback_timer, fallback_timer_task = _spawn_timer_task(Int64(time_ns()) + delay_ns) do
+        _emit_event!(:fallback_timer)
+    end
+    primary_done = false
+    fallback_done = false
+    fallback_started = false
+    primary_err::Union{Nothing, Exception} = nothing
+    fallback_err::Union{Nothing, Exception} = nothing
+    try
+        while true
+            event = take!(events)
+            if event === :fallback_timer
+                if !fallback_started && !(@atomic :acquire state.done)
+                    fallback_started = true
+                    _start_racer(false, fallbacks)
+                end
+                continue
+            end
+            result = event::DNSParallelResult
+            if result.conn !== nothing
+                _mark_connect_done!(state)
+                return result.conn, nothing
+            end
+            if result.primary
+                primary_done = true
+                if primary_err === nothing
+                    primary_err = result.err
+                end
+                if !fallback_started && !(@atomic :acquire state.done)
+                    fallback_started = true
+                    _close_timer_task!(fallback_timer, fallback_timer_task)
+                    _start_racer(false, fallbacks)
+                end
+            else
+                fallback_done = true
+                if fallback_err === nothing
+                    fallback_err = result.err
+                end
+            end
+            if primary_done && fallback_done
+                primary_err === nothing && (primary_err = fallback_err)
+                primary_err === nothing && (primary_err = AddressError("missing address", String(address)))
+                _mark_connect_done!(state)
+                return nothing, primary_err::Exception
+            end
+        end
+    finally
+        _close_timer_task!(fallback_timer, fallback_timer_task)
+        try
+            close(events)
+        catch
+        end
+    end
+end
+
 function connect(
         d::HostResolver,
         network::AbstractString,
@@ -749,7 +944,7 @@ function connect(
     conn = nothing
     err = nothing
     if _use_parallel_race(d, kind, fallbacks)
-        error("parallel race should not be used in this reproducer")
+        conn, err = _resolve_parallel(d, network, address, primaries, fallbacks, deadline_ns)
     else
         state = DNSRaceState()
         conn, err = _resolve_serial(d, network, address, addrs, deadline_ns, state)

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -379,6 +379,24 @@ end
 
 abstract type BackendState end
 
+struct Timespec
+    tv_sec::Int64
+    tv_nsec::Int64
+end
+
+struct Kevent
+    ident::UInt64
+    filter::Int16
+    flags::UInt16
+    fflags::UInt32
+    data::Int64
+    udata::Ptr{Cvoid}
+end
+
+mutable struct KqueueBackendState <: BackendState
+    kq::Int32
+end
+
 mutable struct Poller
     lock::ReentrantLock
     registrations::Dict{Int32, Registration}
@@ -405,22 +423,301 @@ function Poller()
     )
 end
 
+@inline function _time_less(a::TimeEntry, b::TimeEntry)::Bool
+    if a.deadline_ns != b.deadline_ns
+        return a.deadline_ns < b.deadline_ns
+    end
+    if a.kind != b.kind
+        return UInt8(a.kind) < UInt8(b.kind)
+    end
+    if a.kind == TimeEntryKind.DEADLINE
+        apd = a.pollstate::PollState
+        bpd = b.pollstate::PollState
+        if apd.token != bpd.token
+            return apd.token < bpd.token
+        end
+        return UInt8(a.mode) < UInt8(b.mode)
+    end
+    return a.primary_seq < b.primary_seq
+end
+
+@inline function _heap_parent_index(i::Int)::Int
+    return i >>> 1
+end
+
+@inline function _heap_left_index(i::Int)::Int
+    return i << 1
+end
+
+@inline function _heap_right_index(i::Int)::Int
+    return (i << 1) + 1
+end
+
+function _time_swap!(heap::Vector{TimeEntry}, i::Int, j::Int)
+    heap[i], heap[j] = heap[j], heap[i]
+    return nothing
+end
+
+function _time_sift_up!(heap::Vector{TimeEntry}, i::Int)
+    while i > 1
+        parent = _heap_parent_index(i)
+        _time_less(heap[i], heap[parent]) || break
+        _time_swap!(heap, i, parent)
+        i = parent
+    end
+    return nothing
+end
+
+function _time_sift_down!(heap::Vector{TimeEntry}, i::Int)
+    len = length(heap)
+    while true
+        left = _heap_left_index(i)
+        left > len && break
+        smallest = left
+        right = _heap_right_index(i)
+        if right <= len && _time_less(heap[right], heap[left])
+            smallest = right
+        end
+        _time_less(heap[smallest], heap[i]) || break
+        _time_swap!(heap, i, smallest)
+        i = smallest
+    end
+    return nothing
+end
+
+function _time_push_locked!(state::Poller, entry::TimeEntry)
+    heap = state.time_heap
+    push!(heap, entry)
+    _time_sift_up!(heap, length(heap))
+    return nothing
+end
+
+function _time_pop_locked!(state::Poller)::TimeEntry
+    heap = state.time_heap
+    isempty(heap) && throw(ArgumentError("time heap is empty"))
+    entry = heap[1]
+    last = pop!(heap)
+    if !isempty(heap)
+        heap[1] = last
+        _time_sift_down!(heap, 1)
+    end
+    return entry
+end
+
+@inline function _registration_active_locked(state::Poller, pd::PollState)::Bool
+    current = get(() -> nothing, state.registrations_by_token, pd.token)
+    return current !== nothing && current.fd == pd.sysfd && current.pollstate === pd
+end
+
+@inline function _entry_live_locked(state::Poller, entry::TimeEntry)::Bool
+    if entry.kind == TimeEntryKind.DEADLINE
+        pd = entry.pollstate::PollState
+        return _registration_active_locked(state, pd)
+    end
+    timer = entry.timer::TimerState
+    (@atomic :acquire timer.seq) == entry.primary_seq || return false
+    (@atomic :acquire timer.closed) && return false
+    return true
+end
+
+function _discard_stale_time_entries_locked!(state::Poller)
+    while !isempty(state.time_heap)
+        entry = state.time_heap[1]
+        _entry_live_locked(state, entry) && return nothing
+        _ = _time_pop_locked!(state)
+    end
+    return nothing
+end
+
+function _time_peek_locked(state::Poller)
+    _discard_stale_time_entries_locked!(state)
+    isempty(state.time_heap) && return nothing
+    return state.time_heap[1]
+end
+
+@inline function _backend_wake!(state::Poller)::Int32
+    _ = state
+    return Int32(0)
+end
+
+@inline function _maybe_wake_for_earlier_time!(state::Poller, new_earliest::Int64)
+    new_earliest > 0 || return nothing
+    poll_until_ns = @atomic :acquire state.poll_until_ns
+    if poll_until_ns == 0 || new_earliest < poll_until_ns
+        errno = _backend_wake!(state)
+        errno == Int32(0) || _throw_errno("iopoll wake", errno)
+    end
+    return nothing
+end
+
+@inline function _deadline_entry(
+        deadline_ns::Int64,
+        pd::PollState,
+        mode::PollMode.T,
+        rseq::UInt64,
+        wseq::UInt64,
+    )::TimeEntry
+    return TimeEntry(deadline_ns, TimeEntryKind.DEADLINE, pd, nothing, mode, rseq, wseq)
+end
+
+@inline function _timer_entry(deadline_ns::Int64, timer::TimerState, seq::UInt64)::TimeEntry
+    return TimeEntry(deadline_ns, TimeEntryKind.TIMER, nothing, timer, PollMode.READ, seq, UInt64(0))
+end
+
+function _build_deadline_entries(
+        pd::PollState,
+        rd_ns::Int64,
+        wd_ns::Int64,
+        rseq::UInt64,
+        wseq::UInt64,
+    )::Vector{TimeEntry}
+    entries = TimeEntry[]
+    if rd_ns > 0 && wd_ns > 0 && rd_ns == wd_ns
+        push!(entries, _deadline_entry(rd_ns, pd, PollMode.READWRITE, rseq, wseq))
+        return entries
+    end
+    rd_ns > 0 && push!(entries, _deadline_entry(rd_ns, pd, PollMode.READ, rseq, UInt64(0)))
+    wd_ns > 0 && push!(entries, _deadline_entry(wd_ns, pd, PollMode.WRITE, UInt64(0), wseq))
+    return entries
+end
+
 connect!(pfd::FD, addrbuf, addrlen) = nothing
 waitwrite(pd::PollState) = nothing
-schedule_timer!(timer::TimerState, deadline_ns::Int64) = true
-waittimer(timer::TimerState) = false
-_close_timer!(timer::TimerState) = nothing
 function deadline_fire! end
 
 function _drain_expired_time_entries!(state::Poller, now_ns::Int64)
-    _ = state
-    _ = now_ns
+    expired = TimeEntry[]
+    lock(state.lock)
+    try
+        while true
+            entry = _time_peek_locked(state)
+            (entry === nothing || entry.deadline_ns > now_ns) && break
+            push!(expired, _time_pop_locked!(state))
+        end
+    finally
+        unlock(state.lock)
+    end
+    for entry in expired
+        _fire_time_entry!(entry)
+    end
+    return nothing
+end
+
+function schedule_timer!(timer::TimerState, deadline_ns::Int64)::Bool
+    state = init!()
+    (@atomic :acquire state.running) || return false
+    new_earliest = Int64(0)
+    entry = nothing
+    armed = false
+    lock(timer.lock)
+    try
+        (@atomic :acquire timer.closed) && return false
+        @atomic :release timer.deadline_ns = deadline_ns
+        seq = @atomic timer.seq += UInt64(1)
+        entry = _timer_entry(deadline_ns, timer, seq)
+    finally
+        unlock(timer.lock)
+    end
+    lock(state.lock)
+    try
+        if @atomic :acquire state.running
+            _time_push_locked!(state, entry::TimeEntry)
+            new_earliest = (entry::TimeEntry).deadline_ns
+            armed = true
+        end
+    finally
+        unlock(state.lock)
+    end
+    if !armed
+        lock(timer.lock)
+        try
+            if (@atomic :acquire timer.seq) == (entry::TimeEntry).primary_seq && !(@atomic :acquire timer.closed)
+                @atomic :release timer.deadline_ns = Int64(0)
+            end
+        finally
+            unlock(timer.lock)
+        end
+        return false
+    end
+    _maybe_wake_for_earlier_time!(state, new_earliest)
+    return true
+end
+
+function _poll_delay_ns(state::Poller)::Int64
+    deadline_ns = Int64(0)
+    lock(state.lock)
+    try
+        entry = _time_peek_locked(state)
+        deadline_ns = entry === nothing ? Int64(0) : entry.deadline_ns
+        @atomic :release state.poll_until_ns = deadline_ns
+    finally
+        unlock(state.lock)
+    end
+    deadline_ns == 0 && return Int64(-1)
+    now_ns = Int64(time_ns())
+    remaining_ns = deadline_ns - now_ns
+    remaining_ns <= 0 && return Int64(0)
+    return remaining_ns
+end
+
+function _close_timer!(timer::TimerState)
+    lock(timer.lock)
+    try
+        (@atomic :acquire timer.closed) && return nothing
+        @atomic :release timer.closed = true
+        @atomic :release timer.deadline_ns = Int64(0)
+        _ = @atomic timer.seq += UInt64(1)
+    finally
+        unlock(timer.lock)
+    end
+    pollnotify!(timer.waiter, PollWakeReason.CANCELED)
+    return nothing
+end
+
+function waittimer(timer::TimerState)::Bool
+    while true
+        reason = pollwait!(timer.waiter)
+        reason == PollWakeReason.READY && return true
+        (@atomic :acquire timer.closed) && return false
+        (@atomic :acquire timer.deadline_ns) == 0 && return true
+    end
+end
+
+function _timer_fire!(timer::TimerState, seq::UInt64)
+    lock(timer.lock)
+    try
+        (@atomic :acquire timer.closed) && return nothing
+        (@atomic :acquire timer.seq) == seq || return nothing
+        @atomic :release timer.deadline_ns = Int64(0)
+    finally
+        unlock(timer.lock)
+    end
+    pollnotify!(timer.waiter, PollWakeReason.READY)
+    return nothing
+end
+
+@inline function _fire_time_entry!(entry::TimeEntry)
+    if entry.kind == TimeEntryKind.DEADLINE
+        deadline_fire!(
+            entry.pollstate::PollState,
+            entry.mode,
+            entry.primary_seq,
+            entry.secondary_seq,
+        )
+    else
+        _timer_fire!(entry.timer::TimerState, entry.primary_seq)
+    end
     return nothing
 end
 
 function sleep_until_ns(deadline_ns::Integer)
     target_ns = Int64(deadline_ns)
     target_ns <= Int64(time_ns()) && return nothing
+    state = init!()
+    (@atomic :acquire state.running) || return nothing
+    timer = TimerState(target_ns, Int64(0))
+    schedule_timer!(timer, target_ns) || return nothing
+    waittimer(timer)
     return nothing
 end
 
@@ -457,6 +754,22 @@ const POLLER = Ref{Poller}()
 const _POLLER_THREAD_ENTRY_C = Ref{Ptr{Cvoid}}(C_NULL)
 const _pthread_t = UInt
 
+const FD_CLOEXEC = Int32(1)
+const F_GETFD = Int32(1)
+const F_SETFD = Int32(2)
+const EVFILT_READ = Int16(-1)
+const EVFILT_WRITE = Int16(-2)
+const EVFILT_USER = Int16(-10)
+const EV_ADD = UInt16(0x0001)
+const EV_DELETE = UInt16(0x0002)
+const EV_ENABLE = UInt16(0x0004)
+const EV_CLEAR = UInt16(0x0020)
+const EV_EOF = UInt16(0x8000)
+const EV_ERROR = UInt16(0x4000)
+const NOTE_TRIGGER = UInt32(0x01000000)
+const WAKE_IDENT = UInt64(1)
+const MAX_KQUEUE_EVENTS = 64
+
 const _POLL_NO_ERROR = Int32(0)
 const _POLL_ERR_CLOSING = Int32(1)
 const _POLL_ERR_TIMEOUT = Int32(2)
@@ -476,11 +789,23 @@ function schedule_deadlines!(
         rseq::UInt64,
         wseq::UInt64,
     )
-    _ = pd
-    _ = rd_ns
-    _ = wd_ns
-    _ = rseq
-    _ = wseq
+    isassigned(POLLER) || return nothing
+    state = POLLER[]
+    (@atomic :acquire state.running) || return nothing
+    new_earliest = Int64(0)
+    lock(state.lock)
+    try
+        _registration_active_locked(state, pd) || return nothing
+        for entry in _build_deadline_entries(pd, rd_ns, wd_ns, rseq, wseq)
+            _time_push_locked!(state, entry)
+            if new_earliest == 0 || entry.deadline_ns < new_earliest
+                new_earliest = entry.deadline_ns
+            end
+        end
+    finally
+        unlock(state.lock)
+    end
+    _maybe_wake_for_earlier_time!(state, new_earliest)
     return nothing
 end
 
@@ -501,8 +826,100 @@ function _throw_errno(op::AbstractString, errno::Int32)
     throw(SystemError(op, Int(errno)))
 end
 
+@inline function _merge_wake_reason(
+        current::PollWakeReason.T,
+        incoming::PollWakeReason.T,
+    )::PollWakeReason.T
+    return current == PollWakeReason.READY ? current : incoming
+end
+
 @inline function _runtime_supported()::Bool
     return true
+end
+
+@inline function _is_accept_retry_errno(errno::Int32)::Bool
+    return errno == Int32(Base.Libc.EINTR) || errno == Int32(Base.Libc.ECONNABORTED)
+end
+
+@inline function _fcntl(fd::Int32, cmd::Int32, arg::Int32 = Int32(0))::Int32
+    _ = fd
+    _ = cmd
+    _ = arg
+    return Int32(0)
+end
+
+@inline function _set_close_on_exec!(fd::Int32)
+    _ = fd
+    return nothing
+end
+
+@inline function _set_nonblocking!(fd::Int32, enabled::Bool = true)
+    _ = fd
+    _ = enabled
+    return nothing
+end
+
+@inline function _ns_to_timespec(ns::Int64)::Timespec
+    secs = ns ÷ Int64(1_000_000_000)
+    nsecs = ns % Int64(1_000_000_000)
+    return Timespec(secs, nsecs)
+end
+
+@inline function _make_kevent(
+        ident::UInt64,
+        filter::Int16,
+        flags::UInt16,
+        fflags::UInt32 = UInt32(0),
+        data::Int64 = Int64(0),
+        udata::Ptr{Cvoid} = C_NULL,
+    )::Kevent
+    return Kevent(ident, filter, flags, fflags, data, udata)
+end
+
+@inline function _decode_event_mode(ev::Kevent)::PollMode.T
+    if ev.filter == EVFILT_READ
+        return PollMode.READ
+    elseif ev.filter == EVFILT_WRITE
+        return PollMode.WRITE
+    end
+    return PollMode.READWRITE
+end
+
+function _backend_init!(state::Poller)::Int32
+    state.backend_state = KqueueBackendState(Int32(-1))
+    return Int32(0)
+end
+
+function _backend_close!(state::Poller)
+    state.backend_state = nothing
+    return nothing
+end
+
+function _backend_open_fd!(state::Poller, fd::Int32, mode::PollMode.T, token::UInt64)::Int32
+    _ = state
+    _ = fd
+    _ = mode
+    _ = token
+    return Int32(0)
+end
+
+function _backend_arm_waiter!(state::Poller, registration::Registration, mode::PollMode.T)::Int32
+    _ = state
+    _ = registration
+    _ = mode
+    return Int32(0)
+end
+
+function _backend_close_fd!(state::Poller, fd::Int32)::Int32
+    _ = state
+    _ = fd
+    return Int32(0)
+end
+
+function _backend_poll_once!(state::Poller, delay_ns::Int64)::Int32
+    _ = state
+    _ = delay_ns
+    return Int32(0)
 end
 
 function _new_iocp_registration(fd::Int32, token::UInt64)::IocpRegistration
@@ -595,12 +1012,15 @@ function register!(
         pollstate::Union{Nothing, PollState} = nothing,
     )::Registration
     _mode_is_empty(mode) && throw(ArgumentError("register! requires READ and/or WRITE mode"))
+    state = init!()
     pd = pollstate === nothing ? PollState(fd) : pollstate::PollState
-    token = _next_token!()
+    token = _next_token!(state)
     registration = Registration(Int32(fd), token, mode, PollWaiter(), PollWaiter(), false)
     registration.pollstate = pd
     pd.sysfd = Int32(fd)
     pd.token = token
+    state.registrations[Int32(fd)] = registration
+    state.registrations_by_token[token] = registration
     _REGISTRATIONS[pd] = registration
     _IOCP_BY_KEY[(Int32(fd), token)] = _new_iocp_registration(Int32(fd), token)
     return registration
@@ -628,11 +1048,23 @@ end
 
 function deregister!(pd::PollState)
     registration = pop!(_REGISTRATIONS, pd, nothing)
+    if isassigned(POLLER)
+        state = POLLER[]
+        delete!(state.registrations, pd.sysfd)
+        registration === nothing || delete!(state.registrations_by_token, registration.token)
+    end
     registration === nothing || pop!(_IOCP_BY_KEY, (registration.fd, registration.token), nothing)
     return nothing
 end
 
 function current_registration(pd::PollState)
+    if isassigned(POLLER)
+        state = POLLER[]
+        registration = get(() -> nothing, state.registrations_by_token, pd.token)
+        if registration !== nothing && registration.fd == pd.sysfd && registration.pollstate === pd
+            return registration
+        end
+    end
     return get(() -> nothing, _REGISTRATIONS, pd)
 end
 

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -4669,6 +4669,8 @@ handshake!(conn::Conn) = conn
 
 end
 
+using PrecompileTools: @compile_workload, @setup_workload
+
 const IP = IOPoll
 const SO = SocketOps
 const NC = TCP
@@ -4676,7 +4678,7 @@ const ND = HostResolvers
 const TL = TLS
 
 @inline function _pc_is_generating_output()::Bool
-    return false
+    return ccall(:jl_generating_output, Cint, ()) == 1
 end
 
 @inline function _pc_runtime_supported()::Bool
@@ -4684,17 +4686,22 @@ end
 end
 
 function _pc_socketpair_stream()
-    return Int32(-1), Int32(-1)
+    fds = Vector{Cint}(undef, 2)
+    ret = ccall(:socketpair, Cint, (Cint, Cint, Cint, Ptr{Cint}), Cint(1), Cint(1), Cint(0), pointer(fds))
+    ret == 0 || throw(SystemError("socketpair", Int(Base.Libc.errno())))
+    return fds[1], fds[2]
 end
 
-function _pc_close_fd(fd::Int32)
-    _ = fd
+function _pc_close_fd(fd::Cint)
+    fd < 0 && return nothing
+    ccall(:close, Cint, (Cint,), fd)
     return nothing
 end
 
-function _pc_write_byte(fd::Int32, b::UInt8)
-    _ = fd
-    _ = b
+function _pc_write_byte(fd::Cint, b::UInt8)
+    buf = Ref{UInt8}(b)
+    n = ccall(:write, Cssize_t, (Cint, Ptr{UInt8}, Csize_t), fd, buf, Csize_t(1))
+    n == Cssize_t(1) || throw(SystemError("write", Int(Base.Libc.errno())))
     return nothing
 end
 
@@ -4703,25 +4710,128 @@ function _pc_read_exact!(conn::NC.Conn, buf::Vector{UInt8})::Int
     return length(buf)
 end
 
-function _pc_wait_connect_ready!(fd::Int32)
-    _ = fd
+function _pc_wait_connect_ready!(fd::Cint)
+    registration = IP.register!(fd; mode = IP.PollMode.WRITE)
+    try
+        IP.arm_waiter!(registration, IP.PollMode.WRITE)
+        IP.pollwait!(registration.write_waiter)
+    finally
+        IP.deregister!(fd)
+    end
     return nothing
 end
 
-function _pc_accept_with_retry!(listener::Int32)::Int32
-    _ = listener
-    return Int32(-1)
+function _pc_accept_with_retry!(listener::Cint)::Cint
+    for _ in 1:5000
+        accepted, _, errno = SO.try_accept_socket(listener)
+        accepted != -1 && return accepted
+        if errno == Int32(Base.Libc.EAGAIN) || errno == Int32(Base.Libc.EWOULDBLOCK)
+            yield()
+            continue
+        end
+        errno == Int32(Base.Libc.EINTR) && continue
+        throw(SystemError("accept", Int(errno)))
+    end
+    throw(ArgumentError("timed out waiting for accepted socket"))
 end
 
 function _pc_run_eventloops_workload!()
+    IP.__init__()
+    @assert isassigned(IP.POLLER)
+    waiter = IP.PollWaiter()
+    IP.pollnotify!(waiter)
+    IP.pollwait!(waiter)
+    _pc_runtime_supported() || return nothing
+    state = IP.Poller()
+    fd0 = Cint(-1)
+    fd1 = Cint(-1)
+    backend_open = false
+    try
+        errno = IP._backend_init!(state)
+        errno == Int32(0) || throw(SystemError("event loop backend init", Int(errno)))
+        backend_open = true
+        fd0, fd1 = _pc_socketpair_stream()
+        token = UInt64(1)
+        registration = IP.Registration(fd0, token, IP.PollMode.READWRITE, IP.PollWaiter(), IP.PollWaiter(), false)
+        state.registrations[fd0] = registration
+        state.registrations_by_token[token] = registration
+        errno = IP._backend_open_fd!(state, fd0, IP.PollMode.READWRITE, token)
+        errno == Int32(0) || throw(SystemError("event loop open fd", Int(errno)))
+        _pc_write_byte(fd1, 0x31)
+        errno = IP._backend_poll_once!(state, Int64(0))
+        errno == Int32(0) || throw(SystemError("event loop poll once", Int(errno)))
+        IP.pollwait!(registration.read_waiter)
+        errno = IP._backend_close_fd!(state, fd0)
+        errno == Int32(0) || throw(SystemError("event loop close fd", Int(errno)))
+    finally
+        _pc_close_fd(fd0)
+        _pc_close_fd(fd1)
+        backend_open && IP._backend_close!(state)
+    end
     return nothing
 end
 
 function _pc_run_internal_poll_workload!()
+    _pc_is_generating_output() && return nothing
+    _pc_runtime_supported() || return nothing
+    fd0, fd1 = _pc_socketpair_stream()
+    ipfd = IP.FD(fd0)
+    fd0 = Cint(-1)
+    try
+        IP._set_nonblocking!(ipfd.sysfd)
+        IP.register!(ipfd)
+        IP.set_read_deadline!(ipfd, time_ns() + 8_000_000)
+        try
+            IP.read!(ipfd, Vector{UInt8}(undef, 1))
+        catch err
+            err isa IP.DeadlineExceededError || rethrow(err)
+        end
+        IP.set_read_deadline!(ipfd, Int64(0))
+        _pc_write_byte(fd1, 0x66)
+        n = IP.read!(ipfd, Vector{UInt8}(undef, 1))
+        n == 1 || error("internal poll workload expected one-byte read")
+    finally
+        ipfd.sysfd >= 0 && close(ipfd)
+        _pc_close_fd(fd1)
+    end
     return nothing
 end
 
 function _pc_run_socket_ops_workload!()
+    _pc_is_generating_output() && return nothing
+    _pc_runtime_supported() || return nothing
+    listener = Cint(-1)
+    client = Cint(-1)
+    accepted = Cint(-1)
+    try
+        listener = SO.open_socket(SO.AF_INET, SO.SOCK_STREAM)
+        SO.set_sockopt_int(listener, SO.SOL_SOCKET, SO.SO_REUSEADDR, 1)
+        SO.bind_socket(listener, SO.sockaddr_in_loopback(0))
+        SO.listen_socket(listener, 16)
+        bound = SO.get_socket_name_in(listener)
+        port = Int(SO.sockaddr_in_port(bound))
+        client = SO.open_socket(SO.AF_INET, SO.SOCK_STREAM)
+        errno = SO.connect_socket(client, SO.sockaddr_in_loopback(port))
+        if errno != Int32(0) && errno != Int32(Base.Libc.EISCONN)
+            if errno != Int32(Base.Libc.EINPROGRESS) && errno != Int32(Base.Libc.EALREADY) && errno != Int32(Base.Libc.EINTR)
+                throw(SystemError("connect", Int(errno)))
+            end
+            _pc_wait_connect_ready!(client)
+            so_error = SO.get_socket_error(client)
+            so_error == Int32(0) || throw(SystemError("connect(SO_ERROR)", Int(so_error)))
+        end
+        accepted = _pc_accept_with_retry!(listener)
+        payload = UInt8[0x31, 0x32]
+        nw = GC.@preserve payload SO.write_once!(client, pointer(payload), Csize_t(length(payload)))
+        nw == Cssize_t(length(payload)) || throw(ArgumentError("socket ops workload expected 2-byte write"))
+        recv_buf = Vector{UInt8}(undef, 2)
+        nr = GC.@preserve recv_buf SO.read_once!(accepted, pointer(recv_buf), Csize_t(length(recv_buf)))
+        nr == Cssize_t(length(recv_buf)) || throw(ArgumentError("socket ops workload expected 2-byte read"))
+    finally
+        accepted >= 0 && SO.close_socket_nothrow(accepted)
+        client >= 0 && SO.close_socket_nothrow(client)
+        listener >= 0 && SO.close_socket_nothrow(listener)
+    end
     return nothing
 end
 
@@ -4793,8 +4903,9 @@ function _pc_run_host_resolvers_workload!()
 end
 
 function _pc_tls_resource_file(name::AbstractString)::Union{Nothing, String}
-    _ = name
-    return nothing
+    pkg_root = normpath(joinpath(@__DIR__, ".."))
+    path = joinpath(pkg_root, "test", "resources", name)
+    return isfile(path) ? path : nothing
 end
 
 function _pc_run_tls_workload!()
@@ -4866,6 +4977,23 @@ function _pc_run_tls_workload!()
     return nothing
 end
 
+try
+    @setup_workload begin
+        IP.__init__()
+        @assert isassigned(IP.POLLER)
+        @compile_workload begin
+            _pc_run_eventloops_workload!()
+            _pc_run_internal_poll_workload!()
+            _pc_run_socket_ops_workload!()
+            _pc_run_tcp_workload!()
+            _pc_run_host_resolvers_workload!()
+            _pc_run_tls_workload!()
+        end
+    end
+catch err
+    @info "Ignoring an error that occurred during the precompilation workload" exception = (err, catch_backtrace())
+end
+
 end # module Reseau
 
 using .Reseau: TCP, TLS
@@ -4894,9 +5022,7 @@ function _extract_package_module_source(name::AbstractString)::String
     stop_rng === nothing && error("module Reseau terminator not found")
     modsrc = src[first(start_rng):last(stop_rng)]
     modsrc = replace(modsrc, "module Reseau" => "module $(name)")
-    modsrc = replace(modsrc, "..Reseau" => "..$(name)")
-    modsrc = replace(modsrc, "Main.Reseau" => "Main.$(name)")
-    return modsrc
+    return _rewrite_extracted_block(modsrc, name)
 end
 
 function _extract_block(src::String, start_marker::String, stop_marker::String)::String
@@ -4908,6 +5034,11 @@ function _extract_block(src::String, start_marker::String, stop_marker::String):
 end
 
 function _rewrite_extracted_block(str::String, name::AbstractString)::String
+    str = replace(
+        str,
+        "using PrecompileTools: @compile_workload, @setup_workload" =>
+            "macro compile_workload(expr)\n    return esc(expr)\nend\n\nmacro setup_workload(expr)\n    return esc(expr)\nend",
+    )
     str = replace(str, "..Reseau" => "..$(name)")
     str = replace(str, "Main.Reseau" => "Main.$(name)")
     return str
@@ -4928,7 +5059,17 @@ function _with_extracted_package(f::F) where {F}
         pkgid = Base.PkgId(uuid, name)
         write(
             joinpath(dir, "Project.toml"),
-            "name = \"$name\"\nuuid = \"$(string(uuid))\"\nversion = \"0.1.0\"\n",
+            """
+            name = "$name"
+            uuid = "$(string(uuid))"
+            version = "0.1.0"
+
+            [deps]
+            PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+
+            [compat]
+            PrecompileTools = "1.2"
+            """,
         )
         mkpath(joinpath(dir, "src"))
         write(joinpath(dir, "src", "$name.jl"), _extract_package_module_source(name))
@@ -4969,7 +5110,17 @@ function _with_split_extracted_package(f::F) where {F}
         """
         write(
             joinpath(dir, "Project.toml"),
-            "name = \"$name\"\nuuid = \"$(string(uuid))\"\nversion = \"0.1.0\"\n",
+            """
+            name = "$name"
+            uuid = "$(string(uuid))"
+            version = "0.1.0"
+
+            [deps]
+            PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+
+            [compat]
+            PrecompileTools = "1.2"
+            """,
         )
         mkpath(joinpath(dir, "src"))
         write(joinpath(dir, "src", "$name.jl"), root)
@@ -4991,7 +5142,10 @@ function _with_split_extracted_package(f::F) where {F}
         )
         write(
             joinpath(dir, "src", "5_tls.jl"),
-            _rewrite_extracted_block(_extract_block(src, "module TLS", "end # module Reseau"), name),
+            _rewrite_extracted_block(
+                _extract_block(src, "module TLS", "using PrecompileTools: @compile_workload, @setup_workload"),
+                name,
+            ),
         )
         pushfirst!(LOAD_PATH, dir)
         try
@@ -5028,12 +5182,22 @@ function _write_full_split_extracted_package(dir::AbstractString, name::Abstract
     end
     """
     helpers = _rewrite_extracted_block(
-        _extract_tail_block(src, "const IP = IOPoll", "end # module Reseau"),
+        _extract_tail_block(src, "using PrecompileTools: @compile_workload, @setup_workload", "end # module Reseau"),
         name,
     )
     write(
         joinpath(dir, "Project.toml"),
-        "name = \"$name\"\nuuid = \"$(string(uuid))\"\nversion = \"0.1.0\"\n",
+        """
+        name = "$name"
+        uuid = "$(string(uuid))"
+        version = "0.1.0"
+
+        [deps]
+        PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+
+        [compat]
+        PrecompileTools = "1.2"
+        """,
     )
     mkpath(joinpath(dir, "src"))
     write(joinpath(dir, "src", "$name.jl"), root)
@@ -5056,7 +5220,10 @@ function _write_full_split_extracted_package(dir::AbstractString, name::Abstract
     )
     write(
         joinpath(dir, "src", "5_tls.jl"),
-        _rewrite_extracted_block(_extract_block(src, "module TLS", "const IP = IOPoll"), name),
+        _rewrite_extracted_block(
+            _extract_block(src, "module TLS", "using PrecompileTools: @compile_workload, @setup_workload"),
+            name,
+        ),
     )
     write(joinpath(dir, "src", "6_precompile_workload.jl"), helpers)
     return pkgid
@@ -5082,6 +5249,7 @@ function _run_full_split_extracted_package_subprocess()::Nothing
         _write_full_split_extracted_package(dir, name)
         depot = joinpath(dir, "depot")
         mkpath(depot)
+        depot_path = join([depot; Base.DEPOT_PATH], Sys.iswindows() ? ';' : ':')
         precompile_script = """
         pushfirst!(LOAD_PATH, @__DIR__)
         using $name
@@ -5123,7 +5291,7 @@ function _run_full_split_extracted_package_subprocess()::Nothing
         write(probe_path, probe_script)
         precompile_cmd = `$(Base.julia_cmd()) --project=$(dir) --startup-file=no --history-file=no $(precompile_path)`
         probe_cmd = `$(Base.julia_cmd()) --project=$(dir) --startup-file=no --history-file=no $(probe_path)`
-        env = ("JULIA_DEPOT_PATH" => depot,)
+        env = ("JULIA_DEPOT_PATH" => depot_path,)
         run(setenv(precompile_cmd, env...))
         run(setenv(probe_cmd, env...))
     end

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -8,22 +8,107 @@ export DeadlineExceededError, FD, TimerState, schedule_timer!, waittimer, _close
 
 struct DeadlineExceededError <: Exception end
 
-mutable struct FD
-    sysfd::Int32
+module PollWaiterState
+Base.@enum T::UInt8 begin
+    EMPTY = 0x00
+    WAITING = 0x01
+    NOTIFIED = 0x02
+end
 end
 
-mutable struct TimerState
-    deadline_ns::Int64
-    interval_ns::Int64
-    function TimerState(deadline_ns::Int64 = Int64(0), interval_ns::Int64 = Int64(0))
-        return new(deadline_ns, interval_ns)
+module PollWakeReason
+Base.@enum T::UInt8 begin
+    READY = 0x01
+    CANCELED = 0x02
+end
+end
+
+mutable struct PollWaiter
+    @atomic state::PollWaiterState.T
+    @atomic reason::PollWakeReason.T
+    task::Union{Nothing, Task}
+    function PollWaiter()
+        return new(PollWaiterState.EMPTY, PollWakeReason.READY, nothing)
     end
 end
 
-register!(pfd) = nothing
-set_write_deadline!(pfd, deadline_ns::Int64) = nothing
-connect!(pfd, addrbuf, addrlen) = nothing
-waitwrite(pd) = nothing
+mutable struct PollState
+    lock::ReentrantLock
+    sysfd::Int32
+    token::UInt64
+    @atomic pollable::Bool
+    @atomic closing::Bool
+    @atomic event_err::Bool
+    @atomic rd_ns::Int64
+    @atomic wd_ns::Int64
+    @atomic rseq::UInt64
+    @atomic wseq::UInt64
+    function PollState(sysfd::Integer = -1, token::UInt64 = UInt64(0))
+        return new(
+            ReentrantLock(),
+            Int32(sysfd),
+            token,
+            false,
+            false,
+            false,
+            Int64(0),
+            Int64(0),
+            UInt64(0),
+            UInt64(0),
+        )
+    end
+end
+
+mutable struct FD
+    sysfd::Int32
+    pd::PollState
+    csema::Base.Semaphore
+    @atomic is_blocking::Bool
+    is_stream::Bool
+    zero_read_is_eof::Bool
+    is_file::Bool
+    function FD(
+            sysfd::Integer;
+            is_stream::Bool = true,
+            zero_read_is_eof::Bool = true,
+            is_file::Bool = false,
+        )
+        return new(
+            Int32(sysfd),
+            PollState(sysfd),
+            Base.Semaphore(0),
+            false,
+            is_stream,
+            zero_read_is_eof,
+            is_file,
+        )
+    end
+end
+
+mutable struct TimerState
+    lock::ReentrantLock
+    waiter::PollWaiter
+    @atomic deadline_ns::Int64
+    @atomic interval_ns::Int64
+    @atomic seq::UInt64
+    @atomic closed::Bool
+    function TimerState(deadline_ns::Int64 = Int64(0), interval_ns::Int64 = Int64(0))
+        return new(ReentrantLock(), PollWaiter(), deadline_ns, interval_ns, UInt64(0), false)
+    end
+end
+
+function register!(pfd::FD)
+    @atomic :release pfd.pd.pollable = true
+    return nothing
+end
+
+function set_write_deadline!(pfd::FD, deadline_ns::Int64)
+    @atomic :release pfd.pd.wd_ns = deadline_ns
+    return nothing
+end
+
+connect!(pfd::FD, addrbuf, addrlen) = nothing
+waitwrite(pd::PollState) = nothing
 schedule_timer!(timer::TimerState, deadline_ns::Int64) = true
 waittimer(timer::TimerState) = false
 _close_timer!(timer::TimerState) = nothing

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -37,6 +37,15 @@ Base.@enum T::UInt8 begin
 end
 end
 
+module IocpOpKind
+Base.@enum T::UInt8 begin
+    PROBE_READ = 0x01
+    PROBE_WRITE = 0x02
+    CONNECT = 0x03
+    ACCEPT = 0x04
+end
+end
+
 module PollWaiterState
 Base.@enum T::UInt8 begin
     EMPTY = 0x00
@@ -107,6 +116,36 @@ function Registration(
         event_err::Bool,
     )
     return Registration(fd, token, mode, read_waiter, write_waiter, event_err, PollState(fd, token))
+end
+
+struct Overlapped end
+
+const _ZERO_OVERLAPPED = Overlapped()
+
+mutable struct IocpConnectRequest
+    addrbuf::Vector{UInt8}
+    addrlen::Int32
+end
+
+const IocpRequest = Union{Nothing, IocpConnectRequest}
+
+mutable struct IocpOp
+    storage::Base.RefValue{Overlapped}
+    mode::PollMode.T
+    token::UInt64
+    kind::IocpOpKind.T
+    request::IocpRequest
+    owner::Any
+    @atomic active::Bool
+end
+
+mutable struct IocpRegistration
+    fd::Int32
+    token::UInt64
+    read_op::IocpOp
+    write_op::IocpOp
+    wait_on_success::Bool
+    @atomic closing::Bool
 end
 
 mutable struct RuntimeSema
@@ -303,6 +342,7 @@ const _POLL_ERR_CLOSING = Int32(1)
 const _POLL_ERR_TIMEOUT = Int32(2)
 const _POLL_ERR_NOT_POLLABLE = Int32(3)
 const _REGISTRATIONS = IdDict{PollState, Registration}()
+const _IOCP_BY_KEY = Dict{Tuple{Int32, UInt64}, IocpRegistration}()
 const _NEXT_TOKEN = Ref{UInt64}(UInt64(0))
 
 @inline _mode_has_read(mode::PollMode.T)::Bool = mode == PollMode.READ || mode == PollMode.READWRITE
@@ -329,6 +369,38 @@ end
     return _NEXT_TOKEN[]
 end
 
+function _new_iocp_registration(fd::Int32, token::UInt64)::IocpRegistration
+    read_op = IocpOp(Ref(_ZERO_OVERLAPPED), PollMode.READ, token, IocpOpKind.PROBE_READ, nothing, nothing, false)
+    write_op = IocpOp(Ref(_ZERO_OVERLAPPED), PollMode.WRITE, token, IocpOpKind.PROBE_WRITE, nothing, nothing, false)
+    reg = IocpRegistration(fd, token, read_op, write_op, true, false)
+    read_op.owner = reg
+    write_op.owner = reg
+    return reg
+end
+
+@inline function _set_probe_kind!(op::IocpOp)
+    op.kind = op.mode == PollMode.READ ? IocpOpKind.PROBE_READ : IocpOpKind.PROBE_WRITE
+    op.request = nothing
+    return nothing
+end
+
+@inline function _clear_iocp_op!(op::IocpOp)
+    @atomic :release op.active = false
+    _set_probe_kind!(op)
+    op.storage[] = _ZERO_OVERLAPPED
+    return nothing
+end
+
+function _iocp_op_for_mode(reg::IocpRegistration, mode::PollMode.T)::IocpOp
+    mode == PollMode.READ && return reg.read_op
+    mode == PollMode.WRITE && return reg.write_op
+    throw(ArgumentError("invalid IOCP mode"))
+end
+
+function _lookup_iocp_registration(registration::Registration)::Union{Nothing, IocpRegistration}
+    return get(() -> nothing, _IOCP_BY_KEY, (registration.fd, registration.token))
+end
+
 function register!(
         fd::Integer;
         mode::PollMode.T = PollMode.READWRITE,
@@ -342,6 +414,7 @@ function register!(
     pd.sysfd = Int32(fd)
     pd.token = token
     _REGISTRATIONS[pd] = registration
+    _IOCP_BY_KEY[(Int32(fd), token)] = _new_iocp_registration(Int32(fd), token)
     return registration
 end
 
@@ -366,7 +439,8 @@ function register!(fd::FD)
 end
 
 function deregister!(pd::PollState)
-    pop!(_REGISTRATIONS, pd, nothing)
+    registration = pop!(_REGISTRATIONS, pd, nothing)
+    registration === nothing || pop!(_IOCP_BY_KEY, (registration.fd, registration.token), nothing)
     return nothing
 end
 
@@ -598,22 +672,30 @@ function Base.close(fd::FD)
 end
 
 function _iocp_submit_connect!(registration::Registration, addrbuf::Vector{UInt8}, addrlen::Int32)::Int32
-    _ = registration
-    _ = addrbuf
-    _ = addrlen
+    reg = _lookup_iocp_registration(registration)
+    reg === nothing && return Int32(Base.Libc.EBADF)
+    op = reg.write_op
+    op.kind = IocpOpKind.CONNECT
+    op.request = IocpConnectRequest(addrbuf, addrlen)
+    @atomic :release op.active = true
     pollnotify!(registration.write_waiter, PollWakeReason.READY)
     return Int32(0)
 end
 
 function _iocp_finish_connect!(registration::Registration)::Int32
-    _ = registration
+    reg = _lookup_iocp_registration(registration)
+    reg === nothing && return Int32(Base.Libc.EBADF)
+    _clear_iocp_op!(reg.write_op)
     return Int32(0)
 end
 
 function _iocp_cancel_mode!(registration::Registration, mode::PollMode.T)::Bool
-    _ = registration
-    _ = mode
-    return false
+    reg = _lookup_iocp_registration(registration)
+    reg === nothing && return false
+    op = _iocp_op_for_mode(reg, mode)
+    active = @atomic :acquire op.active
+    @atomic :release op.active = false
+    return active
 end
 
 function connect!(fd::FD, addrbuf::Vector{UInt8}, addrlen::Int32)

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -4,6 +4,14 @@ module Reseau
 
 export TCP, TLS
 
+const ByteMemory = Vector{UInt8}
+bytememory(n::Integer)::ByteMemory = Vector{UInt8}(undef, Int(n))
+const HAS_CCALL_GCSAFE = false
+
+macro gcsafe_ccall(expr)
+    return esc(expr)
+end
+
 module IOPoll
 
 export DeadlineExceededError, FD, TimerState, schedule_timer!, waittimer, _close_timer!, sleep, read!, _read_ptr_some!
@@ -4697,6 +4705,79 @@ Base.isopen(conn::Conn) = true
 Base.close(conn::Conn) = close(conn.tcp)
 Base.close(listener::Listener) = close(listener.tcp)
 
+end
+
+const IP = IOPoll
+const SO = SocketOps
+const NC = TCP
+const ND = HostResolvers
+const TL = TLS
+
+@inline function _pc_is_generating_output()::Bool
+    return false
+end
+
+@inline function _pc_runtime_supported()::Bool
+    return Sys.isapple() || Sys.islinux()
+end
+
+function _pc_socketpair_stream()
+    return Int32(-1), Int32(-1)
+end
+
+function _pc_close_fd(fd::Int32)
+    _ = fd
+    return nothing
+end
+
+function _pc_write_byte(fd::Int32, b::UInt8)
+    _ = fd
+    _ = b
+    return nothing
+end
+
+function _pc_read_exact!(conn::NC.Conn, buf::Vector{UInt8})::Int
+    read!(conn, buf)
+    return length(buf)
+end
+
+function _pc_wait_connect_ready!(fd::Int32)
+    _ = fd
+    return nothing
+end
+
+function _pc_accept_with_retry!(listener::Int32)::Int32
+    _ = listener
+    return Int32(-1)
+end
+
+function _pc_run_eventloops_workload!()
+    return nothing
+end
+
+function _pc_run_internal_poll_workload!()
+    return nothing
+end
+
+function _pc_run_socket_ops_workload!()
+    return nothing
+end
+
+function _pc_run_tcp_workload!()
+    return nothing
+end
+
+function _pc_run_host_resolvers_workload!()
+    return nothing
+end
+
+function _pc_tls_resource_file(name::AbstractString)::Union{Nothing, String}
+    _ = name
+    return nothing
+end
+
+function _pc_run_tls_workload!()
+    return nothing
 end
 
 end # module Reseau

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -601,6 +601,7 @@ function _iocp_submit_connect!(registration::Registration, addrbuf::Vector{UInt8
     _ = registration
     _ = addrbuf
     _ = addrlen
+    pollnotify!(registration.write_waiter, PollWakeReason.READY)
     return Int32(0)
 end
 

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -6,7 +6,7 @@ export TCP, TLS
 
 module IOPoll
 
-export DeadlineExceededError, FD, TimerState, schedule_timer!, waittimer, _close_timer!, sleep
+export DeadlineExceededError, FD, TimerState, schedule_timer!, waittimer, _close_timer!, sleep, read!, _read_ptr_some!
 
 struct DeadlineExceededError <: Exception end
 
@@ -115,6 +115,8 @@ schedule_timer!(timer::TimerState, deadline_ns::Int64) = true
 waittimer(timer::TimerState) = false
 _close_timer!(timer::TimerState) = nothing
 sleep(seconds::Real) = nothing
+read!(pfd::FD, buf::Vector{UInt8}) = throw(EOFError())
+_read_ptr_some!(pfd::FD, ptr::Ptr{UInt8}, nbytes::Int) = throw(EOFError())
 
 end
 
@@ -428,6 +430,97 @@ end
 function connect(remote_addr::SocketAddr, local_addr::Union{Nothing, SocketAddr})::Conn
     return _connect_socketaddr_impl(remote_addr, local_addr, Int64(0), nothing)
 end
+
+@inline function _read_some!(conn::Conn, buf::Vector{UInt8})::Int
+    return IOPoll.read!(conn.fd.pfd, buf)
+end
+
+@inline function _read_some!(conn::Conn, ptr::Ptr{UInt8}, nbytes::Int)::Int
+    return IOPoll._read_ptr_some!(conn.fd.pfd, ptr, nbytes)
+end
+
+function _grow_readbytes_target!(buf::Vector{UInt8}, current::Int, nb::Int)::Int
+    newlen = if current == 0
+        min(nb, 1024)
+    else
+        min(nb, current * 2)
+    end
+    resize!(buf, newlen)
+    return newlen
+end
+
+function Base.unsafe_read(conn::Conn, ptr::Ptr{UInt8}, nbytes::UInt)
+    remaining = Int(nbytes)
+    offset = 0
+    while remaining > 0
+        n = _read_some!(conn, ptr + offset, remaining)
+        offset += n
+        remaining -= n
+    end
+    return nothing
+end
+
+function Base.read!(conn::Conn, buf::Vector{UInt8})
+    GC.@preserve buf Base.unsafe_read(conn, pointer(buf), UInt(length(buf)))
+    return buf
+end
+
+function Base.readbytes!(conn::Conn, buf::Vector{UInt8}, nb::Integer = length(buf))::Int
+    Base.require_one_based_indexing(buf)
+    requested = Int(nb)
+    requested < 0 && throw(ArgumentError("nb must be >= 0"))
+    requested == 0 && return 0
+
+    original_len = length(buf)
+    current_len = original_len
+    bytes_read = 0
+    while bytes_read < requested
+        if current_len == 0 || bytes_read == current_len
+            current_len = _grow_readbytes_target!(buf, current_len, requested)
+        end
+        chunk_capacity = min(current_len - bytes_read, requested - bytes_read)
+        n = try
+            GC.@preserve buf _read_some!(conn, pointer(buf, bytes_read + 1), chunk_capacity)
+        catch err
+            ex = err::Exception
+            ex isa EOFError || rethrow(ex)
+            break
+        end
+        bytes_read += n
+    end
+    if current_len > original_len
+        resize!(buf, bytes_read)
+    end
+    return bytes_read
+end
+
+function Base.readavailable(conn::Conn)::Vector{UInt8}
+    buf = Vector{UInt8}(undef, Base.SZ_UNBUFFERED_IO)
+    n = try
+        _read_some!(conn, buf)
+    catch err
+        ex = err::Exception
+        ex isa EOFError || rethrow(ex)
+        return UInt8[]
+    end
+    return resize!(buf, n)
+end
+
+function Base.read(conn::Conn, ::Type{UInt8})::UInt8
+    ref = Ref{UInt8}(0x00)
+    Base.unsafe_read(conn, ref, 1)
+    return ref[]
+end
+
+Base.eof(conn::Conn)::Bool = false
+Base.isopen(conn::Conn)::Bool = true
+Base.flush(::Conn) = nothing
+
+function Base.unsafe_write(conn::Conn, ptr::Ptr{UInt8}, nbytes::UInt)
+    return Int(nbytes)
+end
+
+Base.write(conn::Conn, buf::AbstractVector{UInt8}) = Base.unsafe_write(conn, pointer(buf), UInt(length(buf)))
 
 function listen(local_addr::SocketAddr; backlog::Integer = 128, reuseaddr::Bool = true)::Listener
     _ = backlog

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -1,0 +1,9 @@
+using Test
+using Reseau
+
+println("[windows-compiler-bug] loaded Reseau")
+println("[windows-compiler-bug] julia threads: $(Threads.nthreads())")
+
+@test Reseau.TCP === TCP
+@test Reseau.TLS === TLS
+@test true

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -9,6 +9,7 @@ module IOPoll
 export DeadlineExceededError, FD, TimerState, schedule_timer!, waittimer, _close_timer!, sleep, read!, _read_ptr_some!
 
 struct DeadlineExceededError <: Exception end
+struct NoDeadlineError <: Exception end
 
 module PollMode
 Base.@enum T::UInt8 begin
@@ -42,16 +43,6 @@ mutable struct PollWaiter
     end
 end
 
-mutable struct Registration
-    fd::Int32
-    token::UInt64
-    read_waiter::PollWaiter
-    write_waiter::PollWaiter
-    function Registration(fd::Int32, token::UInt64)
-        return new(fd, token, PollWaiter(), PollWaiter())
-    end
-end
-
 mutable struct PollState
     lock::ReentrantLock
     sysfd::Int32
@@ -77,6 +68,27 @@ mutable struct PollState
             UInt64(0),
         )
     end
+end
+
+mutable struct Registration
+    fd::Int32
+    token::UInt64
+    mode::PollMode.T
+    read_waiter::PollWaiter
+    write_waiter::PollWaiter
+    @atomic event_err::Bool
+    pollstate::PollState
+end
+
+function Registration(
+        fd::Int32,
+        token::UInt64,
+        mode::PollMode.T,
+        read_waiter::PollWaiter,
+        write_waiter::PollWaiter,
+        event_err::Bool,
+    )
+    return Registration(fd, token, mode, read_waiter, write_waiter, event_err, PollState(fd, token))
 end
 
 mutable struct FD
@@ -117,16 +129,6 @@ mutable struct TimerState
     end
 end
 
-function register!(pfd::FD)
-    @atomic :release pfd.pd.pollable = true
-    return nothing
-end
-
-function set_write_deadline!(pfd::FD, deadline_ns::Int64)
-    @atomic :release pfd.pd.wd_ns = deadline_ns
-    return nothing
-end
-
 connect!(pfd::FD, addrbuf, addrlen) = nothing
 waitwrite(pd::PollState) = nothing
 schedule_timer!(timer::TimerState, deadline_ns::Int64) = true
@@ -138,11 +140,70 @@ _read_ptr_some!(pfd::FD, ptr::Ptr{UInt8}, nbytes::Int) = throw(EOFError())
 
 const _POLL_NO_ERROR = Int32(0)
 const _REGISTRATIONS = IdDict{PollState, Registration}()
+const _NEXT_TOKEN = Ref{UInt64}(UInt64(0))
 
-function register!(pfd::FD)
-    @atomic :release pfd.pd.pollable = true
-    reg = Registration(pfd.sysfd, UInt64(1))
-    _REGISTRATIONS[pfd.pd] = reg
+@inline _mode_has_read(mode::PollMode.T)::Bool = mode == PollMode.READ || mode == PollMode.READWRITE
+@inline _mode_has_write(mode::PollMode.T)::Bool = mode == PollMode.WRITE || mode == PollMode.READWRITE
+@inline _mode_is_empty(mode::PollMode.T)::Bool = mode != PollMode.READ && mode != PollMode.WRITE && mode != PollMode.READWRITE
+
+function schedule_deadlines!(
+        pd::PollState,
+        rd_ns::Int64,
+        wd_ns::Int64,
+        rseq::UInt64,
+        wseq::UInt64,
+    )
+    _ = pd
+    _ = rd_ns
+    _ = wd_ns
+    _ = rseq
+    _ = wseq
+    return nothing
+end
+
+@inline function _next_token!()::UInt64
+    _NEXT_TOKEN[] += UInt64(1)
+    return _NEXT_TOKEN[]
+end
+
+function register!(
+        fd::Integer;
+        mode::PollMode.T = PollMode.READWRITE,
+        pollstate::Union{Nothing, PollState} = nothing,
+    )::Registration
+    _mode_is_empty(mode) && throw(ArgumentError("register! requires READ and/or WRITE mode"))
+    pd = pollstate === nothing ? PollState(fd) : pollstate::PollState
+    token = _next_token!()
+    registration = Registration(Int32(fd), token, mode, PollWaiter(), PollWaiter(), false)
+    registration.pollstate = pd
+    pd.sysfd = Int32(fd)
+    pd.token = token
+    _REGISTRATIONS[pd] = registration
+    return registration
+end
+
+function register!(fd::FD)
+    pd = fd.pd
+    lock(pd.lock)
+    try
+        registration = register!(fd.sysfd; mode = PollMode.READWRITE, pollstate = pd)
+        pd.sysfd = fd.sysfd
+        pd.token = registration.token
+        @atomic :release pd.pollable = true
+        @atomic :release pd.closing = false
+        @atomic :release pd.event_err = false
+        @atomic :release pd.rd_ns = Int64(0)
+        @atomic :release pd.wd_ns = Int64(0)
+        @atomic :release pd.rseq = UInt64(1)
+        @atomic :release pd.wseq = UInt64(1)
+    finally
+        unlock(pd.lock)
+    end
+    return nothing
+end
+
+function deregister!(pd::PollState)
+    pop!(_REGISTRATIONS, pd, nothing)
     return nothing
 end
 
@@ -161,22 +222,171 @@ _convert_poll_error!(res::Int32, is_file::Bool) = nothing
 preparewrite(pd::PollState, is_file::Bool = false) = nothing
 _fd_write_lock!(fd::FD) = nothing
 _fd_write_unlock!(fd::FD) = nothing
+pollable(pd::PollState)::Bool = @atomic :acquire pd.pollable
+
+function _wake_waiters!(pd::PollState, mode::PollMode.T)
+    registration = current_registration(pd)
+    registration === nothing && return nothing
+    if _mode_has_read(mode)
+        pollnotify!(registration.read_waiter, PollWakeReason.CANCELED)
+    end
+    if _mode_has_write(mode)
+        pollnotify!(registration.write_waiter, PollWakeReason.CANCELED)
+    end
+    return nothing
+end
 
 function pollwait!(waiter::PollWaiter)::PollWakeReason.T
-    return PollWakeReason.READY
+    task = current_task()
+    task.sticky && (task.sticky = false)
+    waiter.task = task
+    try
+        state, ok = @atomicreplace(waiter.state, PollWaiterState.EMPTY => PollWaiterState.WAITING)
+        if ok
+            wait()
+        else
+            state == PollWaiterState.NOTIFIED || throw(ArgumentError("concurrent wait on PollWaiter"))
+        end
+        while true
+            state, ok = @atomicreplace(waiter.state, PollWaiterState.NOTIFIED => PollWaiterState.EMPTY)
+            ok && return @atomic :acquire waiter.reason
+            state == PollWaiterState.EMPTY && return @atomic :acquire waiter.reason
+            state == PollWaiterState.WAITING || throw(ArgumentError("invalid PollWaiter state"))
+            wait()
+        end
+    finally
+        waiter.task = nothing
+    end
 end
 
 function pollnotify!(waiter::PollWaiter, reason::PollWakeReason.T = PollWakeReason.READY)::Bool
-    @atomic :release waiter.reason = reason
-    return true
+    state = @atomic :acquire waiter.state
+    while true
+        if state == PollWaiterState.NOTIFIED
+            current = @atomic :acquire waiter.reason
+            current == PollWakeReason.READY && return false
+            @atomic :release waiter.reason = reason
+            return false
+        end
+        state, ok = @atomicreplace(waiter.state, state => PollWaiterState.NOTIFIED)
+        ok || continue
+        @atomic :release waiter.reason = reason
+        if state == PollWaiterState.WAITING
+            task = waiter.task
+            task isa Task || throw(ArgumentError("invalid PollWaiter task state"))
+            schedule(task)
+            return true
+        end
+        state == PollWaiterState.EMPTY || throw(ArgumentError("invalid PollWaiter state"))
+        return false
+    end
 end
 
 function arm_waiter!(registration::Registration, mode::PollMode.T)
     if mode == PollMode.WRITE
         pollnotify!(registration.write_waiter, PollWakeReason.READY)
-    else
-        pollnotify!(registration.read_waiter, PollWakeReason.READY)
+        return nothing
     end
+    pollnotify!(registration.read_waiter, PollWakeReason.READY)
+    return nothing
+end
+
+function Base.close(pd::PollState)
+    was_pollable = false
+    lock(pd.lock)
+    try
+        was_pollable = @atomic :acquire pd.pollable
+        @atomic :release pd.pollable = false
+    finally
+        unlock(pd.lock)
+    end
+    was_pollable && pd.sysfd >= 0 && deregister!(pd)
+    return nothing
+end
+
+function evict!(pd::PollState)
+    lock(pd.lock)
+    try
+        (@atomic :acquire pd.closing) && return nothing
+        @atomic :release pd.closing = true
+        @atomic pd.rseq += UInt64(1)
+        @atomic pd.wseq += UInt64(1)
+    finally
+        unlock(pd.lock)
+    end
+    _wake_waiters!(pd, PollMode.READWRITE)
+    return nothing
+end
+
+@inline function _monotonic_ns()::Int64
+    return Int64(time_ns())
+end
+
+function _set_deadline_impl!(fd::FD, deadline_ns::Integer, mode::PollMode.T)
+    deadline = Int64(deadline_ns)
+    try
+        pd = fd.pd
+        (@atomic :acquire pd.pollable) || throw(NoDeadlineError())
+        wake_read = false
+        wake_write = false
+        rd_ns = Int64(0)
+        wd_ns = Int64(0)
+        rseq = UInt64(0)
+        wseq = UInt64(0)
+        lock(pd.lock)
+        try
+            (@atomic :acquire pd.closing) && return nothing
+            if _mode_has_read(mode)
+                @atomic pd.rseq += UInt64(1)
+                if deadline == 0
+                    @atomic :release pd.rd_ns = Int64(0)
+                elseif deadline <= _monotonic_ns()
+                    @atomic :release pd.rd_ns = Int64(-1)
+                    wake_read = true
+                else
+                    @atomic :release pd.rd_ns = deadline
+                end
+            end
+            if _mode_has_write(mode)
+                @atomic pd.wseq += UInt64(1)
+                if deadline == 0
+                    @atomic :release pd.wd_ns = Int64(0)
+                elseif deadline <= _monotonic_ns()
+                    @atomic :release pd.wd_ns = Int64(-1)
+                    wake_write = true
+                else
+                    @atomic :release pd.wd_ns = deadline
+                end
+            end
+            rd_ns = @atomic :acquire pd.rd_ns
+            wd_ns = @atomic :acquire pd.wd_ns
+            rseq = @atomic :acquire pd.rseq
+            wseq = @atomic :acquire pd.wseq
+        finally
+            unlock(pd.lock)
+        end
+        schedule_deadlines!(pd, rd_ns, wd_ns, rseq, wseq)
+        if wake_read && wake_write
+            _wake_waiters!(pd, PollMode.READWRITE)
+        elseif wake_read
+            _wake_waiters!(pd, PollMode.READ)
+        elseif wake_write
+            _wake_waiters!(pd, PollMode.WRITE)
+        end
+    finally
+        nothing
+    end
+    return nothing
+end
+
+function set_write_deadline!(fd::FD, deadline_ns::Integer)
+    _set_deadline_impl!(fd, deadline_ns, PollMode.WRITE)
+    return nothing
+end
+
+function Base.close(fd::FD)
+    evict!(fd.pd)
+    close(fd.pd)
     return nothing
 end
 
@@ -218,6 +428,7 @@ function connect!(fd::FD, addrbuf::Vector{UInt8}, addrlen::Int32)
         end
         errno = _iocp_finish_connect!(registration)
         errno == Int32(0) || throw(SystemError("connectex", Int(errno)))
+        Main.Reseau.SocketOps.update_connect_context!(fd.sysfd)
     finally
         _fd_write_unlock!(fd)
     end
@@ -228,11 +439,16 @@ end
 
 module SocketOps
 
-export AF_INET, AF_INET6, SOCK_STREAM, SockAddrIn, SockAddrIn6, open_socket, bind_socket, set_nonblocking!, sockaddr_in, sockaddr_in_any, sockaddr_in6, sockaddr_in6_any, sockaddr_bytes
+export AF_INET, AF_INET6, SOCK_STREAM, IPPROTO_TCP, TCP_NODELAY, SOL_SOCKET, SO_KEEPALIVE, SO_ERROR, SockAddrIn, SockAddrIn6, open_socket, bind_socket, connect_socket, set_nonblocking!, set_sockopt_int, get_socket_error, update_connect_context!, sockaddr_in, sockaddr_in_any, sockaddr_in6, sockaddr_in6_any, sockaddr_bytes
 
 const AF_INET = Int32(2)
 const AF_INET6 = Int32(23)
 const SOCK_STREAM = Int32(1)
+const IPPROTO_TCP = Int32(6)
+const TCP_NODELAY = Int32(1)
+const SOL_SOCKET = Int32(0xffff)
+const SO_KEEPALIVE = Int32(0x0008)
+const SO_ERROR = Int32(0x1007)
 
 struct SockAddrIn
     sin_family::UInt16
@@ -270,7 +486,11 @@ end
 
 open_socket(family::Int32, sotype::Int32) = Int32(1)
 bind_socket(sysfd::Int32, sockaddr::Union{SockAddrIn, SockAddrIn6}) = nothing
+connect_socket(sysfd::Int32, sockaddr::Union{SockAddrIn, SockAddrIn6}) = Int32(0)
 set_nonblocking!(sysfd::Int32, enabled::Bool) = nothing
+set_sockopt_int(fd::Int32, level::Int32, optname::Int32, value::Integer) = nothing
+get_socket_error(fd::Int32)::Int32 = Int32(0)
+update_connect_context!(fd::Int32) = nothing
 
 function sockaddr_in(ip::NTuple{4, UInt8}, port::Integer)::SockAddrIn
     return SockAddrIn(
@@ -354,7 +574,7 @@ mutable struct FD
     raddr::Union{Nothing, SocketAddr}
 end
 
-struct Conn
+struct Conn <: IO
     fd::FD
 end
 
@@ -418,7 +638,17 @@ function _finalize_connected_addrs!(fd::FD, fallback_remote::SocketAddr)
     return nothing
 end
 
-_apply_default_tcp_opts!(fd::FD) = nothing
+function _apply_default_tcp_opts!(fd::FD)
+    try
+        SocketOps.set_sockopt_int(fd.pfd.sysfd, SocketOps.IPPROTO_TCP, SocketOps.TCP_NODELAY, 1)
+    catch
+    end
+    try
+        SocketOps.set_sockopt_int(fd.pfd.sysfd, SocketOps.SOL_SOCKET, SocketOps.SO_KEEPALIVE, 1)
+    catch
+    end
+    return nothing
+end
 
 function _wait_connect_complete!(
         fd::FD,
@@ -671,9 +901,9 @@ end
 
 end
 
-Base.close(fd::TCP.FD) = nothing
-Base.close(::TCP.Conn) = nothing
-Base.close(::TCP.Listener) = nothing
+Base.close(fd::TCP.FD) = close(fd.pfd)
+Base.close(conn::TCP.Conn) = close(conn.fd)
+Base.close(listener::TCP.Listener) = close(listener.fd)
 
 module HostResolvers
 

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -2,9 +2,13 @@ using Test
 
 module IOPoll
 
-export DeadlineExceededError
+export DeadlineExceededError, FD
 
 struct DeadlineExceededError <: Exception end
+
+mutable struct FD
+    sysfd::Int32
+end
 
 register!(pfd) = nothing
 set_write_deadline!(pfd, deadline_ns::Int64) = nothing
@@ -30,6 +34,9 @@ end
 
 module TCP
 
+using ..IOPoll
+using ..SocketOps
+
 export connect, SocketAddr, SocketAddrV4, SocketAddrV6, SocketEndpoint, Conn, ConnectCanceledError, loopback_addr, loopback_addr6, _connect_socketaddr_impl
 
 function connect end
@@ -49,12 +56,8 @@ end
 
 const SocketEndpoint = Union{SocketAddrV4, SocketAddrV6}
 
-mutable struct PollFD
-    sysfd::Int32
-end
-
 mutable struct FD
-    pfd::PollFD
+    pfd::IOPoll.FD
     family::Int32
     sotype::Int32
     net::Symbol
@@ -100,7 +103,7 @@ function _new_netfd(
         net::Symbol = :tcp,
         is_connected::Bool = false,
     )::FD
-    return FD(PollFD(sysfd), family, sotype, net, is_connected, nothing, nothing)
+    return FD(IOPoll.FD(sysfd), family, sotype, net, is_connected, nothing, nothing)
 end
 
 function _finalize_connected_addrs!(fd::FD, fallback_remote::SocketAddr)
@@ -257,11 +260,29 @@ abstract type AbstractResolver end
 
 struct SystemResolver <: AbstractResolver end
 
-struct SingleflightResolver{R <: AbstractResolver} <: AbstractResolver
-    parent::R
+mutable struct _LookupFlight
+    lock::ReentrantLock
+    cond::Threads.Condition
+    result::Union{Nothing, Vector{TCP.SocketEndpoint}}
+    err::Union{Nothing, Exception}
+    @atomic done::Bool
+    function _LookupFlight()
+        lock = ReentrantLock()
+        return new(lock, Threads.Condition(lock), nothing, nothing, false)
+    end
 end
 
-SingleflightResolver(parent::R) where {R <: AbstractResolver} = SingleflightResolver{R}(parent)
+mutable struct SingleflightResolver{R <: AbstractResolver} <: AbstractResolver
+    parent::R
+    lock::ReentrantLock
+    inflight::Dict{Tuple{String, String}, _LookupFlight}
+    @atomic actual_lookups::Int
+    @atomic shared_hits::Int
+end
+
+function SingleflightResolver(parent::R) where {R <: AbstractResolver}
+    return SingleflightResolver{R}(parent, ReentrantLock(), Dict{Tuple{String, String}, _LookupFlight}(), 0, 0)
+end
 
 struct ResolverPolicy
     prefer_ipv6::Bool
@@ -278,8 +299,10 @@ const DEFAULT_RESOLVER = SystemResolver()
 
 mutable struct DNSRaceState
     @atomic done::Bool
+    lock::ReentrantLock
+    wait_fds::Vector{IOPoll.FD}
     function DNSRaceState()
-        return new(false)
+        return new(false, ReentrantLock(), IOPoll.FD[])
     end
 end
 
@@ -287,8 +310,33 @@ end
     return @atomic :acquire state.done
 end
 
-TCP._connect_wait_register!(state::DNSRaceState, fd::TCP.FD) = nothing
-TCP._connect_wait_unregister!(state::DNSRaceState, fd::TCP.FD) = nothing
+function TCP._connect_wait_register!(state::DNSRaceState, fd::TCP.FD)
+    lock(state.lock)
+    try
+        if @atomic :acquire state.done
+            try
+                IOPoll.set_write_deadline!(fd.pfd, Int64(time_ns()) - Int64(1))
+            catch
+            end
+            return nothing
+        end
+        push!(state.wait_fds, fd.pfd)
+    finally
+        unlock(state.lock)
+    end
+    return nothing
+end
+
+function TCP._connect_wait_unregister!(state::DNSRaceState, fd::TCP.FD)
+    lock(state.lock)
+    try
+        idx = findfirst(x -> x === fd.pfd, state.wait_fds)
+        idx === nothing || deleteat!(state.wait_fds, idx)
+    finally
+        unlock(state.lock)
+    end
+    return nothing
+end
 
 struct HostResolver{R <: AbstractResolver}
     timeout_ns::Int64
@@ -476,6 +524,20 @@ function _mark_connect_done!(state::DNSRaceState)
         current && return false
         _, ok = @atomicreplace(state.done, current => true)
         ok || continue
+        waiters = IOPoll.FD[]
+        lock(state.lock)
+        try
+            append!(waiters, state.wait_fds)
+            empty!(state.wait_fds)
+        finally
+            unlock(state.lock)
+        end
+        for waiter in waiters
+            try
+                IOPoll.set_write_deadline!(waiter, Int64(time_ns()) - Int64(1))
+            catch
+            end
+        end
         return true
     end
 end

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -4899,6 +4899,20 @@ function _extract_package_module_source(name::AbstractString)::String
     return modsrc
 end
 
+function _extract_block(src::String, start_marker::String, stop_marker::String)::String
+    start_rng = findfirst(start_marker, src)
+    stop_rng = findfirst(stop_marker, src)
+    start_rng === nothing && error("start marker not found: $start_marker")
+    stop_rng === nothing && error("stop marker not found: $stop_marker")
+    return src[first(start_rng):prevind(src, first(stop_rng))]
+end
+
+function _rewrite_extracted_block(str::String, name::AbstractString)::String
+    str = replace(str, "..Reseau" => "..$(name)")
+    str = replace(str, "Main.Reseau" => "Main.$(name)")
+    return str
+end
+
 function _with_extracted_package(f::F) where {F}
     mktempdir() do dir
         name = "StandalonePkg"
@@ -4920,6 +4934,67 @@ function _with_extracted_package(f::F) where {F}
     end
 end
 
+function _with_split_extracted_package(f::F) where {F}
+    src = read(@__FILE__, String)
+    mktempdir() do dir
+        name = "StandalonePkgSplit"
+        uuid = uuid4()
+        pkgid = Base.PkgId(uuid, name)
+        compat = """
+        const ByteMemory = Vector{UInt8}
+        bytememory(n::Integer)::ByteMemory = Vector{UInt8}(undef, Int(n))
+        const HAS_CCALL_GCSAFE = false
+        macro gcsafe_ccall(expr)
+            return esc(expr)
+        end
+        """
+        root = """
+        module $name
+        export TCP, TLS
+        $compat
+        include("1_socket_ops.jl")
+        include("2_iopoll.jl")
+        include("3_tcp.jl")
+        include("4_host_resolvers.jl")
+        include("5_tls.jl")
+        end
+        """
+        write(
+            joinpath(dir, "Project.toml"),
+            "name = \"$name\"\nuuid = \"$(string(uuid))\"\nversion = \"0.1.0\"\n",
+        )
+        mkpath(joinpath(dir, "src"))
+        write(joinpath(dir, "src", "$name.jl"), root)
+        write(
+            joinpath(dir, "src", "1_socket_ops.jl"),
+            _rewrite_extracted_block(_extract_block(src, "module SocketOps", "module TCP"), name),
+        )
+        write(
+            joinpath(dir, "src", "2_iopoll.jl"),
+            _rewrite_extracted_block(_extract_block(src, "module IOPoll", "module SocketOps"), name),
+        )
+        write(
+            joinpath(dir, "src", "3_tcp.jl"),
+            _rewrite_extracted_block(_extract_block(src, "module TCP", "module HostResolvers"), name),
+        )
+        write(
+            joinpath(dir, "src", "4_host_resolvers.jl"),
+            _rewrite_extracted_block(_extract_block(src, "module HostResolvers", "module TLS"), name),
+        )
+        write(
+            joinpath(dir, "src", "5_tls.jl"),
+            _rewrite_extracted_block(_extract_block(src, "module TLS", "end # module Reseau"), name),
+        )
+        pushfirst!(LOAD_PATH, dir)
+        try
+            mod = Base.require(pkgid)
+            return f(mod)
+        finally
+            popfirst!(LOAD_PATH)
+        end
+    end
+end
+
 println("[windows-compiler-bug] julia threads: $(Threads.nthreads())")
 
 @test Reseau.TCP === TCP
@@ -4927,6 +5002,39 @@ println("[windows-compiler-bug] julia threads: $(Threads.nthreads())")
 
 _probe("extracted package kwcall + runtime") do
     _with_extracted_package() do mod
+        c = getproperty(mod, :TCP)
+        kwtt_v4 = (
+            NamedTuple{(:local_addr,), Tuple{getproperty(c, :SocketAddrV4)}},
+            typeof(getproperty(c, :connect)),
+            String,
+            String,
+        )
+        kwtt_v6 = (
+            NamedTuple{(:local_addr,), Tuple{getproperty(c, :SocketAddrV6)}},
+            typeof(getproperty(c, :connect)),
+            String,
+            String,
+        )
+        Base.precompile(Tuple{typeof(Core.kwcall), kwtt_v4...})
+        Base.code_typed(Core.kwcall, kwtt_v4)
+        Base.precompile(Tuple{typeof(Core.kwcall), kwtt_v6...})
+        Base.code_typed(Core.kwcall, kwtt_v6)
+        local_v4 = Base.invokelatest(getproperty(c, :loopback_addr), 0)
+        local_v6 = Base.invokelatest(getproperty(c, :loopback_addr6), 0)
+        try
+            Base.invokelatest(getproperty(c, :connect), "tcp", "127.0.0.1:1"; local_addr = local_v4)
+        catch
+        end
+        try
+            Base.invokelatest(getproperty(c, :connect), "tcp", "127.0.0.1:1"; local_addr = local_v6)
+        catch
+        end
+        return nothing
+    end
+end
+
+_probe("split package kwcall + runtime") do
+    _with_split_extracted_package() do mod
         c = getproperty(mod, :TCP)
         kwtt_v4 = (
             NamedTuple{(:local_addr,), Tuple{getproperty(c, :SocketAddrV4)}},

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -1,5 +1,7 @@
 using Test
 
+module Reseau
+
 module IOPoll
 
 export DeadlineExceededError, FD
@@ -668,6 +670,8 @@ end
 
 end
 
+end # module Reseau
+
 function _probe(f, label::AbstractString)
     println("[windows-compiler-bug] probe start: $(label)")
     try
@@ -682,11 +686,11 @@ end
 println("[windows-compiler-bug] julia threads: $(Threads.nthreads())")
 
 _probe("tcp kwcall local_addr v4") do
-    TCP.connect("tcp", "127.0.0.1:1"; local_addr = TCP.loopback_addr(0))
+    Reseau.TCP.connect("tcp", "127.0.0.1:1"; local_addr = Reseau.TCP.loopback_addr(0))
 end
 
 _probe("tcp kwcall local_addr v6 mismatch") do
-    TCP.connect("tcp", "127.0.0.1:1"; local_addr = TCP.loopback_addr6(0))
+    Reseau.TCP.connect("tcp", "127.0.0.1:1"; local_addr = Reseau.TCP.loopback_addr6(0))
 end
 
 @test true

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -664,6 +664,68 @@ end
     return addr isa TCP.SocketAddrV6
 end
 
+function _parse_ipv4_literal(host::AbstractString)::Union{Nothing, NTuple{4, UInt8}}
+    parts = split(String(host), '.')
+    length(parts) == 4 || return nothing
+    bytes = UInt8[]
+    for part in parts
+        isempty(part) && return nothing
+        v = tryparse(Int, part)
+        v === nothing && return nothing
+        (0 <= v <= 255) || return nothing
+        push!(bytes, UInt8(v))
+    end
+    return (bytes[1], bytes[2], bytes[3], bytes[4])
+end
+
+function _parse_ipv6_literal(host::AbstractString)::Union{Nothing, NTuple{16, UInt8}}
+    h = String(host)
+    h == "::1" || return nothing
+    return (
+        UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+        UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+        UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+        UInt8(0), UInt8(0), UInt8(0), UInt8(1),
+    )
+end
+
+function _split_host_zone(host::AbstractString)::Tuple{String, String}
+    s = String(host)
+    i = findlast(==('%'), s)
+    i === nothing && return s, ""
+    i == firstindex(s) && return s, ""
+    i == lastindex(s) && throw(AddressError("invalid scoped address zone", s))
+    return s[1:prevind(s, i)], s[nextind(s, i):end]
+end
+
+function _scope_id_from_zone(zone::AbstractString)::UInt32
+    z = String(zone)
+    isempty(z) && return UInt32(0)
+    numeric = tryparse(Int, z)
+    if numeric !== nothing
+        (numeric < 0 || numeric > typemax(UInt32)) && throw(AddressError("invalid scope id", z))
+        return UInt32(numeric)
+    end
+    throw(AddressError("unknown interface zone", z))
+end
+
+function _literal_host_addr(host::AbstractString)::Union{Nothing, TCP.SocketEndpoint}
+    h = String(host)
+    isempty(h) && return nothing
+    host_only, zone = _split_host_zone(h)
+    ip4 = _parse_ipv4_literal(host_only)
+    if ip4 !== nothing
+        isempty(zone) || throw(AddressError("invalid scoped address", h))
+        return TCP.SocketAddrV4(ip4::NTuple{4, UInt8}, 0x0000)
+    end
+    ip6 = _parse_ipv6_literal(host_only)
+    if ip6 !== nothing
+        scope_id = _scope_id_from_zone(zone)
+        return TCP.SocketAddrV6(ip6::NTuple{16, UInt8}, 0x0000, scope_id)
+    end
+    return nothing
+end
+
 function split_host_port(hostport::AbstractString)::Tuple{String, String}
     s = String(hostport)
     i = findlast(==(':'), s)
@@ -796,12 +858,8 @@ end
 
 function _resolve_system_host(host::AbstractString)::Vector{TCP.SocketEndpoint}
     h = String(host)
-    if h == "127.0.0.1"
-        return TCP.SocketEndpoint[TCP.loopback_addr(0)]
-    end
-    if h == "::1"
-        return TCP.SocketEndpoint[TCP.loopback_addr6(0)]
-    end
+    literal = _literal_host_addr(h)
+    literal === nothing || return TCP.SocketEndpoint[literal]
     throw(AddressError("lookup failed", h))
 end
 
@@ -907,6 +965,10 @@ function _resolve_host_ips(
         return _resolve_static_host(resolver::StaticResolver, network, host)
     end
     return _resolve_system_host(host)
+end
+
+function _resolve_host_ips(resolver::AbstractResolver, host::AbstractString)::Vector{TCP.SocketEndpoint}
+    return _resolve_host_ips(resolver, "tcp", host)
 end
 
 function _apply_policy_and_network(

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -4702,8 +4702,13 @@ function listen(
 end
 
 Base.isopen(conn::Conn) = true
+Base.write(conn::Conn, buf::AbstractVector{UInt8}) = write(conn.tcp, buf)
+Base.read!(conn::Conn, buf::Vector{UInt8}) = read!(conn.tcp, buf)
 Base.close(conn::Conn) = close(conn.tcp)
 Base.close(listener::Listener) = close(listener.tcp)
+addr(listener::Listener) = TCP.addr(listener.tcp)
+accept(listener::Listener) = Conn(TCP.accept(listener.tcp), listener.config)
+handshake!(conn::Conn) = conn
 
 end
 
@@ -4764,10 +4769,69 @@ function _pc_run_socket_ops_workload!()
 end
 
 function _pc_run_tcp_workload!()
+    _pc_is_generating_output() && return nothing
+    _pc_runtime_supported() || return nothing
+    listener = nothing
+    client = nothing
+    server = nothing
+    try
+        listener = NC.listen(NC.loopback_addr(0); backlog = 16)
+        laddr = NC.addr(listener)
+        accept_task = errormonitor(Threads.@spawn NC.accept(listener))
+        client = NC.connect(NC.loopback_addr(Int((laddr::NC.SocketAddrV4).port)))
+        server = fetch(accept_task)
+        payload = UInt8[0x41, 0x42, 0x43]
+        written = write(client, payload)
+        written == length(payload) || throw(ArgumentError("tcp workload expected 3-byte write"))
+        recv_buf = Vector{UInt8}(undef, length(payload))
+        _pc_read_exact!(server, recv_buf) == length(payload) || throw(EOFError())
+    finally
+        try
+            server === nothing || close(server)
+        catch
+        end
+        try
+            client === nothing || close(client)
+        catch
+        end
+        try
+            listener === nothing || close(listener)
+        catch
+        end
+    end
     return nothing
 end
 
 function _pc_run_host_resolvers_workload!()
+    _pc_is_generating_output() && return nothing
+    _pc_runtime_supported() || return nothing
+    listener = nothing
+    client = nothing
+    server = nothing
+    try
+        listener = ND.listen("tcp", "127.0.0.1:0"; backlog = 16)
+        laddr = NC.addr(listener)
+        client = ND.connect("tcp", ND.join_host_port("127.0.0.1", Int((laddr::NC.SocketAddrV4).port)))
+        server = NC.accept(listener)
+        payload = UInt8[0x51, 0x52]
+        written = write(client, payload)
+        written == length(payload) || throw(ArgumentError("host resolver workload expected 2-byte write"))
+        recv_buf = Vector{UInt8}(undef, length(payload))
+        _pc_read_exact!(server, recv_buf) == length(payload) || throw(EOFError())
+    finally
+        try
+            server === nothing || close(server)
+        catch
+        end
+        try
+            client === nothing || close(client)
+        catch
+        end
+        try
+            listener === nothing || close(listener)
+        catch
+        end
+    end
     return nothing
 end
 
@@ -4777,6 +4841,71 @@ function _pc_tls_resource_file(name::AbstractString)::Union{Nothing, String}
 end
 
 function _pc_run_tls_workload!()
+    _pc_is_generating_output() && return nothing
+    _pc_runtime_supported() || return nothing
+    cert_path = _pc_tls_resource_file("unittests.crt")
+    key_path = _pc_tls_resource_file("unittests.key")
+    (cert_path === nothing || key_path === nothing) && return nothing
+    listener = nothing
+    client = nothing
+    server = nothing
+    try
+        server_cfg = TL.Config(
+            verify_peer = false,
+            cert_file = cert_path::String,
+            key_file = key_path::String,
+            handshake_timeout_ns = 1_000_000_000,
+        )
+        listener = TL.listen("tcp", "127.0.0.1:0", server_cfg; backlog = 8)
+        laddr = TL.addr(listener)::NC.SocketAddrV4
+        accept_task = errormonitor(Threads.@spawn begin
+            conn = TL.accept(listener::TL.Listener)
+            TL.handshake!(conn)
+            return conn
+        end)
+        client_cfg = TL.Config(
+            verify_peer = false,
+            server_name = "localhost",
+            handshake_timeout_ns = 1_000_000_000,
+        )
+        client = TL.connect(
+            "tcp",
+            "127.0.0.1:$(Int(laddr.port))";
+            server_name = client_cfg.server_name,
+            verify_peer = client_cfg.verify_peer,
+            client_auth = client_cfg.client_auth,
+            cert_file = client_cfg.cert_file,
+            key_file = client_cfg.key_file,
+            ca_file = client_cfg.ca_file,
+            client_ca_file = client_cfg.client_ca_file,
+            alpn_protocols = copy(client_cfg.alpn_protocols),
+            handshake_timeout_ns = client_cfg.handshake_timeout_ns,
+            min_version = client_cfg.min_version,
+            max_version = client_cfg.max_version,
+        )
+        status = IP.timedwait(() -> istaskdone(accept_task), 2.0; pollint = 0.001)
+        status == :timed_out && throw(ArgumentError("TLS precompile workload timed out during accept"))
+        server = fetch(accept_task)
+        payload = UInt8[0x54, 0x4c, 0x53]
+        recv_buf = Vector{UInt8}(undef, 3)
+        written = write(client, payload)
+        written == 3 || throw(ArgumentError("TLS precompile workload expected 3-byte write"))
+        read!(server, recv_buf)
+    finally
+        try
+            server === nothing || close(server)
+        catch
+        end
+        try
+            client === nothing || close(client)
+        catch
+        end
+        try
+            listener === nothing || close(listener)
+        catch
+        end
+        IP.shutdown!()
+    end
     return nothing
 end
 

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -4869,7 +4869,9 @@ end # module Reseau
 
 using .Reseau: TCP, TLS
 
+const IP = Reseau.IOPoll
 const NC = Reseau.TCP
+const ND = Reseau.HostResolvers
 const TL = Reseau.TLS
 
 function _probe(f, label::AbstractString)
@@ -4899,6 +4901,30 @@ _probe("kwsort infer local_addr v6") do
     tt = (NamedTuple{(:local_addr,), Tuple{NC.SocketAddrV6}}, typeof(NC.connect), String, String)
     Base.precompile(Tuple{typeof(Core.kwcall), tt...})
     Base.code_typed(Core.kwcall, tt)
+    return nothing
+end
+
+_probe("infer HostResolvers.connect direct") do
+    Base.precompile(Tuple{typeof(ND.connect), ND.HostResolver, String, String})
+    Base.code_typed(ND.connect, (ND.HostResolver, String, String))
+    return nothing
+end
+
+_probe("infer HostResolvers._resolve_serial") do
+    Base.precompile(Tuple{typeof(ND._resolve_serial), ND.HostResolver, String, String, Vector{NC.SocketEndpoint}, Int64, ND.DNSRaceState})
+    Base.code_typed(ND._resolve_serial, (ND.HostResolver, String, String, Vector{NC.SocketEndpoint}, Int64, ND.DNSRaceState))
+    return nothing
+end
+
+_probe("infer TCP._connect_socketaddr_impl") do
+    Base.precompile(Tuple{typeof(NC._connect_socketaddr_impl), NC.SocketAddrV4, Union{Nothing, NC.SocketAddr}, Int64, Any})
+    Base.code_typed(NC._connect_socketaddr_impl, (NC.SocketAddrV4, Union{Nothing, NC.SocketAddr}, Int64, Any))
+    return nothing
+end
+
+_probe("infer IOPoll.connect!") do
+    Base.precompile(Tuple{typeof(IP.connect!), IP.FD, Vector{UInt8}, Int32})
+    Base.code_typed(IP.connect!, (IP.FD, Vector{UInt8}, Int32))
     return nothing
 end
 

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -934,7 +934,7 @@ end
 function _new_iocp_registration(fd::Int32, token::UInt64)::IocpRegistration
     read_op = IocpOp(Ref(_ZERO_OVERLAPPED), PollMode.READ, token, IocpOpKind.PROBE_READ, nothing, nothing, false)
     write_op = IocpOp(Ref(_ZERO_OVERLAPPED), PollMode.WRITE, token, IocpOpKind.PROBE_WRITE, nothing, nothing, false)
-    reg = IocpRegistration(fd, token, read_op, write_op, true, false)
+    reg = IocpRegistration(fd, token, read_op, write_op, false, false)
     read_op.owner = reg
     write_op.owner = reg
     return reg
@@ -981,8 +981,9 @@ function _load_connectex_ptr(fd::Int32)::Ptr{Cvoid}
         _ = guid_ref
         _ = out_ref
         _ = bytes_ref
-        _CONNECTEX_PTR[] = out_ref[]
-        return out_ref[]
+        ptr = out_ref[] == C_NULL ? Ptr{Cvoid}(0x1) : out_ref[]
+        _CONNECTEX_PTR[] = ptr
+        return ptr
     finally
         unlock(_CONNECTEX_LOCK)
     end
@@ -1520,10 +1521,11 @@ function _submit_iocp_op!(registration::Registration, reg::IocpRegistration, op:
         request = op.request
         request isa IocpConnectRequest || throw(ArgumentError("missing ConnectEx request"))
         connectex_ptr = _load_connectex_ptr(reg.fd)
+        connectex_ptr == C_NULL && return _map_overlapped_errno(_wsa_get_last_error())
         _ = request.addrbuf
         _ = request.addrlen
         _ = connectex_ptr
-        rc = Int32(0)
+        rc = Int32(1)
     else
         rc = Int32(Base.Libc.ENOSYS)
     end
@@ -1531,22 +1533,34 @@ function _submit_iocp_op!(registration::Registration, reg::IocpRegistration, op:
         if rc == 0
             reg.wait_on_success && return Int32(0)
             @atomic :release op.active = false
-            pollnotify!(
-                op.mode == PollMode.READ ? registration.read_waiter : registration.write_waiter,
-                PollWakeReason.READY,
-            )
+            _notify_registration!(registration, op.mode)
+            return Int32(0)
+        end
+        err = _wsa_get_last_error()
+        if err == _ERROR_IO_PENDING
             return Int32(0)
         end
         @atomic :release op.active = false
+        if err == _WSAEWOULDBLOCK || err == _WSAEINPROGRESS || err == _WSAEALREADY || err == _WSAENOTCONN
+            return Int32(0)
+        end
+        @atomic :release registration.event_err = true
+        _notify_registration!(registration, op.mode)
         return Int32(0)
     end
-    if rc == 0
-        pollnotify!(registration.write_waiter, PollWakeReason.READY)
+    if rc != 0
+        reg.wait_on_success && return Int32(0)
+        @atomic :release op.active = false
+        _notify_registration!(registration, op.mode)
+        return Int32(0)
+    end
+    err = _wsa_get_last_error()
+    if err == _ERROR_IO_PENDING
         return Int32(0)
     end
     @atomic :release op.active = false
     _clear_iocp_op!(op)
-    return Int32(Base.Libc.EIO)
+    return _map_overlapped_errno(err)
 end
 
 function _finish_iocp_mode!(registration::Registration, mode::PollMode.T)::Int32

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -332,17 +332,95 @@ end
     return !isempty(fallbacks)
 end
 
+@inline function _is_ipv4(addr::TCP.SocketEndpoint)::Bool
+    return addr isa TCP.SocketAddrV4
+end
+
+@inline function _is_ipv6(addr::TCP.SocketEndpoint)::Bool
+    return addr isa TCP.SocketAddrV6
+end
+
+function split_host_port(address::AbstractString)::Tuple{String, String}
+    addr = String(address)
+    idx = findlast(==(':'), addr)
+    idx === nothing && throw(AddressError("missing port in address", addr))
+    host = addr[begin:prevind(addr, idx)]
+    service = addr[nextind(addr, idx):end]
+    isempty(service) && throw(AddressError("missing port in address", addr))
+    return host, service
+end
+
+function lookup_port(resolver::AbstractResolver, network::AbstractString, service::AbstractString)::Int
+    _ = resolver
+    _ = network
+    return parse(Int, service)
+end
+
+function _with_port(addr::TCP.SocketAddrV4, port::Int)::TCP.SocketAddrV4
+    return TCP.SocketAddrV4(addr.ip, UInt16(port))
+end
+
+function _with_port(addr::TCP.SocketAddrV6, port::Int)::TCP.SocketAddrV6
+    return TCP.SocketAddrV6(addr.ip, UInt16(port), addr.scope_id)
+end
+
+function _resolve_host_ips(
+        resolver::AbstractResolver,
+        network::AbstractString,
+        host::AbstractString,
+    )::Vector{TCP.SocketEndpoint}
+    _ = resolver
+    _ = network
+    h = String(host)
+    if h == "127.0.0.1"
+        return TCP.SocketEndpoint[TCP.loopback_addr(0)]
+    end
+    if h == "::1"
+        return TCP.SocketEndpoint[TCP.loopback_addr6(0)]
+    end
+    throw(AddressError("lookup failed", h))
+end
+
+function _apply_policy_and_network(
+        ips::Vector{TCP.SocketEndpoint},
+        kind::Symbol,
+        policy::ResolverPolicy,
+    )::Vector{TCP.SocketEndpoint}
+    _ = kind
+    _ = policy
+    return ips
+end
+
+function resolve_tcp_addrs(
+        resolver::AbstractResolver,
+        network::AbstractString,
+        address::AbstractString;
+        op::Symbol = :connect,
+        policy::ResolverPolicy = ResolverPolicy(),
+    )::Vector{TCP.SocketEndpoint}
+    kind = _network_kind(network)
+    addr = String(address)
+    op == :connect && isempty(addr) && throw(AddressError("missing address", addr))
+    host, service = split_host_port(addr)
+    port = lookup_port(resolver, network, service)
+    ips = _resolve_host_ips(resolver, network, host)
+    filtered = _apply_policy_and_network(ips, kind, policy)
+    isempty(filtered) && throw(AddressError("no suitable address", host))
+    out = TCP.SocketEndpoint[]
+    for ipaddr in filtered
+        push!(out, _with_port(ipaddr, port))
+    end
+    return out
+end
+
 function _resolve_with_deadline(
         d::HostResolver,
         network::AbstractString,
         address::AbstractString,
         deadline_ns::Int64,
     )::Vector{TCP.SocketEndpoint}
-    _ = d
-    _ = network
-    _ = address
-    _ = deadline_ns
-    return TCP.SocketEndpoint[TCP.loopback_addr(1)]
+    deadline_ns == 0 && return resolve_tcp_addrs(d.resolver, network, address; op = :connect, policy = d.policy)
+    return resolve_tcp_addrs(d.resolver, network, address; op = :connect, policy = d.policy)
 end
 
 function _partial_deadline_ns(now_ns::Int64, deadline_ns::Int64, addrs_remaining::Int)::Int64

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -10,6 +10,24 @@ export DeadlineExceededError, FD, TimerState, schedule_timer!, waittimer, _close
 
 struct DeadlineExceededError <: Exception end
 struct NoDeadlineError <: Exception end
+struct NetClosingError <: Exception end
+struct FileClosingError <: Exception end
+struct NotPollableError <: Exception end
+
+const _MUTEX_CLOSED = UInt64(1) << 0
+const _MUTEX_RLOCK = UInt64(1) << 1
+const _MUTEX_WLOCK = UInt64(1) << 2
+const _MUTEX_REF = UInt64(1) << 3
+const _MUTEX_REF_MASK = (UInt64(1) << 20 - UInt64(1)) << 3
+const _MUTEX_RWAIT = UInt64(1) << 23
+const _MUTEX_RMASK = (UInt64(1) << 20 - UInt64(1)) << 23
+const _MUTEX_WWAIT = UInt64(1) << 43
+const _MUTEX_WMASK = (UInt64(1) << 20 - UInt64(1)) << 43
+
+@inline function _closing_error(is_file::Bool)::Exception
+    is_file && return FileClosingError()
+    return NetClosingError()
+end
 
 module PollMode
 Base.@enum T::UInt8 begin
@@ -91,7 +109,148 @@ function Registration(
     return Registration(fd, token, mode, read_waiter, write_waiter, event_err, PollState(fd, token))
 end
 
+mutable struct RuntimeSema
+    lock::ReentrantLock
+    cond::Base.Threads.Condition
+    count::Int
+    function RuntimeSema()
+        lock = ReentrantLock()
+        return new(lock, Base.Threads.Condition(lock), 0)
+    end
+end
+
+function _runtime_sema_acquire!(sema::RuntimeSema)
+    lock(sema.lock)
+    try
+        while sema.count == 0
+            wait(sema.cond)
+        end
+        sema.count -= 1
+    finally
+        unlock(sema.lock)
+    end
+    return nothing
+end
+
+function _runtime_sema_release!(sema::RuntimeSema)
+    lock(sema.lock)
+    try
+        sema.count += 1
+        notify(sema.cond)
+    finally
+        unlock(sema.lock)
+    end
+    return nothing
+end
+
+function _new_binary_semaphore0()
+    sema = Base.Semaphore(1)
+    Base.acquire(sema)
+    return sema
+end
+
+mutable struct FDLock
+    @atomic state::UInt64
+    const rsema::RuntimeSema
+    const wsema::RuntimeSema
+    function FDLock()
+        return new(UInt64(0), RuntimeSema(), RuntimeSema())
+    end
+end
+
+function _fdlock_incref!(mu::FDLock)::Bool
+    while true
+        old = @atomic :acquire mu.state
+        (old & _MUTEX_CLOSED) != 0 && return false
+        new = old + _MUTEX_REF
+        (new & _MUTEX_REF_MASK) == 0 && throw(ArgumentError("too many concurrent operations on a single fd"))
+        _, ok = @atomicreplace(mu.state, old => new)
+        ok && return true
+    end
+end
+
+function _fdlock_incref_and_close!(mu::FDLock)::Bool
+    while true
+        old = @atomic :acquire mu.state
+        (old & _MUTEX_CLOSED) != 0 && return false
+        new = (old | _MUTEX_CLOSED) + _MUTEX_REF
+        (new & _MUTEX_REF_MASK) == 0 && throw(ArgumentError("too many concurrent operations on a single fd"))
+        new &= ~(_MUTEX_RMASK | _MUTEX_WMASK)
+        _, ok = @atomicreplace(mu.state, old => new)
+        ok || continue
+        wake = old
+        while (wake & _MUTEX_RMASK) != 0
+            wake -= _MUTEX_RWAIT
+            _runtime_sema_release!(mu.rsema)
+        end
+        while (wake & _MUTEX_WMASK) != 0
+            wake -= _MUTEX_WWAIT
+            _runtime_sema_release!(mu.wsema)
+        end
+        return true
+    end
+end
+
+function _fdlock_decref!(mu::FDLock)::Bool
+    while true
+        old = @atomic :acquire mu.state
+        (old & _MUTEX_REF_MASK) == 0 && throw(ArgumentError("inconsistent fd mutex state"))
+        new = old - _MUTEX_REF
+        _, ok = @atomicreplace(mu.state, old => new)
+        ok || continue
+        return (new & (_MUTEX_CLOSED | _MUTEX_REF_MASK)) == _MUTEX_CLOSED
+    end
+end
+
+function _fdlock_rwlock!(mu::FDLock, read_lock::Bool, wait_lock::Bool)::Bool
+    mutex_bit = read_lock ? _MUTEX_RLOCK : _MUTEX_WLOCK
+    mutex_wait = read_lock ? _MUTEX_RWAIT : _MUTEX_WWAIT
+    mutex_mask = read_lock ? _MUTEX_RMASK : _MUTEX_WMASK
+    mutex_sema = read_lock ? mu.rsema : mu.wsema
+    while true
+        old = @atomic :acquire mu.state
+        (old & _MUTEX_CLOSED) != 0 && return false
+        new = UInt64(0)
+        if (old & mutex_bit) == 0
+            new = (old | mutex_bit) + _MUTEX_REF
+            (new & _MUTEX_REF_MASK) == 0 && throw(ArgumentError("too many concurrent operations on a single fd"))
+        else
+            wait_lock || return false
+            new = old + mutex_wait
+            (new & mutex_mask) == 0 && throw(ArgumentError("too many concurrent operations on a single fd"))
+        end
+        _, ok = @atomicreplace(mu.state, old => new)
+        ok || continue
+        if (old & mutex_bit) == 0
+            return true
+        end
+        _runtime_sema_acquire!(mutex_sema)
+    end
+end
+
+function _fdlock_rwunlock!(mu::FDLock, read_lock::Bool)::Bool
+    mutex_bit = read_lock ? _MUTEX_RLOCK : _MUTEX_WLOCK
+    mutex_wait = read_lock ? _MUTEX_RWAIT : _MUTEX_WWAIT
+    mutex_mask = read_lock ? _MUTEX_RMASK : _MUTEX_WMASK
+    mutex_sema = read_lock ? mu.rsema : mu.wsema
+    while true
+        old = @atomic :acquire mu.state
+        ((old & mutex_bit) == 0 || (old & _MUTEX_REF_MASK) == 0) && throw(ArgumentError("inconsistent fd mutex state"))
+        new = (old & ~mutex_bit) - _MUTEX_REF
+        if (old & mutex_mask) != 0
+            new -= mutex_wait
+        end
+        _, ok = @atomicreplace(mu.state, old => new)
+        ok || continue
+        if (old & mutex_mask) != 0
+            _runtime_sema_release!(mutex_sema)
+        end
+        return (new & (_MUTEX_CLOSED | _MUTEX_REF_MASK)) == _MUTEX_CLOSED
+    end
+end
+
 mutable struct FD
+    fdlock::FDLock
     sysfd::Int32
     pd::PollState
     csema::Base.Semaphore
@@ -106,9 +265,10 @@ mutable struct FD
             is_file::Bool = false,
         )
         return new(
+            FDLock(),
             Int32(sysfd),
-            PollState(sysfd),
-            Base.Semaphore(0),
+            PollState(),
+            _new_binary_semaphore0(),
             false,
             is_stream,
             zero_read_is_eof,
@@ -139,6 +299,9 @@ read!(pfd::FD, buf::Vector{UInt8}) = throw(EOFError())
 _read_ptr_some!(pfd::FD, ptr::Ptr{UInt8}, nbytes::Int) = throw(EOFError())
 
 const _POLL_NO_ERROR = Int32(0)
+const _POLL_ERR_CLOSING = Int32(1)
+const _POLL_ERR_TIMEOUT = Int32(2)
+const _POLL_ERR_NOT_POLLABLE = Int32(3)
 const _REGISTRATIONS = IdDict{PollState, Registration}()
 const _NEXT_TOKEN = Ref{UInt64}(UInt64(0))
 
@@ -217,11 +380,48 @@ function _poll_registration(pd::PollState)::Registration
     return reg
 end
 
-_check_error(pd::PollState, mode::PollMode.T)::Int32 = _POLL_NO_ERROR
-_convert_poll_error!(res::Int32, is_file::Bool) = nothing
+function _convert_poll_error!(res::Int32, is_file::Bool)
+    res == _POLL_NO_ERROR && return nothing
+    res == _POLL_ERR_CLOSING && throw(_closing_error(is_file))
+    res == _POLL_ERR_TIMEOUT && throw(DeadlineExceededError())
+    res == _POLL_ERR_NOT_POLLABLE && throw(NotPollableError())
+    throw(ArgumentError("invalid poll status"))
+end
+
+function _refresh_event_err!(pd::PollState)
+    (@atomic :acquire pd.pollable) || return nothing
+    registration = current_registration(pd)
+    registration === nothing && return nothing
+    has_event_error = @atomic :acquire registration.event_err
+    @atomic :release pd.event_err = has_event_error
+    return nothing
+end
+
+function _check_error(pd::PollState, mode::PollMode.T)::Int32
+    (@atomic :acquire pd.closing) && return _POLL_ERR_CLOSING
+    if _mode_has_read(mode)
+        (@atomic :acquire pd.rd_ns) < 0 && return _POLL_ERR_TIMEOUT
+    end
+    if _mode_has_write(mode)
+        (@atomic :acquire pd.wd_ns) < 0 && return _POLL_ERR_TIMEOUT
+    end
+    if _mode_has_read(mode)
+        _refresh_event_err!(pd)
+        (@atomic :acquire pd.event_err) && return _POLL_ERR_NOT_POLLABLE
+    end
+    return _POLL_NO_ERROR
+end
+
 preparewrite(pd::PollState, is_file::Bool = false) = nothing
-_fd_write_lock!(fd::FD) = nothing
-_fd_write_unlock!(fd::FD) = nothing
+function _fd_write_lock!(fd::FD)
+    _fdlock_rwlock!(fd.fdlock, false, true) || throw(_closing_error(fd.is_file))
+    return nothing
+end
+
+function _fd_write_unlock!(fd::FD)
+    _fdlock_rwunlock!(fd.fdlock, false) || return nothing
+    return nothing
+end
 pollable(pd::PollState)::Bool = @atomic :acquire pd.pollable
 
 function _wake_waiters!(pd::PollState, mode::PollMode.T)
@@ -324,6 +524,7 @@ end
 
 function _set_deadline_impl!(fd::FD, deadline_ns::Integer, mode::PollMode.T)
     deadline = Int64(deadline_ns)
+    _fdlock_incref!(fd.fdlock) || throw(_closing_error(fd.is_file))
     try
         pd = fd.pd
         (@atomic :acquire pd.pollable) || throw(NoDeadlineError())
@@ -374,7 +575,7 @@ function _set_deadline_impl!(fd::FD, deadline_ns::Integer, mode::PollMode.T)
             _wake_waiters!(pd, PollMode.WRITE)
         end
     finally
-        nothing
+        _fdlock_decref!(fd.fdlock)
     end
     return nothing
 end
@@ -385,7 +586,9 @@ function set_write_deadline!(fd::FD, deadline_ns::Integer)
 end
 
 function Base.close(fd::FD)
+    _fdlock_incref_and_close!(fd.fdlock) || throw(_closing_error(fd.is_file))
     evict!(fd.pd)
+    _fdlock_decref!(fd.fdlock)
     close(fd.pd)
     return nothing
 end

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -4888,6 +4888,20 @@ println("[windows-compiler-bug] julia threads: $(Threads.nthreads())")
 @test Reseau.TCP === TCP
 @test Reseau.TLS === TLS
 
+_probe("kwsort infer local_addr v4") do
+    tt = (NamedTuple{(:local_addr,), Tuple{NC.SocketAddrV4}}, typeof(NC.connect), String, String)
+    Base.precompile(Tuple{typeof(Core.kwcall), tt...})
+    Base.code_typed(Core.kwcall, tt)
+    return nothing
+end
+
+_probe("kwsort infer local_addr v6") do
+    tt = (NamedTuple{(:local_addr,), Tuple{NC.SocketAddrV6}}, typeof(NC.connect), String, String)
+    Base.precompile(Tuple{typeof(Core.kwcall), tt...})
+    Base.code_typed(Core.kwcall, tt)
+    return nothing
+end
+
 _probe("tcp kwcall local_addr v4") do
     NC.connect("tcp", "127.0.0.1:1"; local_addr = NC.loopback_addr(0))
 end

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -215,9 +215,11 @@ module TCP
 using ..IOPoll
 using ..SocketOps
 
-export connect, SocketAddr, SocketAddrV4, SocketAddrV6, SocketEndpoint, Conn, ConnectCanceledError, loopback_addr, loopback_addr6, _connect_socketaddr_impl
+export connect, listen, accept, SocketAddr, SocketAddrV4, SocketAddrV6, SocketEndpoint, Conn, Listener, ConnectCanceledError, loopback_addr, any_addr, loopback_addr6, any_addr6, local_addr, remote_addr, addr, _connect_socketaddr_impl
 
 function connect end
+function listen end
+function accept end
 
 abstract type SocketAddr end
 
@@ -248,10 +250,18 @@ struct Conn
     fd::FD
 end
 
+struct Listener
+    fd::FD
+end
+
 struct ConnectCanceledError <: Exception end
 
 function loopback_addr(port::Integer)::SocketAddrV4
     return SocketAddrV4((UInt8(127), UInt8(0), UInt8(0), UInt8(1)), UInt16(port))
+end
+
+function any_addr(port::Integer)::SocketAddrV4
+    return SocketAddrV4((UInt8(0), UInt8(0), UInt8(0), UInt8(0)), UInt16(port))
 end
 
 function loopback_addr6(port::Integer; scope_id::Integer = 0)::SocketAddrV6
@@ -264,6 +274,10 @@ function loopback_addr6(port::Integer; scope_id::Integer = 0)::SocketAddrV6
         UInt16(port),
         UInt32(scope_id),
     )
+end
+
+function any_addr6(port::Integer; scope_id::Integer = 0)::SocketAddrV6
+    return SocketAddrV6(ntuple(_ -> UInt8(0), 16), UInt16(port), UInt32(scope_id))
 end
 
 @inline _connect_canceled(::Nothing)::Bool = false
@@ -415,16 +429,58 @@ function connect(remote_addr::SocketAddr, local_addr::Union{Nothing, SocketAddr}
     return _connect_socketaddr_impl(remote_addr, local_addr, Int64(0), nothing)
 end
 
+function listen(local_addr::SocketAddr; backlog::Integer = 128, reuseaddr::Bool = true)::Listener
+    _ = backlog
+    _ = reuseaddr
+    family = _addr_family(local_addr)
+    fd = open_tcp_fd!(; family = family)
+    try
+        SocketOps.bind_socket(fd.pfd.sysfd, _to_sockaddr(local_addr))
+        IOPoll.register!(fd.pfd)
+        fd.laddr = local_addr
+        return Listener(fd)
+    catch
+        close(fd)
+        rethrow()
+    end
+end
+
+function accept(listener::Listener)::Conn
+    child = _new_netfd(
+        Int32(2);
+        family = listener.fd.family,
+        sotype = listener.fd.sotype,
+        net = listener.fd.net,
+        is_connected = true,
+    )
+    child.laddr = listener.fd.laddr
+    child.raddr = loopback_addr(1)
+    return Conn(child)
+end
+
+function local_addr(conn::Conn)::Union{Nothing, SocketAddr}
+    return conn.fd.laddr
+end
+
+function remote_addr(conn::Conn)::Union{Nothing, SocketAddr}
+    return conn.fd.raddr
+end
+
+function addr(listener::Listener)::Union{Nothing, SocketAddr}
+    return listener.fd.laddr
+end
+
 end
 
 Base.close(fd::TCP.FD) = nothing
 Base.close(::TCP.Conn) = nothing
+Base.close(::TCP.Listener) = nothing
 
 module HostResolvers
 
 using ..IOPoll
 using ..TCP
-import ..TCP: connect
+import ..TCP: connect, listen
 
 struct AddressError <: Exception
     err::String
@@ -1273,6 +1329,49 @@ function connect(
         kwargs...,
     )::TCP.Conn
     return connect("tcp", address; kwargs...)
+end
+
+function listen(
+        d::HostResolver,
+        network::AbstractString,
+        address::AbstractString;
+        backlog::Integer = 128,
+        reuseaddr::Bool = true,
+    )::TCP.Listener
+    try
+        _network_kind(network)
+    catch err
+        throw(_wrap_op_error("listen", network, nothing, nothing, _as_exception(err)))
+    end
+    addrs = try
+        resolve_tcp_addrs(d.resolver, network, address; op = :listen, policy = d.policy)
+    catch err
+        throw(_wrap_op_error("listen", network, nothing, nothing, _as_exception(err)))
+    end
+    first_err::Union{Nothing, Exception} = nothing
+    for local_addr in addrs
+        try
+            return TCP.listen(local_addr; backlog = backlog, reuseaddr = reuseaddr)
+        catch err
+            first_err === nothing && (first_err = _as_exception(err))
+        end
+    end
+    throw(_wrap_op_error(
+        "listen",
+        network,
+        nothing,
+        isempty(addrs) ? nothing : addrs[1],
+        first_err === nothing ? AddressError("missing address", String(address)) : first_err::Exception,
+    ))
+end
+
+function listen(
+        network::AbstractString,
+        address::AbstractString;
+        backlog::Integer = 128,
+        reuseaddr::Bool = true,
+    )::TCP.Listener
+    return listen(HostResolver(), network, address; backlog = backlog, reuseaddr = reuseaddr)
 end
 
 end

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -6,6 +6,26 @@ export DeadlineExceededError
 
 struct DeadlineExceededError <: Exception end
 
+register!(pfd) = nothing
+set_write_deadline!(pfd, deadline_ns::Int64) = nothing
+connect!(pfd, addrbuf, addrlen) = nothing
+waitwrite(pd) = nothing
+
+end
+
+module SocketOps
+
+export AF_INET, AF_INET6, SOCK_STREAM, open_socket, bind_socket, set_nonblocking!, sockaddr_bytes
+
+const AF_INET = Int32(2)
+const AF_INET6 = Int32(23)
+const SOCK_STREAM = Int32(1)
+
+open_socket(family::Int32, sotype::Int32) = Int32(1)
+bind_socket(sysfd::Int32, sockaddr) = nothing
+set_nonblocking!(sysfd::Int32, enabled::Bool) = nothing
+sockaddr_bytes(sockaddr) = UInt8[0x00]
+
 end
 
 module TCP
@@ -29,7 +49,23 @@ end
 
 const SocketEndpoint = Union{SocketAddrV4, SocketAddrV6}
 
-struct Conn end
+mutable struct PollFD
+    sysfd::Int32
+end
+
+mutable struct FD
+    pfd::PollFD
+    family::Int32
+    sotype::Int32
+    net::Symbol
+    @atomic is_connected::Bool
+    laddr::Union{Nothing, SocketAddr}
+    raddr::Union{Nothing, SocketAddr}
+end
+
+struct Conn
+    fd::FD
+end
 
 struct ConnectCanceledError <: Exception end
 
@@ -49,22 +85,141 @@ function loopback_addr6(port::Integer; scope_id::Integer = 0)::SocketAddrV6
     )
 end
 
+@inline _connect_canceled(::Nothing)::Bool = false
+@inline _connect_canceled(::Any)::Bool = false
+@inline _connect_wait_register!(::Any, ::FD) = nothing
+@inline _connect_wait_unregister!(::Any, ::FD) = nothing
+@inline _addr_family(::SocketAddrV4)::Int32 = SocketOps.AF_INET
+@inline _addr_family(::SocketAddrV6)::Int32 = SocketOps.AF_INET6
+@inline _to_sockaddr(addr::SocketAddr) = addr
+
+function _new_netfd(
+        sysfd::Int32;
+        family::Int32 = SocketOps.AF_INET,
+        sotype::Int32 = SocketOps.SOCK_STREAM,
+        net::Symbol = :tcp,
+        is_connected::Bool = false,
+    )::FD
+    return FD(PollFD(sysfd), family, sotype, net, is_connected, nothing, nothing)
+end
+
+function _finalize_connected_addrs!(fd::FD, fallback_remote::SocketAddr)
+    fd.raddr = fallback_remote
+    @atomic :release fd.is_connected = true
+    return nothing
+end
+
+_apply_default_tcp_opts!(fd::FD) = nothing
+
+function _wait_connect_complete!(
+        fd::FD,
+        remote_addr::SocketAddr,
+        cancel_state = nothing,
+    )
+    _connect_wait_register!(cancel_state, fd)
+    try
+        @static if Sys.iswindows()
+            sockaddr = _to_sockaddr(remote_addr)
+            addrbuf = SocketOps.sockaddr_bytes(sockaddr)
+            addrlen = Int32(1)
+            while true
+                if _connect_canceled(cancel_state)
+                    throw(ConnectCanceledError())
+                end
+                try
+                    IOPoll.connect!(fd.pfd, addrbuf, addrlen)
+                catch err
+                    ex = err::Exception
+                    if ex isa IOPoll.DeadlineExceededError && _connect_canceled(cancel_state)
+                        throw(ConnectCanceledError())
+                    end
+                    rethrow(ex)
+                end
+                _finalize_connected_addrs!(fd, remote_addr)
+                return nothing
+            end
+        end
+        while true
+            if _connect_canceled(cancel_state)
+                throw(ConnectCanceledError())
+            end
+            try
+                IOPoll.waitwrite(fd.pfd)
+            catch err
+                ex = err::Exception
+                if ex isa IOPoll.DeadlineExceededError && _connect_canceled(cancel_state)
+                    throw(ConnectCanceledError())
+                end
+                rethrow(ex)
+            end
+            _finalize_connected_addrs!(fd, remote_addr)
+            return nothing
+        end
+    finally
+        _connect_wait_unregister!(cancel_state, fd)
+    end
+end
+
+@inline function _bind_connectex_local!(fd::FD, family::Int32)
+    _ = fd
+    _ = family
+    return nothing
+end
+
+function open_tcp_fd!(; family::Int32 = SocketOps.AF_INET)::FD
+    sysfd = SocketOps.open_socket(family, SocketOps.SOCK_STREAM)
+    return _new_netfd(sysfd; family = family, sotype = SocketOps.SOCK_STREAM, net = :tcp, is_connected = false)
+end
+
 function _connect_socketaddr_impl(
         remote_addr::SocketAddr,
         local_addr::Union{Nothing, SocketAddr},
         attempt_deadline::Int64,
         state,
     )::Conn
-    _ = attempt_deadline
-    _ = state
-    if local_addr isa SocketAddrV6 && remote_addr isa SocketAddrV4
-        throw(ArgumentError("address family mismatch"))
+    family = _addr_family(remote_addr)
+    if local_addr !== nothing && _addr_family(local_addr) != family
+        throw(ArgumentError("local and remote address families must match"))
     end
-    throw(ArgumentError("connect failed"))
+    fd = open_tcp_fd!(; family = family)
+    try
+        if local_addr !== nothing
+            SocketOps.bind_socket(fd.pfd.sysfd, _to_sockaddr(local_addr))
+        elseif Sys.iswindows()
+            _bind_connectex_local!(fd, family)
+        end
+        SocketOps.set_nonblocking!(fd.pfd.sysfd, true)
+        @static if Sys.iswindows()
+            IOPoll.register!(fd.pfd)
+            if attempt_deadline != 0
+                IOPoll.set_write_deadline!(fd.pfd, attempt_deadline)
+            end
+            try
+                _wait_connect_complete!(fd, remote_addr, state)
+            finally
+                if attempt_deadline != 0
+                    try
+                        IOPoll.set_write_deadline!(fd.pfd, Int64(0))
+                    catch
+                    end
+                end
+            end
+            _apply_default_tcp_opts!(fd)
+            return Conn(fd)
+        end
+        IOPoll.register!(fd.pfd)
+        _wait_connect_complete!(fd, remote_addr, state)
+        _apply_default_tcp_opts!(fd)
+        return Conn(fd)
+    catch
+        close(fd)
+        rethrow()
+    end
 end
 
 end
 
+Base.close(fd::TCP.FD) = nothing
 Base.close(::TCP.Conn) = nothing
 
 module HostResolvers
@@ -119,6 +274,13 @@ mutable struct DNSRaceState
         return new(false)
     end
 end
+
+@inline function TCP._connect_canceled(state::DNSRaceState)::Bool
+    return @atomic :acquire state.done
+end
+
+TCP._connect_wait_register!(state::DNSRaceState, fd::TCP.FD) = nothing
+TCP._connect_wait_unregister!(state::DNSRaceState, fd::TCP.FD) = nothing
 
 struct HostResolver{R <: AbstractResolver}
     timeout_ns::Int64

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -1,9 +1,31 @@
 using Test
 using Reseau
 
+const NC = Reseau.TCP
+
 println("[windows-compiler-bug] loaded Reseau")
 println("[windows-compiler-bug] julia threads: $(Threads.nthreads())")
 
+function _probe(f, label::AbstractString)
+    println("[windows-compiler-bug] probe start: $(label)")
+    try
+        f()
+        println("[windows-compiler-bug] probe done: $(label)")
+    catch ex
+        println("[windows-compiler-bug] probe error ($(label)): $(typeof(ex))")
+    end
+    return nothing
+end
+
 @test Reseau.TCP === TCP
 @test Reseau.TLS === TLS
+
+_probe("tcp kwcall local_addr v4") do
+    NC.connect("tcp", "127.0.0.1:1"; local_addr = NC.loopback_addr(0))
+end
+
+_probe("tcp kwcall local_addr v6 mismatch") do
+    NC.connect("tcp", "127.0.0.1:1"; local_addr = NC.loopback_addr6(0))
+end
+
 @test true

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -10,6 +10,14 @@ export DeadlineExceededError, FD, TimerState, schedule_timer!, waittimer, _close
 
 struct DeadlineExceededError <: Exception end
 
+module PollMode
+Base.@enum T::UInt8 begin
+    READ = 0x01
+    WRITE = 0x02
+    READWRITE = 0x03
+end
+end
+
 module PollWaiterState
 Base.@enum T::UInt8 begin
     EMPTY = 0x00
@@ -31,6 +39,16 @@ mutable struct PollWaiter
     task::Union{Nothing, Task}
     function PollWaiter()
         return new(PollWaiterState.EMPTY, PollWakeReason.READY, nothing)
+    end
+end
+
+mutable struct Registration
+    fd::Int32
+    token::UInt64
+    read_waiter::PollWaiter
+    write_waiter::PollWaiter
+    function Registration(fd::Int32, token::UInt64)
+        return new(fd, token, PollWaiter(), PollWaiter())
     end
 end
 
@@ -117,6 +135,94 @@ _close_timer!(timer::TimerState) = nothing
 sleep(seconds::Real) = nothing
 read!(pfd::FD, buf::Vector{UInt8}) = throw(EOFError())
 _read_ptr_some!(pfd::FD, ptr::Ptr{UInt8}, nbytes::Int) = throw(EOFError())
+
+const _POLL_NO_ERROR = Int32(0)
+const _REGISTRATIONS = IdDict{PollState, Registration}()
+
+function register!(pfd::FD)
+    @atomic :release pfd.pd.pollable = true
+    reg = Registration(pfd.sysfd, UInt64(1))
+    _REGISTRATIONS[pfd.pd] = reg
+    return nothing
+end
+
+function current_registration(pd::PollState)
+    return get(() -> nothing, _REGISTRATIONS, pd)
+end
+
+function _poll_registration(pd::PollState)::Registration
+    reg = current_registration(pd)
+    reg === nothing && throw(SystemError("iopoll wait", Int(Base.Libc.EBADF)))
+    return reg
+end
+
+_check_error(pd::PollState, mode::PollMode.T)::Int32 = _POLL_NO_ERROR
+_convert_poll_error!(res::Int32, is_file::Bool) = nothing
+preparewrite(pd::PollState, is_file::Bool = false) = nothing
+_fd_write_lock!(fd::FD) = nothing
+_fd_write_unlock!(fd::FD) = nothing
+
+function pollwait!(waiter::PollWaiter)::PollWakeReason.T
+    return PollWakeReason.READY
+end
+
+function pollnotify!(waiter::PollWaiter, reason::PollWakeReason.T = PollWakeReason.READY)::Bool
+    @atomic :release waiter.reason = reason
+    return true
+end
+
+function arm_waiter!(registration::Registration, mode::PollMode.T)
+    if mode == PollMode.WRITE
+        pollnotify!(registration.write_waiter, PollWakeReason.READY)
+    else
+        pollnotify!(registration.read_waiter, PollWakeReason.READY)
+    end
+    return nothing
+end
+
+function _iocp_submit_connect!(registration::Registration, addrbuf::Vector{UInt8}, addrlen::Int32)::Int32
+    _ = registration
+    _ = addrbuf
+    _ = addrlen
+    return Int32(0)
+end
+
+function _iocp_finish_connect!(registration::Registration)::Int32
+    _ = registration
+    return Int32(0)
+end
+
+function _iocp_cancel_mode!(registration::Registration, mode::PollMode.T)::Bool
+    _ = registration
+    _ = mode
+    return false
+end
+
+function connect!(fd::FD, addrbuf::Vector{UInt8}, addrlen::Int32)
+    _fd_write_lock!(fd)
+    try
+        preparewrite(fd.pd, fd.is_file)
+        registration = _poll_registration(fd.pd)
+        errno = _iocp_submit_connect!(registration, addrbuf, addrlen)
+        errno == Int32(0) || throw(SystemError("connectex", Int(errno)))
+        try
+            pollwait!(registration.write_waiter)
+            _convert_poll_error!(_check_error(fd.pd, PollMode.WRITE), fd.is_file)
+        catch err
+            ex = err::Exception
+            if _iocp_cancel_mode!(registration, PollMode.WRITE)
+                pollwait!(registration.write_waiter)
+            end
+            _ = _iocp_finish_connect!(registration)
+            rethrow(ex)
+        end
+        errno = _iocp_finish_connect!(registration)
+        errno == Int32(0) || throw(SystemError("connectex", Int(errno)))
+    finally
+        _fd_write_unlock!(fd)
+    end
+    return nothing
+end
 
 end
 

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -1588,6 +1588,7 @@ const _ERROR_INVALID_PARAMETER = UInt32(87)
 const _ERROR_NOT_ENOUGH_MEMORY = UInt32(8)
 const _ERROR_INVALID_HANDLE = UInt32(6)
 const _ERROR_NOT_SUPPORTED = UInt32(50)
+const _SO_UPDATE_ACCEPT_CONTEXT = Int32(0x700b)
 const _SO_UPDATE_CONNECT_CONTEXT = Int32(0x7010)
 const _SIO_GET_EXTENSION_FUNCTION_POINTER = UInt32(0xC8000006)
 const _IPPROTO_UDP = Int32(17)
@@ -1929,9 +1930,23 @@ function _load_extension_ptr!(sock::Int32, guid::Guid)::Ptr{Cvoid}
     guid_ref = Ref(guid)
     out_ref = Ref{Ptr{Cvoid}}(C_NULL)
     bytes_ref = Ref{UInt32}(UInt32(0))
-    _ = sock
-    _ = guid_ref
-    _ = bytes_ref
+    rc = GC.@preserve guid_ref out_ref bytes_ref begin
+        ccall(
+            (:WSAIoctl, _WS2_32),
+            Int32,
+            (UInt, UInt32, Ref{Guid}, UInt32, Ref{Ptr{Cvoid}}, UInt32, Ref{UInt32}, Ptr{Cvoid}, Ptr{Cvoid}),
+            _socket_value(sock),
+            _SIO_GET_EXTENSION_FUNCTION_POINTER,
+            guid_ref,
+            UInt32(sizeof(Guid)),
+            out_ref,
+            UInt32(sizeof(Ptr{Cvoid})),
+            bytes_ref,
+            C_NULL,
+            C_NULL,
+        )
+    end
+    rc == 0 || return C_NULL
     return out_ref[]
 end
 
@@ -1953,6 +1968,8 @@ function _load_sendrecvmsg_ptrs!()::Tuple{Ptr{Cvoid}, Ptr{Cvoid}}
         finally
             close_socket_nothrow(sock)
         end
+        recv_ptr == C_NULL && _throw_errno("WSAIoctl(WSARecvMsg)", _map_wsa_errno(_wsa_get_last_error()))
+        send_ptr == C_NULL && _throw_errno("WSAIoctl(WSASendMsg)", _map_wsa_errno(_wsa_get_last_error()))
         _wsarecvmsg_ptr[] = recv_ptr
         _wsasendmsg_ptr[] = send_ptr
         return send_ptr, recv_ptr
@@ -2354,8 +2371,21 @@ function _recv_msg_simple!(fd::Int32, msg_ref::Ref{MsgHdr}, flags::Int32)::Cssiz
     bufs = _wsabufs_from_msghdr(msg)
     bytes_ref = Ref{UInt32}(UInt32(0))
     flags_ref = Ref{UInt32}(_cint_bits_u32(flags))
-    _ = fd
-    _ = bufs
+    n = GC.@preserve bufs bytes_ref flags_ref begin
+        ccall(
+            (:WSARecv, _WS2_32),
+            Int32,
+            (UInt, Ptr{WSABuf}, UInt32, Ref{UInt32}, Ref{UInt32}, Ptr{Cvoid}, Ptr{Cvoid}),
+            _socket_value(fd),
+            _wsabuf_ptr(bufs),
+            UInt32(length(bufs)),
+            bytes_ref,
+            flags_ref,
+            C_NULL,
+            C_NULL,
+        )
+    end
+    n == _SOCKET_ERROR && return Cssize_t(-1)
     msg_ref[] = MsgHdr(
         msg.msg_name,
         msg.msg_namelen,
@@ -2372,9 +2402,21 @@ function _send_msg_simple!(fd::Int32, msg_ref::Ref{MsgHdr}, flags::Int32)::Cssiz
     msg = msg_ref[]
     bufs = _wsabufs_from_msghdr(msg)
     bytes_ref = Ref{UInt32}(UInt32(0))
-    _ = fd
-    _ = bufs
-    _ = flags
+    n = GC.@preserve bufs bytes_ref begin
+        ccall(
+            (:WSASend, _WS2_32),
+            Int32,
+            (UInt, Ptr{WSABuf}, UInt32, Ref{UInt32}, UInt32, Ptr{Cvoid}, Ptr{Cvoid}),
+            _socket_value(fd),
+            _wsabuf_ptr(bufs),
+            UInt32(length(bufs)),
+            bytes_ref,
+            _cint_bits_u32(flags),
+            C_NULL,
+            C_NULL,
+        )
+    end
+    n == _SOCKET_ERROR && return Cssize_t(-1)
     return Cssize_t(bytes_ref[])
 end
 
@@ -2384,8 +2426,19 @@ function _recv_msg_ext!(fd::Int32, msg_ref::Ref{MsgHdr}, flags::Int32)::Cssize_t
     bufs = _wsabufs_from_msghdr(msg)
     wmsg = Ref(_wsamsg_from_msghdr(msg, bufs, flags))
     bytes_ref = Ref{UInt32}(UInt32(0))
-    _ = fd
-    _ = recv_ptr
+    n = GC.@preserve bufs wmsg bytes_ref begin
+        ccall(
+            recv_ptr,
+            Int32,
+            (UInt, Ref{WSAMsg}, Ref{UInt32}, Ptr{Cvoid}, Ptr{Cvoid}),
+            _socket_value(fd),
+            wmsg,
+            bytes_ref,
+            C_NULL,
+            C_NULL,
+        )
+    end
+    n == _SOCKET_ERROR && return Cssize_t(-1)
     _store_wsamsg_back!(msg_ref, msg, wmsg[])
     return Cssize_t(bytes_ref[])
 end
@@ -2396,9 +2449,20 @@ function _send_msg_ext!(fd::Int32, msg_ref::Ref{MsgHdr}, flags::Int32)::Cssize_t
     bufs = _wsabufs_from_msghdr(msg)
     wmsg = Ref(_wsamsg_from_msghdr(msg, bufs, flags))
     bytes_ref = Ref{UInt32}(UInt32(0))
-    _ = fd
-    _ = send_ptr
-    _ = wmsg
+    n = GC.@preserve bufs wmsg bytes_ref begin
+        ccall(
+            send_ptr,
+            Int32,
+            (UInt, Ref{WSAMsg}, UInt32, Ref{UInt32}, Ptr{Cvoid}, Ptr{Cvoid}),
+            _socket_value(fd),
+            wmsg,
+            UInt32(0),
+            bytes_ref,
+            C_NULL,
+            C_NULL,
+        )
+    end
+    n == _SOCKET_ERROR && return Cssize_t(-1)
     return Cssize_t(bytes_ref[])
 end
 
@@ -2423,12 +2487,36 @@ accept_socket(fd::Int32)::Int32 = Int32(3)
 close_socket(fd::Int32) = nothing
 
 function finish_accept_ex!(listener_fd::Int32, acceptfd::Int32, addrbuf::Vector{UInt8})::AcceptPeer
-    _ = listener_fd
-    _ = acceptfd
-    GC.@preserve addrbuf begin
-        addrptr = Ptr{UInt8}(pointer(addrbuf))
-        return _decode_accept_peer(addrptr, SockLen(length(addrbuf)))
+    listener_ref = Ref{UInt}(_socket_value(listener_fd))
+    GC.@preserve listener_ref begin
+        _set_sockopt_ptr!(
+            acceptfd,
+            _SO_UPDATE_ACCEPT_CONTEXT,
+            Ptr{UInt8}(Base.unsafe_convert(Ptr{UInt}, listener_ref)),
+            sizeof(UInt),
+        )
     end
+    local_ptr = Ref{Ptr{UInt8}}(C_NULL)
+    local_len = Ref{Int32}(0)
+    remote_ptr = Ref{Ptr{UInt8}}(C_NULL)
+    remote_len = Ref{Int32}(0)
+    GC.@preserve addrbuf begin
+        _ = ccall(
+            (:GetAcceptExSockaddrs, _MSWSOCK),
+            Cvoid,
+            (Ptr{UInt8}, UInt32, UInt32, UInt32, Ref{Ptr{UInt8}}, Ref{Int32}, Ref{Ptr{UInt8}}, Ref{Int32}),
+            pointer(addrbuf),
+            UInt32(0),
+            UInt32(_ACCEPT_ADDRBUF_LEN),
+            UInt32(_ACCEPT_ADDRBUF_LEN),
+            local_ptr,
+            local_len,
+            remote_ptr,
+            remote_len,
+        )
+    end
+    remote_ptr[] == C_NULL && return nothing
+    return _decode_accept_peer(remote_ptr[], SockLen(remote_len[]))
 end
 
 function __init__()

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -862,7 +862,7 @@ end
 
 module SocketOps
 
-export AF_INET, AF_INET6, SOCK_STREAM, IPPROTO_TCP, TCP_NODELAY, SOL_SOCKET, SO_KEEPALIVE, SO_ERROR, SockAddrIn, SockAddrIn6, open_socket, bind_socket, connect_socket, set_nonblocking!, set_sockopt_int, get_socket_error, update_connect_context!, sockaddr_in, sockaddr_in_any, sockaddr_in6, sockaddr_in6_any, sockaddr_bytes
+export AF_INET, AF_INET6, SOCK_STREAM, IPPROTO_TCP, TCP_NODELAY, SOL_SOCKET, SO_KEEPALIVE, SO_ERROR, SockAddrIn, SockAddrIn6, AcceptPeer, open_socket, bind_socket, connect_socket, set_nonblocking!, set_sockopt_int, get_socket_error, update_connect_context!, sockaddr_in, sockaddr_in_any, sockaddr_in6, sockaddr_in6_any, sockaddr_bytes
 
 const SockLen = Int32
 const AF_INET = Int32(2)
@@ -948,6 +948,8 @@ struct SockAddrIn6
     sin6_addr::NTuple{16, UInt8}
     sin6_scope_id::UInt32
 end
+
+const AcceptPeer = Union{SockAddrIn, SockAddrIn6}
 
 struct _WSAData
     wVersion::UInt16
@@ -1410,8 +1412,28 @@ end
     )
 end
 
+@inline function sockaddr_in_port(addr::SockAddrIn)::UInt16
+    return _hton16(addr.sin_port)
+end
+
 @inline sockaddr_in6_ip(addr::SockAddrIn6)::NTuple{16, UInt8} = addr.sin6_addr
+@inline function sockaddr_in6_port(addr::SockAddrIn6)::UInt16
+    return _hton16(addr.sin6_port)
+end
 @inline sockaddr_in6_scopeid(addr::SockAddrIn6)::UInt32 = addr.sin6_scope_id
+
+listen_socket(fd::Int32, backlog::Integer) = nothing
+get_socket_name_in(fd::Int32)::SockAddrIn = sockaddr_in_any(0)
+get_socket_name_in6(fd::Int32)::SockAddrIn6 = sockaddr_in6_any(0)
+get_peer_name_in(fd::Int32)::SockAddrIn = sockaddr_in((UInt8(127), UInt8(0), UInt8(0), UInt8(1)), 1)
+get_peer_name_in6(fd::Int32)::SockAddrIn6 = sockaddr_in6((
+        UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+        UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+        UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+        UInt8(0), UInt8(0), UInt8(0), UInt8(1),
+    ), 1)
+last_error() = Int32(Base.Libc.EAGAIN)
+recv_from!(fd::Int32, ptr::Ptr{UInt8}, nbytes, flags)::Int = 0
 
 end
 
@@ -1511,6 +1533,35 @@ end
     return SocketOps.sockaddr_in6(addr.ip, Int(addr.port); scope_id = Int(addr.scope_id))
 end
 
+@inline function _from_sockaddr(addr::SocketOps.SockAddrIn)::SocketAddrV4
+    return SocketAddrV4(SocketOps.sockaddr_in_ip(addr), Int(SocketOps.sockaddr_in_port(addr)))
+end
+
+@inline function _from_sockaddr(addr::SocketOps.SockAddrIn6)::SocketAddrV6
+    return SocketAddrV6(
+        SocketOps.sockaddr_in6_ip(addr),
+        Int(SocketOps.sockaddr_in6_port(addr));
+        scope_id = Int(SocketOps.sockaddr_in6_scopeid(addr)),
+    )
+end
+
+@inline function _set_remote_addr_from_accept!(fd::FD, peer_addr::SocketOps.AcceptPeer)
+    if peer_addr isa SocketOps.SockAddrIn
+        fd.raddr = _from_sockaddr(peer_addr::SocketOps.SockAddrIn)
+        return nothing
+    end
+    if peer_addr isa SocketOps.SockAddrIn6
+        fd.raddr = _from_sockaddr(peer_addr::SocketOps.SockAddrIn6)
+        return nothing
+    end
+    _set_remote_addr!(fd)
+    return nothing
+end
+
+@inline function _is_accept_retry_errno(errno::Int32)::Bool
+    return errno == Int32(Base.Libc.EINTR) || errno == Int32(Base.Libc.ECONNABORTED)
+end
+
 function _new_netfd(
         sysfd::Int32;
         family::Int32 = SocketOps.AF_INET,
@@ -1521,8 +1572,36 @@ function _new_netfd(
     return FD(IOPoll.FD(sysfd), family, sotype, net, is_connected, nothing, nothing)
 end
 
+function _set_local_addr!(fd::FD)
+    if fd.family == SocketOps.AF_INET6
+        fd.laddr = _from_sockaddr(SocketOps.get_socket_name_in6(fd.pfd.sysfd))
+        return nothing
+    end
+    fd.laddr = _from_sockaddr(SocketOps.get_socket_name_in(fd.pfd.sysfd))
+    return nothing
+end
+
+function _set_remote_addr!(fd::FD)
+    if fd.family == SocketOps.AF_INET6
+        fd.raddr = _from_sockaddr(SocketOps.get_peer_name_in6(fd.pfd.sysfd))
+        return nothing
+    end
+    fd.raddr = _from_sockaddr(SocketOps.get_peer_name_in(fd.pfd.sysfd))
+    return nothing
+end
+
 function _finalize_connected_addrs!(fd::FD, fallback_remote::SocketAddr)
-    fd.raddr = fallback_remote
+    _set_local_addr!(fd)
+    if fd.raddr === nothing
+        try
+            _set_remote_addr!(fd)
+        catch err
+            if !(err isa SystemError) || !_is_temporary_unconnected(err)
+                rethrow(err)
+            end
+            fd.raddr = fallback_remote
+        end
+    end
     @atomic :release fd.is_connected = true
     return nothing
 end
@@ -1791,8 +1870,12 @@ function accept(listener::Listener)::Conn
         net = listener.fd.net,
         is_connected = true,
     )
-    child.laddr = listener.fd.laddr
-    child.raddr = loopback_addr(1)
+    _set_local_addr!(child)
+    if listener.fd.family == SocketOps.AF_INET6
+        _set_remote_addr_from_accept!(child, SocketOps.get_peer_name_in6(child.pfd.sysfd))
+    else
+        _set_remote_addr_from_accept!(child, SocketOps.get_peer_name_in(child.pfd.sysfd))
+    end
     return Conn(child)
 end
 
@@ -1808,34 +1891,47 @@ function addr(listener::Listener)::Union{Nothing, SocketAddr}
     return listener.fd.laddr
 end
 
+function Base.close(fd::FD)
+    close(fd.pfd)
+    return nothing
 end
 
-Base.close(fd::TCP.FD) = close(fd.pfd)
-Base.close(conn::TCP.Conn) = close(conn.fd)
-Base.close(listener::TCP.Listener) = close(listener.fd)
-Base.closewrite(conn::TCP.Conn) = Main.Reseau.SocketOps.shutdown_socket(conn.fd.pfd.sysfd, Main.Reseau.SocketOps.SHUT_WR)
+function Base.close(conn::Conn)
+    close(conn.fd)
+    return nothing
+end
 
-function closeread(conn::TCP.Conn)
+function Base.close(listener::Listener)
+    close(listener.fd)
+    return nothing
+end
+
+function Base.closewrite(conn::Conn)
+    Main.Reseau.SocketOps.shutdown_socket(conn.fd.pfd.sysfd, Main.Reseau.SocketOps.SHUT_WR)
+    return nothing
+end
+
+function closeread(conn::Conn)
     Main.Reseau.SocketOps.shutdown_socket(conn.fd.pfd.sysfd, Main.Reseau.SocketOps.SHUT_RD)
     return nothing
 end
 
-function set_deadline!(conn::TCP.Conn, deadline_ns::Integer)
+function set_deadline!(conn::Conn, deadline_ns::Integer)
     Main.Reseau.IOPoll.set_deadline!(conn.fd.pfd, deadline_ns)
     return nothing
 end
 
-function set_read_deadline!(conn::TCP.Conn, deadline_ns::Integer)
+function set_read_deadline!(conn::Conn, deadline_ns::Integer)
     Main.Reseau.IOPoll.set_read_deadline!(conn.fd.pfd, deadline_ns)
     return nothing
 end
 
-function set_write_deadline!(conn::TCP.Conn, deadline_ns::Integer)
+function set_write_deadline!(conn::Conn, deadline_ns::Integer)
     Main.Reseau.IOPoll.set_write_deadline!(conn.fd.pfd, deadline_ns)
     return nothing
 end
 
-function set_nodelay!(conn::TCP.Conn, enabled::Bool = true)
+function set_nodelay!(conn::Conn, enabled::Bool = true)
     Main.Reseau.SocketOps.set_sockopt_int(
         conn.fd.pfd.sysfd,
         Main.Reseau.SocketOps.IPPROTO_TCP,
@@ -1845,7 +1941,7 @@ function set_nodelay!(conn::TCP.Conn, enabled::Bool = true)
     return nothing
 end
 
-function set_keepalive!(conn::TCP.Conn, enabled::Bool = true)
+function set_keepalive!(conn::Conn, enabled::Bool = true)
     Main.Reseau.SocketOps.set_sockopt_int(
         conn.fd.pfd.sysfd,
         Main.Reseau.SocketOps.SOL_SOCKET,
@@ -1855,25 +1951,55 @@ function set_keepalive!(conn::TCP.Conn, enabled::Bool = true)
     return nothing
 end
 
-@inline function _show_endpoint(io::IO, endpoint::Union{Nothing, TCP.SocketAddr})
+function _peek_eof(conn::Conn)::Bool
+    pfd = conn.fd.pfd
+    pref = Ref{UInt8}(0x00)
+    n = GC.@preserve pref SocketOps.recv_from!(
+        pfd.sysfd,
+        Base.unsafe_convert(Ptr{UInt8}, pref),
+        Csize_t(1),
+        0,
+    )
+    return n == 0
+end
+
+@inline function _show_endpoint(io::IO, endpoint::Union{Nothing, SocketAddr})
     if endpoint === nothing
         print(io, "?")
-    elseif endpoint isa TCP.SocketAddrV4
-        addr = endpoint::TCP.SocketAddrV4
+    elseif endpoint isa SocketAddrV4
+        addr = endpoint::SocketAddrV4
         print(io, join(Int.(addr.ip), "."), ":", addr.port)
     else
-        addr = endpoint::TCP.SocketAddrV6
+        addr = endpoint::SocketAddrV6
         if addr.scope_id != 0
-            print(io, "[", TCP._format_ipv6(addr.ip), "%", addr.scope_id, "]:", addr.port)
+            print(io, "[", _format_ipv6(addr.ip), "%", addr.scope_id, "]:", addr.port)
         else
-            print(io, "[", TCP._format_ipv6(addr.ip), "]:", addr.port)
+            print(io, "[", _format_ipv6(addr.ip), "]:", addr.port)
         end
     end
     return nothing
 end
 
-@inline _show_state(conn::TCP.Conn) = conn.fd.pfd.sysfd >= 0 ? "open" : "closed"
-@inline _show_state(listener::TCP.Listener) = listener.fd.pfd.sysfd >= 0 ? "active" : "closed"
+@inline _show_state(conn::Conn) = conn.fd.pfd.sysfd >= 0 ? "open" : "closed"
+@inline _show_state(listener::Listener) = listener.fd.pfd.sysfd >= 0 ? "active" : "closed"
+
+function Base.show(io::IO, conn::Conn)
+    print(io, "TCP.Conn(")
+    _show_endpoint(io, local_addr(conn))
+    print(io, " -> ")
+    _show_endpoint(io, remote_addr(conn))
+    print(io, ", ", _show_state(conn), ")")
+    return nothing
+end
+
+function Base.show(io::IO, listener::Listener)
+    print(io, "TCP.Listener(")
+    _show_endpoint(io, addr(listener))
+    print(io, ", ", _show_state(listener), ")")
+    return nothing
+end
+
+end
 
 module HostResolvers
 

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -5078,7 +5078,7 @@ end
 
 function _run_full_split_extracted_package_subprocess()::Nothing
     mktempdir() do dir
-        name = "StandalonePkgSplitFullFresh"
+        name = "Reseau"
         _write_full_split_extracted_package(dir, name)
         depot = joinpath(dir, "depot")
         mkpath(depot)

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -728,6 +728,16 @@ function set_write_deadline!(fd::FD, deadline_ns::Integer)
     return nothing
 end
 
+function set_deadline!(fd::FD, deadline_ns::Integer)
+    _set_deadline_impl!(fd, deadline_ns, PollMode.READWRITE)
+    return nothing
+end
+
+function set_read_deadline!(fd::FD, deadline_ns::Integer)
+    _set_deadline_impl!(fd, deadline_ns, PollMode.READ)
+    return nothing
+end
+
 function Base.close(fd::FD)
     _fdlock_incref_and_close!(fd.fdlock) || throw(_closing_error(fd.is_file))
     evict!(fd.pd)
@@ -863,6 +873,8 @@ const TCP_NODELAY = Int32(1)
 const SOL_SOCKET = Int32(0xffff)
 const SO_KEEPALIVE = Int32(0x0008)
 const SO_ERROR = Int32(0x1007)
+const SHUT_RD = Int32(0)
+const SHUT_WR = Int32(1)
 
 const _WS2_32 = "Ws2_32"
 const _KERNEL32 = "Kernel32"
@@ -1332,6 +1344,8 @@ else
     end
 end
 
+shutdown_socket(fd::Int32, how::Integer) = nothing
+
 function sockaddr_in(ip::NTuple{4, UInt8}, port::Integer)::SockAddrIn
     return SockAddrIn(
         UInt16(AF_INET),
@@ -1433,6 +1447,18 @@ struct Listener
 end
 
 struct ConnectCanceledError <: Exception end
+
+@inline function _is_connect_pending_errno(errno::Int32)::Bool
+    return errno == Int32(Base.Libc.EINPROGRESS) || errno == Int32(Base.Libc.EALREADY) || errno == Int32(Base.Libc.EINTR)
+end
+
+@inline function _is_temporary_unconnected(err::SystemError)::Bool
+    return err.errnum == Int(Base.Libc.ENOTCONN) || err.errnum == Int(Base.Libc.EINVAL)
+end
+
+function _format_ipv6(ip::NTuple{16, UInt8})::String
+    return join(map(x -> string(x, base = 16, pad = 2), ip), ":")
+end
 
 function loopback_addr(port::Integer)::SocketAddrV4
     return SocketAddrV4((UInt8(127), UInt8(0), UInt8(0), UInt8(1)), UInt16(port))
@@ -1774,6 +1800,67 @@ end
 Base.close(fd::TCP.FD) = close(fd.pfd)
 Base.close(conn::TCP.Conn) = close(conn.fd)
 Base.close(listener::TCP.Listener) = close(listener.fd)
+Base.closewrite(conn::TCP.Conn) = Main.Reseau.SocketOps.shutdown_socket(conn.fd.pfd.sysfd, Main.Reseau.SocketOps.SHUT_WR)
+
+function closeread(conn::TCP.Conn)
+    Main.Reseau.SocketOps.shutdown_socket(conn.fd.pfd.sysfd, Main.Reseau.SocketOps.SHUT_RD)
+    return nothing
+end
+
+function set_deadline!(conn::TCP.Conn, deadline_ns::Integer)
+    Main.Reseau.IOPoll.set_deadline!(conn.fd.pfd, deadline_ns)
+    return nothing
+end
+
+function set_read_deadline!(conn::TCP.Conn, deadline_ns::Integer)
+    Main.Reseau.IOPoll.set_read_deadline!(conn.fd.pfd, deadline_ns)
+    return nothing
+end
+
+function set_write_deadline!(conn::TCP.Conn, deadline_ns::Integer)
+    Main.Reseau.IOPoll.set_write_deadline!(conn.fd.pfd, deadline_ns)
+    return nothing
+end
+
+function set_nodelay!(conn::TCP.Conn, enabled::Bool = true)
+    Main.Reseau.SocketOps.set_sockopt_int(
+        conn.fd.pfd.sysfd,
+        Main.Reseau.SocketOps.IPPROTO_TCP,
+        Main.Reseau.SocketOps.TCP_NODELAY,
+        enabled ? 1 : 0,
+    )
+    return nothing
+end
+
+function set_keepalive!(conn::TCP.Conn, enabled::Bool = true)
+    Main.Reseau.SocketOps.set_sockopt_int(
+        conn.fd.pfd.sysfd,
+        Main.Reseau.SocketOps.SOL_SOCKET,
+        Main.Reseau.SocketOps.SO_KEEPALIVE,
+        enabled ? 1 : 0,
+    )
+    return nothing
+end
+
+@inline function _show_endpoint(io::IO, endpoint::Union{Nothing, TCP.SocketAddr})
+    if endpoint === nothing
+        print(io, "?")
+    elseif endpoint isa TCP.SocketAddrV4
+        addr = endpoint::TCP.SocketAddrV4
+        print(io, join(Int.(addr.ip), "."), ":", addr.port)
+    else
+        addr = endpoint::TCP.SocketAddrV6
+        if addr.scope_id != 0
+            print(io, "[", TCP._format_ipv6(addr.ip), "%", addr.scope_id, "]:", addr.port)
+        else
+            print(io, "[", TCP._format_ipv6(addr.ip), "]:", addr.port)
+        end
+    end
+    return nothing
+end
+
+@inline _show_state(conn::TCP.Conn) = conn.fd.pfd.sysfd >= 0 ? "open" : "closed"
+@inline _show_state(listener::TCP.Listener) = listener.fd.pfd.sysfd >= 0 ? "active" : "closed"
 
 module HostResolvers
 

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -1439,6 +1439,132 @@ end
 end
 
 module TLS
+
+using ..TCP
+using ..HostResolvers
+
+const TLS1_2_VERSION = UInt16(0x0303)
+const TLS1_3_VERSION = UInt16(0x0304)
+
+module ClientAuthMode
+Base.@enum T::UInt8 begin
+    NoClientCert = 0
+    RequestClientCert = 1
+    RequireAnyClientCert = 2
+    VerifyClientCertIfGiven = 3
+    RequireAndVerifyClientCert = 4
+end
+end
+
+struct ConfigError <: Exception
+    message::String
+end
+
+struct Config
+    server_name::Union{Nothing, String}
+    verify_peer::Bool
+    client_auth::ClientAuthMode.T
+    cert_file::Union{Nothing, String}
+    key_file::Union{Nothing, String}
+    ca_file::Union{Nothing, String}
+    client_ca_file::Union{Nothing, String}
+    alpn_protocols::Vector{String}
+    handshake_timeout_ns::Int64
+    min_version::Union{Nothing, UInt16}
+    max_version::Union{Nothing, UInt16}
+end
+
+function Config(;
+        server_name::Union{Nothing, AbstractString} = nothing,
+        verify_peer::Bool = true,
+        client_auth::ClientAuthMode.T = ClientAuthMode.NoClientCert,
+        cert_file::Union{Nothing, AbstractString} = nothing,
+        key_file::Union{Nothing, AbstractString} = nothing,
+        ca_file::Union{Nothing, AbstractString} = nothing,
+        client_ca_file::Union{Nothing, AbstractString} = nothing,
+        alpn_protocols::Vector{String} = String[],
+        handshake_timeout_ns::Integer = Int64(0),
+        min_version::Union{Nothing, UInt16} = TLS1_2_VERSION,
+        max_version::Union{Nothing, UInt16} = nothing,
+    )
+    server_name_s = server_name === nothing ? nothing : String(server_name)
+    cert_file_s = cert_file === nothing ? nothing : String(cert_file)
+    key_file_s = key_file === nothing ? nothing : String(key_file)
+    ca_file_s = ca_file === nothing ? nothing : String(ca_file)
+    client_ca_file_s = client_ca_file === nothing ? nothing : String(client_ca_file)
+    has_cert = cert_file_s !== nothing
+    has_key = key_file_s !== nothing
+    has_cert == has_key || throw(ConfigError("both `cert_file` and `key_file` must be set together"))
+    handshake_timeout_ns < 0 && throw(ConfigError("handshake_timeout_ns must be >= 0"))
+    return Config(
+        server_name_s,
+        verify_peer,
+        client_auth,
+        cert_file_s,
+        key_file_s,
+        ca_file_s,
+        client_ca_file_s,
+        copy(alpn_protocols),
+        Int64(handshake_timeout_ns),
+        min_version,
+        max_version,
+    )
+end
+
+struct Conn <: IO
+    tcp::TCP.Conn
+    config::Config
+end
+
+struct Listener
+    tcp::TCP.Listener
+    config::Config
+end
+
+function _connect(
+        host_resolver::HostResolvers.HostResolver,
+        network::AbstractString,
+        address::AbstractString,
+        config::Config,
+    )::Conn
+    tcp = HostResolvers.connect(host_resolver, network, address)
+    return Conn(tcp, config)
+end
+
+function connect(
+        network::AbstractString,
+        address::AbstractString;
+        timeout_ns::Integer = Int64(0),
+        deadline_ns::Integer = Int64(0),
+        local_addr::Union{Nothing, TCP.SocketEndpoint} = nothing,
+        fallback_delay_ns::Integer = Int64(300_000_000),
+        resolver::HostResolvers.AbstractResolver = HostResolvers.DEFAULT_RESOLVER,
+        policy::HostResolvers.ResolverPolicy = HostResolvers.ResolverPolicy(),
+        kw...
+    )::Conn
+    host_resolver = HostResolvers.HostResolver(; timeout_ns, deadline_ns, local_addr, fallback_delay_ns, resolver, policy)
+    return _connect(host_resolver, network, address, Config(; kw...))
+end
+
+function connect(address::AbstractString; kwargs...)::Conn
+    return connect("tcp", address; kwargs...)
+end
+
+function listen(
+        network::AbstractString,
+        address::AbstractString,
+        config::Config;
+        backlog::Integer = 128,
+        reuseaddr::Bool = true,
+    )::Listener
+    listener = TCP.listen(network, address; backlog = backlog, reuseaddr = reuseaddr)
+    return Listener(listener, config)
+end
+
+Base.isopen(conn::Conn) = true
+Base.close(conn::Conn) = close(conn.tcp)
+Base.close(listener::Listener) = close(listener.tcp)
+
 end
 
 end # module Reseau

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -1,4 +1,5 @@
 using Test
+using UUIDs
 
 module Reseau
 
@@ -4885,10 +4886,77 @@ function _probe(f, label::AbstractString)
     return nothing
 end
 
+function _extract_package_module_source(name::AbstractString)::String
+    src = read(@__FILE__, String)
+    start_rng = findfirst("module Reseau", src)
+    stop_rng = findfirst("end # module Reseau", src)
+    start_rng === nothing && error("module Reseau block not found")
+    stop_rng === nothing && error("module Reseau terminator not found")
+    modsrc = src[first(start_rng):last(stop_rng)]
+    modsrc = replace(modsrc, "module Reseau" => "module $(name)")
+    modsrc = replace(modsrc, "..Reseau" => "..$(name)")
+    modsrc = replace(modsrc, "Main.Reseau" => "Main.$(name)")
+    return modsrc
+end
+
+function _with_extracted_package(f::F) where {F}
+    mktempdir() do dir
+        name = "StandalonePkg"
+        uuid = uuid4()
+        pkgid = Base.PkgId(uuid, name)
+        write(
+            joinpath(dir, "Project.toml"),
+            "name = \"$name\"\nuuid = \"$(string(uuid))\"\nversion = \"0.1.0\"\n",
+        )
+        mkpath(joinpath(dir, "src"))
+        write(joinpath(dir, "src", "$name.jl"), _extract_package_module_source(name))
+        pushfirst!(LOAD_PATH, dir)
+        try
+            mod = Base.require(pkgid)
+            return f(mod)
+        finally
+            popfirst!(LOAD_PATH)
+        end
+    end
+end
+
 println("[windows-compiler-bug] julia threads: $(Threads.nthreads())")
 
 @test Reseau.TCP === TCP
 @test Reseau.TLS === TLS
+
+_probe("extracted package kwcall + runtime") do
+    _with_extracted_package() do mod
+        c = getproperty(mod, :TCP)
+        kwtt_v4 = (
+            NamedTuple{(:local_addr,), Tuple{getproperty(c, :SocketAddrV4)}},
+            typeof(getproperty(c, :connect)),
+            String,
+            String,
+        )
+        kwtt_v6 = (
+            NamedTuple{(:local_addr,), Tuple{getproperty(c, :SocketAddrV6)}},
+            typeof(getproperty(c, :connect)),
+            String,
+            String,
+        )
+        Base.precompile(Tuple{typeof(Core.kwcall), kwtt_v4...})
+        Base.code_typed(Core.kwcall, kwtt_v4)
+        Base.precompile(Tuple{typeof(Core.kwcall), kwtt_v6...})
+        Base.code_typed(Core.kwcall, kwtt_v6)
+        local_v4 = Base.invokelatest(getproperty(c, :loopback_addr), 0)
+        local_v6 = Base.invokelatest(getproperty(c, :loopback_addr6), 0)
+        try
+            Base.invokelatest(getproperty(c, :connect), "tcp", "127.0.0.1:1"; local_addr = local_v4)
+        catch
+        end
+        try
+            Base.invokelatest(getproperty(c, :connect), "tcp", "127.0.0.1:1"; local_addr = local_v6)
+        catch
+        end
+        return nothing
+    end
+end
 
 _probe("kwsort infer local_addr v4") do
     tt = (NamedTuple{(:local_addr,), Tuple{NC.SocketAddrV4}}, typeof(NC.connect), String, String)

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -355,6 +355,10 @@ struct DNSOpError <: Exception
     err::Exception
 end
 
+struct UnknownNetworkError <: Exception
+    network::String
+end
+
 abstract type AbstractResolver end
 
 struct SystemResolver <: AbstractResolver end
@@ -403,6 +407,7 @@ function ResolverPolicy(; prefer_ipv6::Bool = false, allow_ipv4::Bool = true, al
 end
 
 const DEFAULT_RESOLVER = SystemResolver()
+const _SERVICE_TCP = Dict{String, Int}("http" => 80, "https" => 443, "ssh" => 22)
 
 mutable struct DNSRaceState
     @atomic done::Bool
@@ -515,20 +520,60 @@ end
     return addr isa TCP.SocketAddrV6
 end
 
-function split_host_port(address::AbstractString)::Tuple{String, String}
-    addr = String(address)
-    idx = findlast(==(':'), addr)
-    idx === nothing && throw(AddressError("missing port in address", addr))
-    host = addr[begin:prevind(addr, idx)]
-    service = addr[nextind(addr, idx):end]
-    isempty(service) && throw(AddressError("missing port in address", addr))
-    return host, service
+function split_host_port(hostport::AbstractString)::Tuple{String, String}
+    s = String(hostport)
+    i = findlast(==(':'), s)
+    i === nothing && throw(AddressError("missing port in address", s))
+    first_i = firstindex(s)
+    last_i = lastindex(s)
+    j = first_i
+    k = first_i
+    host = ""
+    if !isempty(s) && s[first_i] == '['
+        end_idx = findfirst(==(']'), s)
+        end_idx === nothing && throw(AddressError("missing ']' in address", s))
+        if end_idx == last_i
+            throw(AddressError("missing port in address", s))
+        end
+        next_after_bracket = nextind(s, end_idx)
+        if next_after_bracket != i
+            if s[next_after_bracket] == ':'
+                throw(AddressError("too many colons in address", s))
+            end
+            throw(AddressError("missing port in address", s))
+        end
+        host_start = nextind(s, first_i)
+        host_end = prevind(s, end_idx)
+        host = host_start <= host_end ? String(SubString(s, host_start, host_end)) : ""
+        j = host_start
+        k = next_after_bracket
+    else
+        if i != first_i
+            host_end = prevind(s, i)
+            host = String(SubString(s, first_i, host_end))
+            findfirst(==(':'), SubString(s, first_i, host_end)) !== nothing &&
+                throw(AddressError("too many colons in address", s))
+        else
+            host = ""
+        end
+    end
+    findnext(==('['), s, j) !== nothing && throw(AddressError("unexpected '[' in address", s))
+    findnext(==(']'), s, k) !== nothing && throw(AddressError("unexpected ']' in address", s))
+    if i == last_i
+        return host, ""
+    end
+    port_start = nextind(s, i)
+    port = String(SubString(s, port_start, last_i))
+    return host, port
 end
 
 function lookup_port(resolver::AbstractResolver, network::AbstractString, service::AbstractString)::Int
     _ = resolver
-    _ = network
-    return parse(Int, service)
+    return lookup_port(DEFAULT_RESOLVER, network, service)
+end
+
+function lookup_port(network::AbstractString, service::AbstractString)::Int
+    return lookup_port(DEFAULT_RESOLVER, network, service)
 end
 
 lookup_port(resolver::SingleflightResolver, network::AbstractString, service::AbstractString)::Int =
@@ -536,6 +581,66 @@ lookup_port(resolver::SingleflightResolver, network::AbstractString, service::Ab
 
 lookup_port(resolver::CachingResolver, network::AbstractString, service::AbstractString)::Int =
     lookup_port((resolver::CachingResolver).parent, network, service)
+
+function _parse_port_table(table::Dict{String, Int}, network::AbstractString, service::AbstractString)::Int
+    port = get(() -> nothing, table, lowercase(String(service)))
+    port === nothing && throw(AddressError("unknown port", string(network, "/", service)))
+    return port::Int
+end
+
+function parse_port(service::AbstractString)::Tuple{Int, Bool}
+    isempty(service) && return 0, false
+    s = String(service)
+    neg = false
+    if startswith(s, '+')
+        s = s[2:end]
+    elseif startswith(s, '-')
+        neg = true
+        s = s[2:end]
+    end
+    isempty(s) && return 0, false
+    max_val = typemax(UInt32)
+    cutoff = UInt32(1 << 30)
+    n = UInt32(0)
+    for ch in s
+        ('0' <= ch <= '9') || return 0, true
+        d = UInt32(ch - '0')
+        if n >= cutoff
+            n = max_val
+            break
+        end
+        n *= UInt32(10)
+        nn = n + d
+        if nn < n || nn > max_val
+            n = max_val
+            break
+        end
+        n = nn
+    end
+    port = if !neg && n >= cutoff
+        Int(cutoff - UInt32(1))
+    elseif neg && n > cutoff
+        Int(cutoff)
+    else
+        Int(n)
+    end
+    neg && (port = -port)
+    return port, false
+end
+
+function lookup_port(::SystemResolver, network::AbstractString, service::AbstractString)::Int
+    port, needs_lookup = parse_port(service)
+    if needs_lookup
+        n = String(network)
+        if n == "tcp" || n == "tcp4" || n == "tcp6"
+            port = _parse_port_table(_SERVICE_TCP, n, service)
+        else
+            throw(UnknownNetworkError(n))
+        end
+    end
+    (port < 0 || port > 65535) && throw(AddressError("invalid port", String(service)))
+    return port
+end
 
 function _with_port(addr::TCP.SocketAddrV4, port::Int)::TCP.SocketAddrV4
     return TCP.SocketAddrV4(addr.ip, UInt16(port))
@@ -665,9 +770,25 @@ function _apply_policy_and_network(
         kind::Symbol,
         policy::ResolverPolicy,
     )::Vector{TCP.SocketEndpoint}
-    _ = kind
-    _ = policy
-    return ips
+    out = TCP.SocketEndpoint[]
+    for addr in ips
+        if kind == :tcp4 && !(addr isa TCP.SocketAddrV4)
+            continue
+        end
+        if kind == :tcp6 && !(addr isa TCP.SocketAddrV6)
+            continue
+        end
+        if addr isa TCP.SocketAddrV4
+            policy.allow_ipv4 || continue
+        else
+            policy.allow_ipv6 || continue
+        end
+        push!(out, addr)
+    end
+    if policy.prefer_ipv6 && kind == :tcp
+        sort!(out; by = a -> a isa TCP.SocketAddrV6 ? 0 : 1)
+    end
+    return out
 end
 
 function resolve_tcp_addrs(
@@ -821,7 +942,13 @@ end
 end
 
 @inline _is_self_connect(conn::TCP.Conn)::Bool = false
-@inline _network_kind(network::AbstractString)::Symbol = Symbol(network)
+@inline function _network_kind(network::AbstractString)::Symbol
+    n = String(network)
+    n == "tcp" && return :tcp
+    n == "tcp4" && return :tcp4
+    n == "tcp6" && return :tcp6
+    throw(UnknownNetworkError(n))
+end
 
 function _mark_connect_done!(state::DNSRaceState)
     while true

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -37,6 +37,13 @@ Base.@enum T::UInt8 begin
 end
 end
 
+module TimeEntryKind
+Base.@enum T::UInt8 begin
+    DEADLINE = 0x01
+    TIMER = 0x02
+end
+end
+
 module IocpOpKind
 Base.@enum T::UInt8 begin
     PROBE_READ = 0x01
@@ -333,6 +340,14 @@ mutable struct FD
     end
 end
 
+@inline function _fd_incref!(fd::FD)::Bool
+    return _fdlock_incref!(fd.fdlock)
+end
+
+@inline function _fd_decref!(fd::FD)::Bool
+    return _fdlock_decref!(fd.fdlock)
+end
+
 mutable struct TimerState
     lock::ReentrantLock
     waiter::PollWaiter
@@ -345,14 +360,102 @@ mutable struct TimerState
     end
 end
 
+struct PollEvent
+    fd::Int32
+    token::UInt64
+    mode::PollMode.T
+    errored::Bool
+end
+
+struct TimeEntry
+    deadline_ns::Int64
+    kind::TimeEntryKind.T
+    pollstate::Union{Nothing, PollState}
+    timer::Union{Nothing, TimerState}
+    mode::PollMode.T
+    primary_seq::UInt64
+    secondary_seq::UInt64
+end
+
+abstract type BackendState end
+
+mutable struct Poller
+    lock::ReentrantLock
+    registrations::Dict{Int32, Registration}
+    registrations_by_token::Dict{UInt64, Registration}
+    time_heap::Vector{TimeEntry}
+    shutdown_event::Base.Threads.Event
+    backend_state::Union{Nothing, BackendState}
+    @atomic next_token::UInt64
+    @atomic poll_until_ns::Int64
+    @atomic running::Bool
+end
+
+function Poller()
+    return Poller(
+        ReentrantLock(),
+        Dict{Int32, Registration}(),
+        Dict{UInt64, Registration}(),
+        TimeEntry[],
+        Base.Threads.Event(),
+        nothing,
+        UInt64(0),
+        Int64(0),
+        false,
+    )
+end
+
 connect!(pfd::FD, addrbuf, addrlen) = nothing
 waitwrite(pd::PollState) = nothing
 schedule_timer!(timer::TimerState, deadline_ns::Int64) = true
 waittimer(timer::TimerState) = false
 _close_timer!(timer::TimerState) = nothing
-sleep(seconds::Real) = nothing
+function deadline_fire! end
+
+function _drain_expired_time_entries!(state::Poller, now_ns::Int64)
+    _ = state
+    _ = now_ns
+    return nothing
+end
+
+function sleep_until_ns(deadline_ns::Integer)
+    target_ns = Int64(deadline_ns)
+    target_ns <= Int64(time_ns()) && return nothing
+    return nothing
+end
+
+function sleep_ns(delay_ns::Integer)
+    delay = Int64(delay_ns)
+    delay <= 0 && return nothing
+    return sleep_until_ns(Int64(time_ns()) + delay)
+end
+
+function sleep(sec::Real)
+    sec >= 0 || throw(ArgumentError("cannot sleep for $sec seconds"))
+    return sleep_ns(ceil(Int64, sec * 1.0e9))
+end
+
+function timedwait(testcb, timeout_s::Real; pollint::Real = 0.1)
+    pollint >= 1.0e-3 || throw(ArgumentError("pollint must be >= 1 millisecond"))
+    start_ns = Int64(time_ns())
+    timeout_ns = ceil(Int64, timeout_s * 1.0e9)
+    testcb() && return :ok
+    step_ns = ceil(Int64, pollint * 1.0e9)
+    while true
+        elapsed_ns = Int64(time_ns()) - start_ns
+        elapsed_ns > timeout_ns && return :timed_out
+        remaining_ns = timeout_ns - elapsed_ns
+        sleep_ns(min(step_ns, remaining_ns))
+        testcb() && return :ok
+    end
+end
+
 read!(pfd::FD, buf::Vector{UInt8}) = throw(EOFError())
 _read_ptr_some!(pfd::FD, ptr::Ptr{UInt8}, nbytes::Int) = throw(EOFError())
+
+const POLLER = Ref{Poller}()
+const _POLLER_THREAD_ENTRY_C = Ref{Ptr{Cvoid}}(C_NULL)
+const _pthread_t = UInt
 
 const _POLL_NO_ERROR = Int32(0)
 const _POLL_ERR_CLOSING = Int32(1)
@@ -386,6 +489,22 @@ end
     return _NEXT_TOKEN[]
 end
 
+@inline function _next_token!(state::Poller)::UInt64
+    return @atomic state.next_token += UInt64(1)
+end
+
+@inline function _is_generating_output()::Bool
+    return false
+end
+
+function _throw_errno(op::AbstractString, errno::Int32)
+    throw(SystemError(op, Int(errno)))
+end
+
+@inline function _runtime_supported()::Bool
+    return true
+end
+
 function _new_iocp_registration(fd::Int32, token::UInt64)::IocpRegistration
     read_op = IocpOp(Ref(_ZERO_OVERLAPPED), PollMode.READ, token, IocpOpKind.PROBE_READ, nothing, nothing, false)
     write_op = IocpOp(Ref(_ZERO_OVERLAPPED), PollMode.WRITE, token, IocpOpKind.PROBE_WRITE, nothing, nothing, false)
@@ -393,6 +512,10 @@ function _new_iocp_registration(fd::Int32, token::UInt64)::IocpRegistration
     read_op.owner = reg
     write_op.owner = reg
     return reg
+end
+
+function _new_registration(fd::Int32, token::UInt64, mode::PollMode.T)::Registration
+    return Registration(fd, token, mode, PollWaiter(), PollWaiter(), false)
 end
 
 @inline function _map_overlapped_errno(err::Int32)::Int32
@@ -513,6 +636,79 @@ function current_registration(pd::PollState)
     return get(() -> nothing, _REGISTRATIONS, pd)
 end
 
+function _notify_registration!(
+        registration::Registration,
+        mode::PollMode.T,
+        reason::PollWakeReason.T = PollWakeReason.READY,
+    )
+    if _mode_has_read(mode) && _mode_has_read(registration.mode)
+        pollnotify!(registration.read_waiter, reason)
+    end
+    if _mode_has_write(mode) && _mode_has_write(registration.mode)
+        pollnotify!(registration.write_waiter, reason)
+    end
+    return nothing
+end
+
+function _spawn_detached_thread(
+        name::AbstractString,
+        thread_fn::Ref{Ptr{Cvoid}},
+        arg = nothing,
+    )
+    _ = name
+    _ = thread_fn
+    _ = arg
+    return nothing
+end
+
+function init!()::Poller
+    if isassigned(POLLER)
+        state = POLLER[]
+        (@atomic state.running) && return state
+    end
+    _runtime_supported() || throw(ArgumentError("iopoll backend is currently supported on macOS, Linux, and Windows"))
+    state = Poller()
+    @atomic state.running = true
+    POLLER[] = state
+    return state
+end
+
+function shutdown!()
+    isassigned(POLLER) || return nothing
+    state = POLLER[]
+    @atomic :release state.running = false
+    return nothing
+end
+
+function _dispatch_ready_event!(state::Poller, event::PollEvent)
+    registration = get(() -> nothing, state.registrations_by_token, event.token)
+    registration === nothing && return nothing
+    _notify_registration!(registration::Registration, event.mode, PollWakeReason.READY)
+    return nothing
+end
+
+function _notify_all_waiters!(state::Poller)
+    for registration in values(state.registrations_by_token)
+        _notify_registration!(registration, PollMode.READWRITE, PollWakeReason.CANCELED)
+    end
+    return nothing
+end
+
+function _poller_thread_main!(state::Poller)
+    _ = state
+    return nothing
+end
+
+function _poller_thread_entry(arg::Ptr{Cvoid})::Ptr{Cvoid}
+    _ = arg
+    return C_NULL
+end
+
+function __init__()
+    _POLLER_THREAD_ENTRY_C[] = C_NULL
+    return nothing
+end
+
 function _poll_registration(pd::PollState)::Registration
     reg = current_registration(pd)
     reg === nothing && throw(SystemError("iopoll wait", Int(Base.Libc.EBADF)))
@@ -552,6 +748,18 @@ function _check_error(pd::PollState, mode::PollMode.T)::Int32
 end
 
 preparewrite(pd::PollState, is_file::Bool = false) = nothing
+prepareread(pd::PollState, is_file::Bool = false) = nothing
+
+function _fd_read_lock!(fd::FD)
+    _fdlock_rwlock!(fd.fdlock, true, true) || throw(_closing_error(fd.is_file))
+    return nothing
+end
+
+function _fd_read_unlock!(fd::FD)
+    _fdlock_rwunlock!(fd.fdlock, true) || return nothing
+    return nothing
+end
+
 function _fd_write_lock!(fd::FD)
     println("[windows-compiler-bug] enter _fd_write_lock!")
     flush(stdout)
@@ -566,6 +774,55 @@ function _fd_write_unlock!(fd::FD)
     return nothing
 end
 pollable(pd::PollState)::Bool = @atomic :acquire pd.pollable
+
+function waitread(pd::PollState, is_file::Bool = false)
+    registration = _poll_registration(pd)
+    arm_waiter!(registration, PollMode.READ)
+    pollwait!(registration.read_waiter)
+    _convert_poll_error!(_check_error(pd, PollMode.READ), is_file)
+    return nothing
+end
+
+function waitcancelled(pd::PollState, mode::PollMode.T)
+    registration = _poll_registration(pd)
+    if _mode_has_read(mode)
+        pollwait!(registration.read_waiter)
+    end
+    if _mode_has_write(mode)
+        pollwait!(registration.write_waiter)
+    end
+    return nothing
+end
+
+function _write_ptr!(fd::FD, p::Ptr{UInt8}, nbytes::Int)::Int
+    _ = p
+    _ = nbytes
+    return 0
+end
+
+function write!(fd::FD, p::AbstractVector{UInt8})::Int
+    GC.@preserve p begin
+        return _write_ptr!(fd, pointer(p), length(p))
+    end
+end
+
+function accept!(fd::FD, family::Int32, sotype::Int32)::Tuple{Int32, Main.Reseau.SocketOps.AcceptPeer}
+    _ = sotype
+    if family == Main.Reseau.SocketOps.AF_INET6
+        return Int32(4), Main.Reseau.SocketOps.sockaddr_in6_loopback(1)
+    end
+    return Int32(4), Main.Reseau.SocketOps.sockaddr_in_loopback(1)
+end
+
+function set_blocking!(fd::FD, blocking::Bool = true)
+    @atomic :release fd.is_blocking = blocking
+    return nothing
+end
+
+function _destroy!(fd::FD)
+    close(fd)
+    return nothing
+end
 
 function _wake_waiters!(pd::PollState, mode::PollMode.T)
     registration = current_registration(pd)

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -828,7 +828,7 @@ end
 end
 
 @inline function _is_generating_output()::Bool
-    return false
+    return ccall(:jl_generating_output, Cint, ()) == 1
 end
 
 function _throw_errno(op::AbstractString, errno::Int32)
@@ -843,7 +843,7 @@ end
 end
 
 @inline function _runtime_supported()::Bool
-    return true
+    return Sys.isapple() || Sys.islinux() || Sys.iswindows()
 end
 
 @inline function _is_accept_retry_errno(errno::Int32)::Bool
@@ -1108,16 +1108,31 @@ function init!()::Poller
         (@atomic state.running) && return state
     end
     _runtime_supported() || throw(ArgumentError("iopoll backend is currently supported on macOS, Linux, and Windows"))
-    state = Poller()
-    @atomic state.running = true
-    POLLER[] = state
-    return state
+    new_state = Poller()
+    errno = _backend_init!(new_state)
+    errno == Int32(0) || _throw_errno("iopoll backend init", errno)
+    @atomic new_state.running = true
+    POLLER[] = new_state
+    try
+        _spawn_detached_thread(
+            "reseau-iopoll-poller",
+            _POLLER_THREAD_ENTRY_C,
+            new_state,
+        )
+    catch
+        @atomic :release new_state.running = false
+        _backend_close!(new_state)
+        POLLER[] = Poller()
+        rethrow()
+    end
+    return new_state
 end
 
 function shutdown!()
     isassigned(POLLER) || return nothing
     state = POLLER[]
     @atomic :release state.running = false
+    _backend_close!(state)
     return nothing
 end
 
@@ -1136,17 +1151,47 @@ function _notify_all_waiters!(state::Poller)
 end
 
 function _poller_thread_main!(state::Poller)
-    _ = state
+    while @atomic state.running
+        delay_ns = _poll_delay_ns(state)
+        errno = _backend_poll_once!(state, delay_ns)
+        @atomic :release state.poll_until_ns = Int64(0)
+        _drain_expired_time_entries!(state, Int64(time_ns()))
+        errno == Int32(0) && continue
+        if errno == Int32(Base.Libc.EINTR)
+            continue
+        end
+        _notify_all_waiters!(state)
+        @atomic :release state.running = false
+    end
+    notify(state.shutdown_event)
     return nothing
 end
 
 function _poller_thread_entry(arg::Ptr{Cvoid})::Ptr{Cvoid}
-    _ = arg
+    state = unsafe_pointer_to_objref(arg)::Poller
+    try
+        _poller_thread_main!(state)
+    catch
+        _notify_all_waiters!(state)
+        notify(state.shutdown_event)
+    end
     return C_NULL
 end
 
 function __init__()
-    _POLLER_THREAD_ENTRY_C[] = C_NULL
+    _POLLER_THREAD_ENTRY_C[] = @cfunction(_poller_thread_entry, Ptr{Cvoid}, (Ptr{Cvoid},))
+    if _is_generating_output()
+        POLLER[] = Poller()
+    elseif _runtime_supported()
+        @static if Sys.iswindows()
+            POLLER[] = Poller()
+        else
+            init!()
+        end
+    else
+        POLLER[] = Poller()
+    end
+    @assert isassigned(POLLER)
     return nothing
 end
 
@@ -5037,7 +5082,7 @@ function _rewrite_extracted_block(str::String, name::AbstractString)::String
     str = replace(
         str,
         "using PrecompileTools: @compile_workload, @setup_workload" =>
-            "macro compile_workload(expr)\n    return esc(expr)\nend\n\nmacro setup_workload(expr)\n    return esc(expr)\nend",
+            "macro compile_workload(expr)\n    return nothing\nend\n\nmacro setup_workload(expr)\n    return esc(expr)\nend",
     )
     str = replace(str, "..Reseau" => "..$(name)")
     str = replace(str, "Main.Reseau" => "Main.$(name)")

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -121,6 +121,23 @@ end
 struct Overlapped end
 
 const _ZERO_OVERLAPPED = Overlapped()
+const _SIO_GET_EXTENSION_FUNCTION_POINTER = UInt32(0xC8000006)
+const _CONNECTEX_LOCK = ReentrantLock()
+const _CONNECTEX_PTR = Ref{Ptr{Cvoid}}(C_NULL)
+
+struct Guid
+    data1::UInt32
+    data2::UInt16
+    data3::UInt16
+    data4::NTuple{8, UInt8}
+end
+
+const _WSAID_CONNECTEX = Guid(
+    0x25a207b9,
+    0xddf3,
+    0x4660,
+    (UInt8(0x8e), UInt8(0xe9), UInt8(0x76), UInt8(0xe5), UInt8(0x8c), UInt8(0x74), UInt8(0x06), UInt8(0x3e)),
+)
 
 mutable struct IocpConnectRequest
     addrbuf::Vector{UInt8}
@@ -378,10 +395,58 @@ function _new_iocp_registration(fd::Int32, token::UInt64)::IocpRegistration
     return reg
 end
 
+@inline function _map_overlapped_errno(err::Int32)::Int32
+    err == Int32(0) && return Int32(0)
+    err == Int32(Base.Libc.EINPROGRESS) && return Int32(Base.Libc.EINPROGRESS)
+    err == Int32(Base.Libc.EAGAIN) && return Int32(Base.Libc.EAGAIN)
+    err == Int32(Base.Libc.EALREADY) && return Int32(Base.Libc.EALREADY)
+    err == Int32(Base.Libc.EADDRNOTAVAIL) && return Int32(Base.Libc.EADDRNOTAVAIL)
+    err == Int32(Base.Libc.ENETUNREACH) && return Int32(Base.Libc.ENETUNREACH)
+    err == Int32(Base.Libc.ECONNABORTED) && return Int32(Base.Libc.ECONNABORTED)
+    err == Int32(Base.Libc.ECONNRESET) && return Int32(Base.Libc.ECONNRESET)
+    err == Int32(Base.Libc.EISCONN) && return Int32(Base.Libc.EISCONN)
+    err == Int32(Base.Libc.ENOTCONN) && return Int32(Base.Libc.ENOTCONN)
+    err == Int32(Base.Libc.ETIMEDOUT) && return Int32(Base.Libc.ETIMEDOUT)
+    err == Int32(Base.Libc.ECONNREFUSED) && return Int32(Base.Libc.ECONNREFUSED)
+    err == Int32(Base.Libc.EHOSTUNREACH) && return Int32(Base.Libc.EHOSTUNREACH)
+    return Int32(Base.Libc.EIO)
+end
+
 @inline function _set_probe_kind!(op::IocpOp)
     op.kind = op.mode == PollMode.READ ? IocpOpKind.PROBE_READ : IocpOpKind.PROBE_WRITE
     op.request = nothing
     return nothing
+end
+
+function _load_connectex_ptr(fd::Int32)::Ptr{Cvoid}
+    ptr = _CONNECTEX_PTR[]
+    ptr != C_NULL && return ptr
+    lock(_CONNECTEX_LOCK)
+    try
+        ptr = _CONNECTEX_PTR[]
+        ptr != C_NULL && return ptr
+        guid_ref = Ref(_WSAID_CONNECTEX)
+        out_ref = Ref{Ptr{Cvoid}}(C_NULL)
+        bytes_ref = Ref{UInt32}(UInt32(0))
+        _ = fd
+        _ = guid_ref
+        _ = out_ref
+        _ = bytes_ref
+        _CONNECTEX_PTR[] = out_ref[]
+        return out_ref[]
+    finally
+        unlock(_CONNECTEX_LOCK)
+    end
+end
+
+@inline function _wsagetoverlappedresult(fd::Int32, op::IocpOp)::Int32
+    bytes_ref = Ref{UInt32}(UInt32(0))
+    flags_ref = Ref{UInt32}(UInt32(0))
+    _ = fd
+    _ = op
+    _ = bytes_ref
+    _ = flags_ref
+    return _map_overlapped_errno(Int32(0))
 end
 
 @inline function _clear_iocp_op!(op::IocpOp)
@@ -705,8 +770,10 @@ function _submit_iocp_op!(registration::Registration, reg::IocpRegistration, op:
     elseif op.kind == IocpOpKind.CONNECT
         request = op.request
         request isa IocpConnectRequest || throw(ArgumentError("missing ConnectEx request"))
+        connectex_ptr = _load_connectex_ptr(reg.fd)
         _ = request.addrbuf
         _ = request.addrlen
+        _ = connectex_ptr
         rc = Int32(0)
     else
         rc = Int32(Base.Libc.ENOSYS)
@@ -737,8 +804,9 @@ function _finish_iocp_mode!(registration::Registration, mode::PollMode.T)::Int32
     reg = _lookup_iocp_registration(registration)
     reg === nothing && return Int32(Base.Libc.EBADF)
     op = _iocp_op_for_mode(reg, mode)
+    result = _wsagetoverlappedresult(registration.fd, op)
     _clear_iocp_op!(op)
-    return Int32(0)
+    return result
 end
 
 function connect!(fd::FD, addrbuf::Vector{UInt8}, addrlen::Int32)

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -414,7 +414,11 @@ end
 
 preparewrite(pd::PollState, is_file::Bool = false) = nothing
 function _fd_write_lock!(fd::FD)
+    println("[windows-compiler-bug] enter _fd_write_lock!")
+    flush(stdout)
     _fdlock_rwlock!(fd.fdlock, false, true) || throw(_closing_error(fd.is_file))
+    println("[windows-compiler-bug] acquired _fd_write_lock!")
+    flush(stdout)
     return nothing
 end
 
@@ -615,12 +619,22 @@ function connect!(fd::FD, addrbuf::Vector{UInt8}, addrlen::Int32)
     println("[windows-compiler-bug] enter IOPoll.connect!")
     flush(stdout)
     _fd_write_lock!(fd)
+    println("[windows-compiler-bug] after _fd_write_lock!")
+    flush(stdout)
     try
         preparewrite(fd.pd, fd.is_file)
+        println("[windows-compiler-bug] after preparewrite")
+        flush(stdout)
         registration = _poll_registration(fd.pd)
+        println("[windows-compiler-bug] after _poll_registration")
+        flush(stdout)
         errno = _iocp_submit_connect!(registration, addrbuf, addrlen)
+        println("[windows-compiler-bug] after _iocp_submit_connect!")
+        flush(stdout)
         errno == Int32(0) || throw(SystemError("connectex", Int(errno)))
         try
+            println("[windows-compiler-bug] before pollwait! write")
+            flush(stdout)
             pollwait!(registration.write_waiter)
             _convert_poll_error!(_check_error(fd.pd, PollMode.WRITE), fd.is_file)
         catch err

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -677,16 +677,13 @@ function _iocp_submit_connect!(registration::Registration, addrbuf::Vector{UInt8
     op = reg.write_op
     op.kind = IocpOpKind.CONNECT
     op.request = IocpConnectRequest(addrbuf, addrlen)
-    @atomic :release op.active = true
-    pollnotify!(registration.write_waiter, PollWakeReason.READY)
-    return Int32(0)
+    errno = _submit_iocp_op!(registration, reg, op)
+    errno != Int32(0) && _clear_iocp_op!(op)
+    return errno
 end
 
 function _iocp_finish_connect!(registration::Registration)::Int32
-    reg = _lookup_iocp_registration(registration)
-    reg === nothing && return Int32(Base.Libc.EBADF)
-    _clear_iocp_op!(reg.write_op)
-    return Int32(0)
+    return _finish_iocp_mode!(registration, PollMode.WRITE)
 end
 
 function _iocp_cancel_mode!(registration::Registration, mode::PollMode.T)::Bool
@@ -696,6 +693,52 @@ function _iocp_cancel_mode!(registration::Registration, mode::PollMode.T)::Bool
     active = @atomic :acquire op.active
     @atomic :release op.active = false
     return active
+end
+
+function _submit_iocp_op!(registration::Registration, reg::IocpRegistration, op::IocpOp)::Int32
+    _, ok = @atomicreplace(op.active, false => true)
+    ok || return Int32(Base.Libc.EALREADY)
+    op.storage[] = _ZERO_OVERLAPPED
+    rc = Int32(-1)
+    if op.kind == IocpOpKind.PROBE_READ || op.kind == IocpOpKind.PROBE_WRITE
+        rc = Int32(0)
+    elseif op.kind == IocpOpKind.CONNECT
+        request = op.request
+        request isa IocpConnectRequest || throw(ArgumentError("missing ConnectEx request"))
+        _ = request.addrbuf
+        _ = request.addrlen
+        rc = Int32(0)
+    else
+        rc = Int32(Base.Libc.ENOSYS)
+    end
+    if op.kind == IocpOpKind.PROBE_READ || op.kind == IocpOpKind.PROBE_WRITE
+        if rc == 0
+            reg.wait_on_success && return Int32(0)
+            @atomic :release op.active = false
+            pollnotify!(
+                op.mode == PollMode.READ ? registration.read_waiter : registration.write_waiter,
+                PollWakeReason.READY,
+            )
+            return Int32(0)
+        end
+        @atomic :release op.active = false
+        return Int32(0)
+    end
+    if rc == 0
+        pollnotify!(registration.write_waiter, PollWakeReason.READY)
+        return Int32(0)
+    end
+    @atomic :release op.active = false
+    _clear_iocp_op!(op)
+    return Int32(Base.Libc.EIO)
+end
+
+function _finish_iocp_mode!(registration::Registration, mode::PollMode.T)::Int32
+    reg = _lookup_iocp_registration(registration)
+    reg === nothing && return Int32(Base.Libc.EBADF)
+    op = _iocp_op_for_mode(reg, mode)
+    _clear_iocp_op!(op)
+    return Int32(0)
 end
 
 function connect!(fd::FD, addrbuf::Vector{UInt8}, addrlen::Int32)

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -1589,6 +1589,8 @@ const _ERROR_NOT_ENOUGH_MEMORY = UInt32(8)
 const _ERROR_INVALID_HANDLE = UInt32(6)
 const _ERROR_NOT_SUPPORTED = UInt32(50)
 const _SO_UPDATE_CONNECT_CONTEXT = Int32(0x7010)
+const _SIO_GET_EXTENSION_FUNCTION_POINTER = UInt32(0xC8000006)
+const _IPPROTO_UDP = Int32(17)
 const _WSAEINTR = Int32(10004)
 const _WSAEBADF = Int32(10009)
 const _WSAEACCES = Int32(10013)
@@ -1629,6 +1631,7 @@ const _ERRNO_ESOCKTNOSUPPORT = @static isdefined(Base.Libc, :ESOCKTNOSUPPORT) ? 
 const _ERRNO_ESHUTDOWN = @static isdefined(Base.Libc, :ESHUTDOWN) ? Int32(getfield(Base.Libc, :ESHUTDOWN)) : Int32(Base.Libc.ENOTCONN)
 const _ERRNO_EHOSTDOWN = @static isdefined(Base.Libc, :EHOSTDOWN) ? Int32(getfield(Base.Libc, :EHOSTDOWN)) : Int32(Base.Libc.EHOSTUNREACH)
 const _ERRNO_ECANCELED = @static isdefined(Base.Libc, :ECANCELED) ? Int32(getfield(Base.Libc, :ECANCELED)) : Int32(Base.Libc.EINTR)
+const Cssize_t = Int
 
 struct _SockAddrHeader
     sa_family::UInt16
@@ -1666,6 +1669,27 @@ struct MsgHdr
     msg_flags::Int32
 end
 
+struct Guid
+    data1::UInt32
+    data2::UInt16
+    data3::UInt16
+    data4::NTuple{8, UInt8}
+end
+
+struct WSABuf
+    len::UInt32
+    buf::Ptr{UInt8}
+end
+
+struct WSAMsg
+    name::Ptr{Cvoid}
+    namelen::Int32
+    buffers::Ptr{WSABuf}
+    buffercount::UInt32
+    control::WSABuf
+    flags::UInt32
+end
+
 struct _WSAData
     wVersion::UInt16
     wHighVersion::UInt16
@@ -1675,6 +1699,20 @@ struct _WSAData
     iMaxUdpDg::UInt16
     lpVendorInfo::Ptr{UInt8}
 end
+
+const _WSAID_WSASENDMSG = Guid(
+    0xa441e712,
+    0x754f,
+    0x43ca,
+    (UInt8(0x84), UInt8(0xa7), UInt8(0x0d), UInt8(0xee), UInt8(0x44), UInt8(0xcf), UInt8(0x60), UInt8(0x6d)),
+)
+
+const _WSAID_WSARECVMSG = Guid(
+    0xf689d7c8,
+    0x6f1f,
+    0x436b,
+    (UInt8(0x8a), UInt8(0x53), UInt8(0xe5), UInt8(0x4f), UInt8(0xe3), UInt8(0x51), UInt8(0xc3), UInt8(0x22)),
+)
 
 @inline function _hton16(v::UInt16)::UInt16
     _is_little_endian() && return bswap(v)
@@ -1797,6 +1835,9 @@ const _winsock_initialized = Ref{Bool}(false)
 const _winsock_init_pid = Ref{Int}(0)
 const _fd_state_lock = ReentrantLock()
 const _fd_nonblocking_state = Dict{Int32, Bool}()
+const _sendrecvmsg_lock = ReentrantLock()
+const _wsasendmsg_ptr = Ref{Ptr{Cvoid}}(C_NULL)
+const _wsarecvmsg_ptr = Ref{Ptr{Cvoid}}(C_NULL)
 
 function _set_fd_nonblocking_state!(fd::Int32, enabled::Bool)
     lock(_fd_state_lock)
@@ -1816,6 +1857,108 @@ function _clear_fd_state!(fd::Int32)
         unlock(_fd_state_lock)
     end
     return nothing
+end
+
+function _fd_nonblocking_enabled(fd::Int32)::Bool
+    lock(_fd_state_lock)
+    try
+        return get(() -> false, _fd_nonblocking_state, fd)
+    finally
+        unlock(_fd_state_lock)
+    end
+end
+
+@inline function _cint_bits_u32(v::Int32)::UInt32
+    return reinterpret(UInt32, Int32(v))
+end
+
+@inline function _msg_iov_count(msg::MsgHdr)::Int
+    return Int(msg.msg_iovlen)
+end
+
+function _wsabufs_from_msghdr(msg::MsgHdr)::Vector{WSABuf}
+    count = _msg_iov_count(msg)
+    count < 0 && throw(ArgumentError("negative msg_iovlen"))
+    count == 0 && return WSABuf[]
+    msg.msg_iov == C_NULL && throw(ArgumentError("msg_iov must not be null when msg_iovlen > 0"))
+    bufs = Vector{WSABuf}(undef, count)
+    for i in 1:count
+        iov = unsafe_load(msg.msg_iov, i)
+        len = UInt32(min(iov.iov_len, Csize_t(typemax(UInt32))))
+        bufs[i] = WSABuf(len, Ptr{UInt8}(iov.iov_base))
+    end
+    return bufs
+end
+
+@inline function _wsabuf_ptr(bufs::Vector{WSABuf})::Ptr{WSABuf}
+    isempty(bufs) && return Ptr{WSABuf}(C_NULL)
+    return pointer(bufs)
+end
+
+@inline function _control_wsabuf(msg::MsgHdr)::WSABuf
+    len = UInt32(min(Csize_t(msg.msg_controllen), Csize_t(typemax(UInt32))))
+    ptr = msg.msg_control == C_NULL ? Ptr{UInt8}(C_NULL) : Ptr{UInt8}(msg.msg_control)
+    return WSABuf(len, ptr)
+end
+
+@inline function _wsamsg_from_msghdr(msg::MsgHdr, bufs::Vector{WSABuf}, flags::Int32)::WSAMsg
+    return WSAMsg(
+        msg.msg_name,
+        Int32(msg.msg_namelen),
+        _wsabuf_ptr(bufs),
+        UInt32(length(bufs)),
+        _control_wsabuf(msg),
+        _cint_bits_u32(flags),
+    )
+end
+
+function _store_wsamsg_back!(msg_ref::Ref{MsgHdr}, msg::MsgHdr, wsamsg::WSAMsg)
+    msg_ref[] = MsgHdr(
+        msg.msg_name,
+        SockLen(wsamsg.namelen),
+        msg.msg_iov,
+        msg.msg_iovlen,
+        msg.msg_control,
+        SockLen(wsamsg.control.len),
+        Int32(wsamsg.flags),
+    )
+    return nothing
+end
+
+function _load_extension_ptr!(sock::Int32, guid::Guid)::Ptr{Cvoid}
+    guid_ref = Ref(guid)
+    out_ref = Ref{Ptr{Cvoid}}(C_NULL)
+    bytes_ref = Ref{UInt32}(UInt32(0))
+    _ = sock
+    _ = guid_ref
+    _ = bytes_ref
+    return out_ref[]
+end
+
+function _load_sendrecvmsg_ptrs!()::Tuple{Ptr{Cvoid}, Ptr{Cvoid}}
+    send_ptr = _wsasendmsg_ptr[]
+    recv_ptr = _wsarecvmsg_ptr[]
+    (send_ptr != C_NULL && recv_ptr != C_NULL) && return send_ptr, recv_ptr
+    lock(_sendrecvmsg_lock)
+    try
+        send_ptr = _wsasendmsg_ptr[]
+        recv_ptr = _wsarecvmsg_ptr[]
+        if send_ptr != C_NULL && recv_ptr != C_NULL
+            return send_ptr, recv_ptr
+        end
+        sock = open_socket(AF_INET, SOCK_DGRAM, _IPPROTO_UDP)
+        try
+            recv_ptr = _load_extension_ptr!(sock, _WSAID_WSARECVMSG)
+            send_ptr = _load_extension_ptr!(sock, _WSAID_WSASENDMSG)
+        finally
+            close_socket_nothrow(sock)
+        end
+        _wsarecvmsg_ptr[] = recv_ptr
+        _wsasendmsg_ptr[] = send_ptr
+        return send_ptr, recv_ptr
+    finally
+        unlock(_sendrecvmsg_lock)
+    end
 end
 
 @static if Sys.iswindows()
@@ -2199,17 +2342,99 @@ get_peer_name_in6(fd::Int32)::SockAddrIn6 = sockaddr_in6((
         UInt8(0), UInt8(0), UInt8(0), UInt8(1),
     ), 1)
 fd_is_cloexec(fd::Int32)::Bool = true
-fd_is_nonblocking(fd::Int32)::Bool = true
+fd_is_nonblocking(fd::Int32)::Bool = _fd_nonblocking_enabled(fd)
 last_error() = Int32(Base.Libc.EAGAIN)
 recv_from!(fd::Int32, ptr::Ptr{UInt8}, nbytes, flags)::Int = 0
 read_once!(fd::Int32, ptr::Ptr{UInt8}, nbytes::Csize_t) = 0
 write_once!(fd::Int32, ptr::Ptr{UInt8}, nbytes::Csize_t) = nbytes
 send_to!(fd::Int32, ptr::Ptr{UInt8}, nbytes::Csize_t, flags::Int32, addr::Ptr{Cvoid}, addrlen::SockLen) = nbytes
-recv_msg!(fd::Int32, msg::Ref{MsgHdr}, flags::Int32 = Int32(0)) = 0
-send_msg!(fd::Int32, msg::Ref{MsgHdr}, flags::Int32 = Int32(0)) = 0
+
+function _recv_msg_simple!(fd::Int32, msg_ref::Ref{MsgHdr}, flags::Int32)::Cssize_t
+    msg = msg_ref[]
+    bufs = _wsabufs_from_msghdr(msg)
+    bytes_ref = Ref{UInt32}(UInt32(0))
+    flags_ref = Ref{UInt32}(_cint_bits_u32(flags))
+    _ = fd
+    _ = bufs
+    msg_ref[] = MsgHdr(
+        msg.msg_name,
+        msg.msg_namelen,
+        msg.msg_iov,
+        msg.msg_iovlen,
+        msg.msg_control,
+        msg.msg_controllen,
+        Int32(flags_ref[]),
+    )
+    return Cssize_t(bytes_ref[])
+end
+
+function _send_msg_simple!(fd::Int32, msg_ref::Ref{MsgHdr}, flags::Int32)::Cssize_t
+    msg = msg_ref[]
+    bufs = _wsabufs_from_msghdr(msg)
+    bytes_ref = Ref{UInt32}(UInt32(0))
+    _ = fd
+    _ = bufs
+    _ = flags
+    return Cssize_t(bytes_ref[])
+end
+
+function _recv_msg_ext!(fd::Int32, msg_ref::Ref{MsgHdr}, flags::Int32)::Cssize_t
+    _, recv_ptr = _load_sendrecvmsg_ptrs!()
+    msg = msg_ref[]
+    bufs = _wsabufs_from_msghdr(msg)
+    wmsg = Ref(_wsamsg_from_msghdr(msg, bufs, flags))
+    bytes_ref = Ref{UInt32}(UInt32(0))
+    _ = fd
+    _ = recv_ptr
+    _store_wsamsg_back!(msg_ref, msg, wmsg[])
+    return Cssize_t(bytes_ref[])
+end
+
+function _send_msg_ext!(fd::Int32, msg_ref::Ref{MsgHdr}, flags::Int32)::Cssize_t
+    send_ptr, _ = _load_sendrecvmsg_ptrs!()
+    msg = msg_ref[]
+    bufs = _wsabufs_from_msghdr(msg)
+    wmsg = Ref(_wsamsg_from_msghdr(msg, bufs, flags))
+    bytes_ref = Ref{UInt32}(UInt32(0))
+    _ = fd
+    _ = send_ptr
+    _ = wmsg
+    return Cssize_t(bytes_ref[])
+end
+
+function recv_msg!(fd::Int32, msg::Ref{MsgHdr}, flags::Int32 = Int32(0))::Cssize_t
+    msghdr = msg[]
+    if msghdr.msg_name == C_NULL && msghdr.msg_control == C_NULL
+        return _recv_msg_simple!(fd, msg, flags)
+    end
+    return _recv_msg_ext!(fd, msg, flags)
+end
+
+function send_msg!(fd::Int32, msg::Ref{MsgHdr}, flags::Int32 = Int32(0))::Cssize_t
+    msghdr = msg[]
+    if msghdr.msg_name == C_NULL && msghdr.msg_control == C_NULL
+        return _send_msg_simple!(fd, msg, flags)
+    end
+    return _send_msg_ext!(fd, msg, flags)
+end
+
 try_accept_socket(fd::Int32)::Tuple{Int32, AcceptPeer, Int32} = (Int32(3), sockaddr_in_loopback(1), Int32(0))
 accept_socket(fd::Int32)::Int32 = Int32(3)
 close_socket(fd::Int32) = nothing
+
+function finish_accept_ex!(listener_fd::Int32, acceptfd::Int32, addrbuf::Vector{UInt8})::AcceptPeer
+    _ = listener_fd
+    _ = acceptfd
+    GC.@preserve addrbuf begin
+        addrptr = Ptr{UInt8}(pointer(addrbuf))
+        return _decode_accept_peer(addrptr, SockLen(length(addrbuf)))
+    end
+end
+
+function __init__()
+    @static Sys.iswindows() && ensure_winsock!()
+    return nothing
+end
 
 end
 

--- a/test/windows-compiler-bug.jl
+++ b/test/windows-compiler-bug.jl
@@ -922,6 +922,8 @@ function _connect_socketaddr_impl(
         attempt_deadline::Int64,
         state,
     )::Conn
+    println("[windows-compiler-bug] enter _connect_socketaddr_impl")
+    flush(stdout)
     family = _addr_family(remote_addr)
     if local_addr !== nothing && _addr_family(local_addr) != family
         throw(ArgumentError("local and remote address families must match"))
@@ -1826,6 +1828,8 @@ function _resolve_serial(
         deadline_ns::Int64,
         state::DNSRaceState,
     )::Tuple{Union{Nothing, TCP.Conn}, Union{Nothing, Exception}}
+    println("[windows-compiler-bug] enter _resolve_serial")
+    flush(stdout)
     _ = network
     first_err::Union{Nothing, Exception} = nothing
     for (i, remote_addr) in pairs(addrs)
@@ -1849,6 +1853,8 @@ function _resolve_serial(
                     return nothing, first_err
                 end
                 try
+                    println("[windows-compiler-bug] before _connect_socketaddr_impl")
+                    flush(stdout)
                     conn = TCP._connect_socketaddr_impl(remote_addr, d.local_addr, attempt_deadline, state)
                     if d.local_addr === nothing && _is_self_connect(conn) && attempt < max_attempts
                         close(conn)
@@ -1972,6 +1978,8 @@ function connect(
         network::AbstractString,
         address::AbstractString,
     )::TCP.Conn
+    println("[windows-compiler-bug] enter HostResolvers.connect")
+    flush(stdout)
     deadline_ns = _connect_deadline_ns(d)
     if deadline_ns != 0 && Int64(time_ns()) >= deadline_ns
         throw(_wrap_op_error("connect", network, d.local_addr, nothing, DNSTimeoutError(String(address))))
@@ -1986,6 +1994,8 @@ function connect(
     catch err
         throw(_wrap_op_error("connect", network, d.local_addr, nothing, _as_exception(err)))
     end
+    println("[windows-compiler-bug] resolved addrs")
+    flush(stdout)
     if deadline_ns != 0 && Int64(time_ns()) >= deadline_ns
         throw(_wrap_op_error("connect", network, d.local_addr, nothing, DNSTimeoutError(String(address))))
     end


### PR DESCRIPTION
## Summary
- isolate a dedicated Windows-only compiler-bug workflow
- keep the normal CI workflow from running when the PR only touches the repro files
- build `test/windows-compiler-bug.jl` up from a near-empty baseline to a minimal reproducer

## Current reproducer
- baseline empty-file run: `23228214795` (green)
- minimal reproducer run: `23228278617` (red by design)
- the smaller TCP/HostResolver string-address kwcalls were sufficient:
  - `TCP.connect("tcp", "127.0.0.1:1"; local_addr = TCP.loopback_addr(0))`
  - `TCP.connect("tcp", "127.0.0.1:1"; local_addr = TCP.loopback_addr6(0))`

## Result
The dedicated Windows `JULIA_NUM_THREADS=2` job now reproduces the compiler internal error and fails intentionally when the log contains the `TryCatchFrame` / `Internal error: during type inference of` signature.
