### PR TITLE
Tighten TLS entrypoints, resolver errors, and macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,14 @@ jobs:
             os: macOS-latest
             arch: aarch64
             threads: 1
+          - version: 'min'
+            os: macOS-latest
+            arch: aarch64
+            threads: 1
+          - version: 'pre'
+            os: macOS-latest
+            arch: aarch64
+            threads: 1
           - version: '1'
             os: ubuntu-latest
             arch: x64

--- a/README.md
+++ b/README.md
@@ -114,12 +114,15 @@ config = TLS.Config(
     key_file = "server.key",
 )
 
-listener = TLS.listen("tcp", "127.0.0.1:8443", config)
+listener = TLS.listen(TCP.loopback_addr(8443), config)
 conn = TLS.accept(listener)
 
 close(conn)
 close(listener)
 ```
+
+When you already have a concrete endpoint, `TLS.connect` accepts
+`TCP.SocketAddr` values directly as well.
 
 For verified client-certificate auth, provide `client_ca_file` explicitly:
 

--- a/docs/src/resolution.md
+++ b/docs/src/resolution.md
@@ -62,6 +62,23 @@ The usual default path is:
 Add `CachingResolver` or `StaticResolver` when you want explicit control over
 lookup reuse or deterministic test-time address mapping.
 
+## Error Types
+
+String-address dialing and listening surface a small set of resolver-layer
+errors:
+
+```@docs; canonical=false
+AddressError
+LookupError
+UnknownNetworkError
+DialTimeoutError
+OpError
+```
+
+`OpError` is the high-level wrapper for connect/listen failures. Its inner
+`err` preserves the more specific cause such as malformed input, lookup
+failure, unsupported network, or a dial timeout.
+
 ## Resolving Explicitly
 
 If you want the concrete address list before dialing, use the explicit helper

--- a/docs/src/tls.md
+++ b/docs/src/tls.md
@@ -7,7 +7,8 @@ Description = "TLS clients, listeners, configuration, and handshake behavior in 
 
 `TLS` wraps `TCP` connections and listeners with OpenSSL-backed TLS state while
 keeping deadlines and socket lifecycle aligned with the underlying transport.
-String-address client dialing uses the same resolver/policy layer as
+Concrete-address dialing and listening use the same `connect` and `listen`
+entrypoints as the string-address surface. String-address client dialing uses the resolver/policy layer as
 [`Reseau.TCP.connect`](@ref Reseau.TCP.connect); see [Name Resolution](@ref name-resolution-manual)
 for that part of the stack.
 
@@ -43,8 +44,8 @@ explicitly in [`Config`](@ref).
 
 ## Client and Server Construction
 
-You can either dial and handshake a client in one step, or wrap an existing
-`TCP.Conn` manually:
+You can either dial and handshake a client in one step from a concrete
+`TCP.SocketAddr` or string address, or wrap an existing `TCP.Conn` manually:
 
 ```@docs; canonical=false
 client
@@ -57,7 +58,7 @@ handshake!
 
 Important behaviors to keep in mind:
 
-- [`connect`](@ref) returns a fully handshaken client connection.
+- [`connect`](@ref) returns a fully handshaken client connection for both concrete-address and string-address dialing.
 - [`listen`](@ref) returns a TLS listener whose accepted connections are
   lazy-handshake wrappers.
 - [`client`](@ref) and [`server`](@ref) are the direct wrapping APIs when you

--- a/src/3_tcp.jl
+++ b/src/3_tcp.jl
@@ -157,13 +157,46 @@ function any_addr6(port::Integer; scope_id::Integer = 0)::SocketAddrV6
 end
 
 function _format_ipv6(ip::NTuple{16, UInt8})::String
-    groups = String[]
+    groups = UInt16[]
     for i in 1:8
         hi = UInt16(ip[(2 * i) - 1])
         lo = UInt16(ip[2 * i])
-        push!(groups, string((hi << 8) | lo, base = 16))
+        push!(groups, (hi << 8) | lo)
     end
-    return join(groups, ":")
+    best_start = 0
+    best_len = 0
+    i = 1
+    while i <= length(groups)
+        if groups[i] == 0
+            j = i
+            while j <= length(groups) && groups[j] == 0
+                j += 1
+            end
+            run_len = j - i
+            if run_len > best_len && run_len >= 2
+                best_start = i
+                best_len = run_len
+            end
+            i = j
+        else
+            i += 1
+        end
+    end
+    if best_len >= 2
+        left = [string(groups[idx], base = 16) for idx in 1:(best_start - 1)]
+        right_start = best_start + best_len
+        right = [string(groups[idx], base = 16) for idx in right_start:length(groups)]
+        if isempty(left) && isempty(right)
+            return "::"
+        elseif isempty(left)
+            return "::" * join(right, ":")
+        elseif isempty(right)
+            return join(left, ":") * "::"
+        else
+            return join(left, ":") * "::" * join(right, ":")
+        end
+    end
+    return join((string(group, base = 16) for group in groups), ":")
 end
 
 function Base.show(io::IO, addr::SocketAddrV4)

--- a/src/4_host_resolvers.jl
+++ b/src/4_host_resolvers.jl
@@ -1657,6 +1657,10 @@ end
     return nothing
 end
 
+@inline function _same_addr_family(a::TCP.SocketEndpoint, b::TCP.SocketEndpoint)::Bool
+    return (_is_ipv4(a) && _is_ipv4(b)) || (_is_ipv6(a) && _is_ipv6(b))
+end
+
 @inline function _wrap_op_error(
         op::AbstractString,
         net::AbstractString,
@@ -1876,6 +1880,17 @@ function connect(
         _resolve_with_deadline(d, network, address, deadline_ns)
     catch err
         throw(_wrap_op_error("connect", network, d.local_addr, nothing, _as_exception(err)))
+    end
+    if d.local_addr !== nothing
+        local_addr = d.local_addr::TCP.SocketEndpoint
+        filtered = TCP.SocketEndpoint[]
+        for addr in addrs
+            _same_addr_family(addr, local_addr) && push!(filtered, addr)
+        end
+        if isempty(filtered)
+            throw(_wrap_op_error("connect", network, local_addr, nothing, ArgumentError("local and remote address families must match")))
+        end
+        addrs = filtered
     end
     if deadline_ns != 0 && Int64(time_ns()) >= deadline_ns
         throw(_wrap_op_error("connect", network, d.local_addr, nothing, DialTimeoutError(String(address))))

--- a/src/4_host_resolvers.jl
+++ b/src/4_host_resolvers.jl
@@ -44,21 +44,31 @@ struct UnknownNetworkError <: Exception
 end
 
 """
-    DNSTimeoutError
+    LookupError
 
-Raised when connect cannot complete before the configured deadline.
+Host or service lookup failure.
 """
-struct DNSTimeoutError <: Exception
+struct LookupError <: Exception
+    err::String
+    name::String
+end
+
+"""
+    DialTimeoutError
+
+Raised when dial cannot complete before the configured deadline.
+"""
+struct DialTimeoutError <: Exception
     address::String
 end
 
 """
-    DNSOpError
+    OpError
 
 High-level connect/listen operation error wrapper that preserves operation
 context.
 """
-struct DNSOpError <: Exception
+struct OpError <: Exception
     op::String
     net::String
     source::Union{Nothing, TCP.SocketEndpoint}
@@ -76,12 +86,21 @@ function Base.showerror(io::IO, err::UnknownNetworkError)
     return nothing
 end
 
-function Base.showerror(io::IO, err::DNSTimeoutError)
-    print(io, "connect timeout: $(err.address)")
+function Base.showerror(io::IO, err::LookupError)
+    print(io, "$(err.err): $(err.name)")
     return nothing
 end
 
-function Base.showerror(io::IO, err::DNSOpError)
+function Base.showerror(io::IO, err::DialTimeoutError)
+    if isempty(err.address)
+        print(io, "dial timeout")
+    else
+        print(io, "dial timeout: $(err.address)")
+    end
+    return nothing
+end
+
+function Base.showerror(io::IO, err::OpError)
     print(io, "$(err.op) $(err.net)")
     err.source === nothing || print(io, " ", err.source)
     err.addr === nothing || print(io, " -> ", err.addr)
@@ -173,7 +192,7 @@ Explicit opt-in hostname cache with policy TTLs.
 
 This caches positive host-IP lookups for `ttl_ns`, may serve stale positives for
 up to `stale_ttl_ns` while refreshing in the background, and may cache
-`AddressError` failures for `negative_ttl_ns`. `max_hosts` bounds the number of
+`LookupError` failures for `negative_ttl_ns`. `max_hosts` bounds the number of
 cached host keys and evicts the least-recently-used entry when full.
 """
 mutable struct CachingResolver{R <: AbstractResolver} <: AbstractResolver
@@ -615,7 +634,7 @@ function _native_getaddrinfo(hostname::AbstractString; flags::Cint = Cint(0))::V
             result_ptr,
         )
     end
-    ret == 0 || _addr_error("lookup failed: $(_gai_error_string(ret))", hostname_s)
+    ret == 0 || _lookup_error("lookup failed: $(_gai_error_string(ret))", hostname_s)
     try
         current = result_ptr[]
         while current != C_NULL
@@ -696,6 +715,10 @@ end
 
 function _addr_error(err::AbstractString, addr::AbstractString)
     throw(AddressError(String(err), String(addr)))
+end
+
+function _lookup_error(err::AbstractString, name::AbstractString)
+    throw(LookupError(String(err), String(name)))
 end
 
 @inline function _is_ipv4(addr::TCP.SocketEndpoint)::Bool
@@ -784,7 +807,7 @@ end
 
 function _parse_port_table(table::Dict{String, Int}, network::AbstractString, service::AbstractString)::Int
     port = get(() -> nothing, table, lowercase(String(service)))
-    port === nothing && _addr_error("unknown port", string(network, "/", service))
+    port === nothing && _lookup_error("unknown port", string(network, "/", service))
     return port::Int
 end
 
@@ -950,7 +973,7 @@ function lookup_port(::SystemResolver, network::AbstractString, service::Abstrac
         elseif n == "udp" || n == "udp4" || n == "udp6"
             port = _parse_port_table(_SERVICE_UDP, n, service)
         else
-            _addr_error("unknown network", n)
+            throw(UnknownNetworkError(n))
         end
     end
     (port < 0 || port > 65535) && _addr_error("invalid port", service)
@@ -980,7 +1003,7 @@ function lookup_port(resolver::StaticResolver, network::AbstractString, service:
                 port = _parse_port_table(_SERVICE_UDP, n, service)
             end
         else
-            _addr_error("unknown network", n)
+            throw(UnknownNetworkError(n))
         end
     end
     (port < 0 || port > 65535) && _addr_error("invalid port", service)
@@ -1057,7 +1080,7 @@ function _resolve_static_host(
     literal === nothing || return TCP.SocketEndpoint[literal]
     mapped = get(() -> nothing, resolver.hosts, lowercase(h))
     mapped === nothing || return copy(mapped::Vector{TCP.SocketEndpoint})
-    resolver.fallback === nothing && _addr_error("no suitable address", h)
+    resolver.fallback === nothing && _lookup_error("no suitable address", h)
     return _resolve_host_ips(resolver.fallback::AbstractResolver, network, h)
 end
 
@@ -1207,7 +1230,7 @@ function _refresh_cached_host!(
             return nothing
         end
         entry.refreshing = false
-        if err isa AddressError && resolver.negative_ttl_ns > 0
+        if err isa LookupError && resolver.negative_ttl_ns > 0
             _store_cache_entry_locked!(resolver, key, nothing, err, now_ns)
         end
     finally
@@ -1274,7 +1297,7 @@ function _resolve_cached_host(
     try
         if err === nothing
             _store_cache_entry_locked!(resolver, key, result::Vector{TCP.SocketEndpoint}, nothing, now_ns)
-        elseif err isa AddressError && resolver.negative_ttl_ns > 0
+        elseif err isa LookupError && resolver.negative_ttl_ns > 0
             _store_cache_entry_locked!(resolver, key, nothing, err, now_ns)
         end
     finally
@@ -1377,7 +1400,8 @@ Keyword arguments:
 Returns a `Vector{TCP.SocketEndpoint}` in the order that subsequent connection
 logic should attempt.
 
-Throws `AddressError` or `UnknownNetworkError` when parsing or resolution fails.
+Throws `AddressError`, `LookupError`, or `UnknownNetworkError` when parsing or
+resolution fails.
 """
 function resolve_tcp_addrs(
         resolver::AbstractResolver,
@@ -1397,7 +1421,7 @@ function resolve_tcp_addrs(
         _resolve_host_ips(resolver, network, host)
     end
     filtered = _apply_policy_and_network(ips, kind, policy)
-    isempty(filtered) && _addr_error("no suitable address", host)
+    isempty(filtered) && _lookup_error("no suitable address", host)
     out = TCP.SocketEndpoint[]
     for ipaddr in filtered
         push!(out, _with_port(ipaddr, port))
@@ -1547,7 +1571,7 @@ function _resolve_with_deadline(
     )::Vector{TCP.SocketEndpoint}
     deadline_ns == 0 && return resolve_tcp_addrs(d.resolver, network, address; op = :connect, policy = d.policy)
     now_ns = Int64(time_ns())
-    now_ns >= deadline_ns && throw(DNSTimeoutError(String(address)))
+    now_ns >= deadline_ns && throw(DialTimeoutError(String(address)))
     mtx = ReentrantLock()
     condition = Threads.Condition(mtx)
     done = Ref(false)
@@ -1591,9 +1615,9 @@ function _resolve_with_deadline(
         unlock(mtx)
         _close_timer_task!(timer, timer_task)
     end
-    timed_out[] && throw(DNSTimeoutError(String(address)))
+    timed_out[] && throw(DialTimeoutError(String(address)))
     result = result_ref[]
-    result === nothing && throw(DNSTimeoutError(String(address)))
+    result === nothing && throw(DialTimeoutError(String(address)))
     result isa Exception && throw(result)
     return result::Vector{TCP.SocketEndpoint}
 end
@@ -1601,7 +1625,7 @@ end
 function _partial_deadline_ns(now_ns::Int64, deadline_ns::Int64, addrs_remaining::Int)::Int64
     deadline_ns == 0 && return Int64(0)
     time_remaining = deadline_ns - now_ns
-    time_remaining <= 0 && throw(DNSTimeoutError(""))
+    time_remaining <= 0 && throw(DialTimeoutError(""))
     # Avoid spending the entire remaining budget on the first address candidate
     # when multiple endpoints remain to be tried.
     timeout = time_remaining ÷ addrs_remaining
@@ -1639,8 +1663,8 @@ end
         source::Union{Nothing, TCP.SocketEndpoint},
         addr::Union{Nothing, TCP.SocketEndpoint},
         err::Exception,
-    )::DNSOpError
-    return DNSOpError(String(op), String(net), source, addr, err)
+    )::OpError
+    return OpError(String(op), String(net), source, addr, err)
 end
 
 @inline function _as_exception(err)::Exception
@@ -1686,13 +1710,13 @@ function _resolve_serial(
         end
         now_ns = Int64(time_ns())
         if deadline_ns != 0 && now_ns >= deadline_ns
-            return nothing, DNSTimeoutError(String(address))
+            return nothing, DialTimeoutError(String(address))
         end
         attempt_deadline = try
             _partial_deadline_ns(now_ns, deadline_ns, length(addrs) - i + 1)
         catch err
-            err isa DNSTimeoutError || rethrow(err)
-            return nothing, DNSTimeoutError(String(address))
+            err isa DialTimeoutError || rethrow(err)
+            return nothing, DialTimeoutError(String(address))
         end
         try
             max_attempts = d.local_addr === nothing ? 3 : 1
@@ -1722,7 +1746,7 @@ function _resolve_serial(
                        attempt < max_attempts
                         continue
                     end
-                    mapped = ex isa IOPoll.DeadlineExceededError ? DNSTimeoutError(String(address)) : ex
+                    mapped = ex isa IOPoll.DeadlineExceededError ? DialTimeoutError(String(address)) : ex
                     first_err === nothing && (first_err = mapped)
                     break
                 end
@@ -1830,9 +1854,9 @@ Connect a TCP connection from a `host:port` string.
 This resolves the address, applies deadline and policy rules, optionally runs a
 dual-stack race, and returns a connected `TCP.Conn`.
 
-Throws `DNSOpError` on failure. The wrapped `err` may be an `AddressError`,
-`DNSTimeoutError`, `UnknownNetworkError`, `SystemError`, or a lower-level poll
-error depending on which phase failed.
+Throws `OpError` on failure. The wrapped `err` may be an `AddressError`,
+`LookupError`, `DialTimeoutError`, `UnknownNetworkError`, `SystemError`, or a
+lower-level poll error depending on which phase failed.
 """
 function connect(
         d::HostResolver,
@@ -1841,7 +1865,7 @@ function connect(
     )::TCP.Conn
     deadline_ns = _connect_deadline_ns(d)
     if deadline_ns != 0 && Int64(time_ns()) >= deadline_ns
-        throw(_wrap_op_error("connect", network, d.local_addr, nothing, DNSTimeoutError(String(address))))
+        throw(_wrap_op_error("connect", network, d.local_addr, nothing, DialTimeoutError(String(address))))
     end
     kind = try
         _network_kind(network)
@@ -1854,7 +1878,7 @@ function connect(
         throw(_wrap_op_error("connect", network, d.local_addr, nothing, _as_exception(err)))
     end
     if deadline_ns != 0 && Int64(time_ns()) >= deadline_ns
-        throw(_wrap_op_error("connect", network, d.local_addr, nothing, DNSTimeoutError(String(address))))
+        throw(_wrap_op_error("connect", network, d.local_addr, nothing, DialTimeoutError(String(address))))
     end
     _prefer_ipv4_first!(addrs, d.policy)
     primaries, fallbacks = _partition_addrs(addrs)
@@ -1918,7 +1942,7 @@ Keyword arguments:
 - `backlog`: listen backlog passed to the kernel
 - `reuseaddr`: whether to enable `SO_REUSEADDR` on the underlying socket
 
-Throws `DNSOpError` if resolution fails or no candidate can be bound.
+Throws `OpError` if resolution fails or no candidate can be bound.
 """
 function listen(
         d::HostResolver,

--- a/src/5_tls.jl
+++ b/src/5_tls.jl
@@ -1729,6 +1729,49 @@ function _prepare_connect_config(config::Config, address::AbstractString)::Confi
     return _config_with_server_name(config, host)
 end
 
+function _prepare_connect_config(config::Config, remote_addr::TCP.SocketAddr)::Config
+    config.server_name !== nothing && return config
+    host = try
+        hostport = sprint(show, remote_addr)
+        parsed_host, _ = HostResolvers.split_host_port(hostport)
+        _normalize_peer_name(parsed_host)
+    catch
+        ""
+    end
+    isempty(host) && return config
+    return _config_with_server_name(config, host)
+end
+
+function _connect_client(tcp::TCP.Conn, config::Config, deadline_ns::Int64 = Int64(0))::Conn
+    tls_conn = try
+        client(tcp, config)
+    catch err
+        ex = _as_exception(err)
+        try
+            close(tcp)
+        catch
+        end
+        ex isa Exception && rethrow()
+    end
+    try
+        if deadline_ns != 0
+            _with_temporary_deadline_cap(tls_conn, deadline_ns) do
+                handshake!(tls_conn)
+            end
+        else
+            handshake!(tls_conn)
+        end
+        return tls_conn
+    catch err
+        ex = _as_exception(err)
+        try
+            close(tls_conn)
+        catch
+        end
+        ex isa Exception && rethrow()
+    end
+end
+
 function _connect(
         host_resolver::HostResolvers.HostResolver,
         network::AbstractString,
@@ -1738,28 +1781,41 @@ function _connect(
     tls_config = _prepare_connect_config(config, address)
     connect_deadline_ns = HostResolvers._connect_deadline_ns(host_resolver)
     tcp = TCP.connect(host_resolver, network, address)
-    tls_conn = nothing
-    try
-        tls_conn = client(tcp, tls_config)
-        _with_temporary_deadline_cap(tls_conn, connect_deadline_ns) do
-            handshake!(tls_conn)
-        end
-        return tls_conn
-    catch err
-        ex = _as_exception(err)
-        if tls_conn !== nothing
-            try
-                close(tls_conn)
-            catch
-            end
-        else
-            try
-                close(tcp)
-            catch
-            end
-        end
-        ex isa Exception && rethrow()
-    end
+    return _connect_client(tcp, tls_config, connect_deadline_ns)
+end
+
+function _connect(
+        remote_addr::TCP.SocketAddr,
+        local_addr::Union{Nothing, TCP.SocketAddr},
+        config::Config,
+    )::Conn
+    tls_config = _prepare_connect_config(config, remote_addr)
+    tcp = TCP.connect(remote_addr, local_addr)
+    return _connect_client(tcp, tls_config)
+end
+
+"""
+    connect(remote_addr; kwargs...) -> Conn
+    connect(remote_addr, local_addr; kwargs...) -> Conn
+
+Connect to a concrete `TCP.SocketAddr`, negotiate TLS, and return a fully
+handshaken client connection.
+
+This is the direct-address counterpart to the string-address `connect(network,
+address; ...)` overloads. The underlying socket setup is delegated to
+`TCP.connect`, after which the returned transport is wrapped in TLS and
+handshaken immediately.
+
+TLS keyword arguments are forwarded to `Config`. If `server_name` is omitted, it
+is inferred from the concrete remote address when possible so peer verification
+and SNI can follow the same rules as the string-address client path.
+"""
+function connect(remote_addr::TCP.SocketAddr; kw...)::Conn
+    return _connect(remote_addr, nothing, Config(; kw...))
+end
+
+function connect(remote_addr::TCP.SocketAddr, local_addr::Union{Nothing, TCP.SocketAddr}; kw...)::Conn
+    return _connect(remote_addr, local_addr, Config(; kw...))
 end
 
 """
@@ -1814,6 +1870,26 @@ Convenience shorthand for `connect("tcp", address; kwargs...)`.
 """
 function connect(address::AbstractString; kwargs...)::Conn
     return connect("tcp", address; kwargs...)
+end
+
+"""
+    listen(local_addr, config; backlog=128, reuseaddr=true) -> Listener
+
+Create a TLS listener from a concrete local `TCP.SocketAddr`.
+
+This is the direct-address counterpart to `listen(network, address, config;
+...)`. The underlying TCP listener is created with `TCP.listen`, then accepted
+connections are wrapped in lazy-handshake TLS state.
+"""
+function listen(
+        local_addr::TCP.SocketAddr,
+        config::Config;
+        backlog::Integer = 128,
+        reuseaddr::Bool = true,
+    )::Listener
+    _validate_config(config; is_server = true)
+    listener = TCP.listen(local_addr; backlog = backlog, reuseaddr = reuseaddr)
+    return Listener(listener, config)
 end
 
 end

--- a/src/6_precompile_workload.jl
+++ b/src/6_precompile_workload.jl
@@ -255,7 +255,7 @@ function _pc_run_tls_workload!()
             key_file = key_path::String,
             handshake_timeout_ns = 1_000_000_000,
         )
-        listener = TL.listen("tcp", "127.0.0.1:0", server_cfg; backlog = 8)
+        listener = TL.listen(NC.loopback_addr(0), server_cfg; backlog = 8)
         laddr = TL.addr(listener)::NC.SocketAddrV4
         accept_task = errormonitor(Threads.@spawn begin
             conn = TL.accept(listener::TL.Listener)
@@ -268,8 +268,7 @@ function _pc_run_tls_workload!()
             handshake_timeout_ns = 1_000_000_000,
         )
         client = TL.connect(
-            "tcp",
-            "127.0.0.1:$(Int(laddr.port))";
+            NC.loopback_addr(Int(laddr.port));
             server_name = client_cfg.server_name,
             verify_peer = client_cfg.verify_peer,
             client_auth = client_cfg.client_auth,

--- a/test/host_resolvers_tests.jl
+++ b/test/host_resolvers_tests.jl
@@ -317,7 +317,7 @@ end
             else
                 @test true
             end
-            @test_throws ND.AddressError ND.lookup_port("tcp", "reseau-unknown-service")
+            @test_throws ND.LookupError ND.lookup_port("tcp", "reseau-unknown-service")
             static_lookup = ND.StaticResolver(
                 services_tcp = Dict("smtp-alt" => 2525),
                 services_udp = Dict("dns-alt" => 5353),
@@ -327,8 +327,8 @@ end
             @test ND.lookup_port(static_lookup, "tcp", "fallbacksvc") == 2626
             udp_fallback = ND.StaticResolver(fallback = ND.StaticResolver(services_udp = Dict("udp-fallback" => 5354)))
             @test ND.lookup_port(udp_fallback, "udp", "udp-fallback") == 5354
-            @test_throws ND.AddressError ND.lookup_port("sctp", "domain")
-            @test_throws ND.AddressError ND.lookup_port(static_lookup, "sctp", "smtp-alt")
+            @test_throws ND.UnknownNetworkError ND.lookup_port("sctp", "domain")
+            @test_throws ND.UnknownNetworkError ND.lookup_port(static_lookup, "sctp", "smtp-alt")
         end
         @testset "resolver policies and static resolver" begin
             v4 = NC.loopback_addr(9000)
@@ -359,7 +359,7 @@ end
             )
             @test length(addrs_v4_only) == 1
             @test addrs_v4_only[1] isa NC.SocketAddrV4
-            @test_throws ND.AddressError ND.resolve_tcp_addrs(
+            @test_throws ND.LookupError ND.resolve_tcp_addrs(
                 resolver,
                 "tcp",
                 "v4.local:echo";
@@ -368,7 +368,7 @@ end
             @test ND._resolve_static_host(resolver, "tcp", "DUAL.LOCAL") == NC.SocketEndpoint[v6, v4]
             fallback_only = ND.StaticResolver(fallback = ND.StaticResolver(hosts = Dict("fallback.only" => NC.SocketEndpoint[NC.loopback_addr(9090)])))
             @test ND._resolve_static_host(fallback_only, "tcp", "fallback.only") == NC.SocketEndpoint[NC.loopback_addr(9090)]
-            @test_throws ND.AddressError ND._resolve_static_host(ND.StaticResolver(), "tcp", "missing.static.test")
+            @test_throws ND.LookupError ND._resolve_static_host(ND.StaticResolver(), "tcp", "missing.static.test")
         end
         @testset "wildcard ordering and self-connect helper" begin
             listen_addrs = ND.resolve_tcp_addrs(ND.DEFAULT_RESOLVER, "tcp", ":0"; op = :listen)
@@ -417,8 +417,8 @@ end
             catch ex
                 ex
             end
-            @test bad_host_err isa ND.AddressError
-            if bad_host_err isa ND.AddressError
+            @test bad_host_err isa ND.LookupError
+            if bad_host_err isa ND.LookupError
                 @test occursin("lookup failed", bad_host_err.err)
             end
         end
@@ -521,8 +521,8 @@ end
                     catch ex
                         ex
                     end
-                    @test err isa ND.DNSOpError
-                    if err isa ND.DNSOpError
+                    @test err isa ND.OpError
+                    if err isa ND.OpError
                         @test err.err isa Exception
                         @test err.addr !== nothing
                     end
@@ -576,9 +576,9 @@ end
                     ex
                 end
                 elapsed_ms = (time_ns() - started_ns) / 1.0e6
-                @test timeout_err isa ND.DNSOpError
-                if timeout_err isa ND.DNSOpError
-                    @test timeout_err.err isa ND.DNSTimeoutError
+                @test timeout_err isa ND.OpError
+                if timeout_err isa ND.OpError
+                    @test timeout_err.err isa ND.DialTimeoutError
                 end
                 @test elapsed_ms < 1_000.0
                 threadcall_resolver = _ThreadcallResolver(UInt32(250), NC.SocketEndpoint[NC.loopback_addr(1)])
@@ -590,9 +590,9 @@ end
                     ex
                 end
                 threadcall_elapsed_ms = (time_ns() - threadcall_started_ns) / 1.0e6
-                @test threadcall_timeout_err isa ND.DNSOpError
-                if threadcall_timeout_err isa ND.DNSOpError
-                    @test threadcall_timeout_err.err isa ND.DNSTimeoutError
+                @test threadcall_timeout_err isa ND.OpError
+                if threadcall_timeout_err isa ND.OpError
+                    @test threadcall_timeout_err.err isa ND.DialTimeoutError
                 end
                 @test threadcall_elapsed_ms < 1_000.0
                 empty_net_err = try
@@ -608,8 +608,8 @@ end
                 catch ex
                     ex
                 end
-                @test err_unknown isa ND.DNSOpError
-                if err_unknown isa ND.DNSOpError
+                @test err_unknown isa ND.OpError
+                if err_unknown isa ND.OpError
                     @test err_unknown.err isa ND.UnknownNetworkError
                 end
                 err_bad_addr = try
@@ -618,8 +618,8 @@ end
                 catch ex
                     ex
                 end
-                @test err_bad_addr isa ND.DNSOpError
-                if err_bad_addr isa ND.DNSOpError
+                @test err_bad_addr isa ND.OpError
+                if err_bad_addr isa ND.OpError
                     @test err_bad_addr.err isa ND.AddressError
                 end
                 past_deadline = Int64(time_ns()) - Int64(1)
@@ -629,9 +629,9 @@ end
                 catch ex
                     ex
                 end
-                @test err_timeout isa ND.DNSOpError
-                if err_timeout isa ND.DNSOpError
-                    @test err_timeout.err isa ND.DNSTimeoutError
+                @test err_timeout isa ND.OpError
+                if err_timeout isa ND.OpError
+                    @test err_timeout.err isa ND.DialTimeoutError
                 end
             end
         end
@@ -703,7 +703,7 @@ end
             ND.resolve_tcp_addrs(evict_cache, "tcp", "host-one.test:80")
             @test evict_parent.calls == 3
 
-            neg_parent = _ErrorResolver(ND.AddressError("lookup failed", "neg.test"); delay_s = 0.0)
+            neg_parent = _ErrorResolver(ND.LookupError("lookup failed", "neg.test"); delay_s = 0.0)
             neg_cache = ND.CachingResolver(neg_parent; ttl_ns = 0, stale_ttl_ns = 0, negative_ttl_ns = 50_000_000, max_hosts = 8)
             err1 = try
                 ND.resolve_tcp_addrs(neg_cache, "tcp", "neg.test:80")
@@ -717,8 +717,8 @@ end
             catch ex
                 ex
             end
-            @test err1 isa ND.AddressError
-            @test err2 isa ND.AddressError
+            @test err1 isa ND.LookupError
+            @test err2 isa ND.LookupError
             @test neg_parent.calls == 1
             @test (@atomic :acquire neg_cache.negative_hits) == 1
             sleep(0.06)
@@ -728,11 +728,11 @@ end
             catch ex
                 ex
             end
-            @test err3 isa ND.AddressError
+            @test err3 isa ND.LookupError
             @test neg_parent.calls == 2
         end
         @testset "singleflight and cache refresh error paths" begin
-            err_resolver = _ErrorResolver(ND.AddressError("lookup failed", "singleflight-error.test"); delay_s = 0.02)
+            err_resolver = _ErrorResolver(ND.LookupError("lookup failed", "singleflight-error.test"); delay_s = 0.02)
             singleflight = ND.SingleflightResolver(err_resolver)
             task1 = errormonitor(Threads.@spawn try
                 ND._resolve_host_ips(singleflight, "tcp", "singleflight-error.test")
@@ -746,13 +746,13 @@ end
             end)
             @test _nd_wait_task_done(task1, 2.0) != :timed_out
             @test _nd_wait_task_done(task2, 2.0) != :timed_out
-            @test fetch(task1) isa ND.AddressError
-            @test fetch(task2) isa ND.AddressError
+            @test fetch(task1) isa ND.LookupError
+            @test fetch(task2) isa ND.LookupError
             @test err_resolver.calls == 1
             @test (@atomic :acquire singleflight.actual_lookups) == 1
             @test (@atomic :acquire singleflight.shared_hits) == 1
 
-            refresh_parent = _ErrorResolver(ND.AddressError("lookup failed", "refresh.test"); delay_s = 0.0)
+            refresh_parent = _ErrorResolver(ND.LookupError("lookup failed", "refresh.test"); delay_s = 0.0)
             refresh_cache = ND.CachingResolver(refresh_parent; ttl_ns = 1_000_000, stale_ttl_ns = 50_000_000, negative_ttl_ns = 50_000_000, max_hosts = 8)
             key = ND._lookup_key("tcp", "refresh.test")
             old_now_ns = Int64(time_ns()) - Int64(100_000_000)
@@ -768,7 +768,7 @@ end
             try
                 entry = refresh_cache.entries[key]
                 @test !entry.refreshing
-                @test entry.err isa ND.AddressError
+                @test entry.err isa ND.LookupError
                 @test entry.result === nothing
             finally
                 unlock(refresh_cache.lock)

--- a/test/host_resolvers_tests.jl
+++ b/test/host_resolvers_tests.jl
@@ -330,6 +330,9 @@ end
             @test_throws ND.UnknownNetworkError ND.lookup_port("sctp", "domain")
             @test_throws ND.UnknownNetworkError ND.lookup_port(static_lookup, "sctp", "smtp-alt")
         end
+        @testset "resolve_tcp_addr convenience wrapper" begin
+            @test ND.resolve_tcp_addr("tcp", "127.0.0.1:80") == NC.loopback_addr(80)
+        end
         @testset "resolver policies and static resolver" begin
             v4 = NC.loopback_addr(9000)
             v6 = NC.loopback_addr6(9000)

--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -105,8 +105,8 @@ end
                 catch ex
                     ex
                 end
-                @test mismatch_err isa Reseau.HostResolvers.DNSOpError
-                if mismatch_err isa Reseau.HostResolvers.DNSOpError
+                @test mismatch_err isa Reseau.HostResolvers.OpError
+                if mismatch_err isa Reseau.HostResolvers.OpError
                     @test mismatch_err.err isa ArgumentError
                 end
             finally

--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -255,6 +255,37 @@ end
                 IP.shutdown!()
             end
         end
+        @testset "combined deadline applies to both read and write state" begin
+            IP.shutdown!()
+            listener = nothing
+            client = nothing
+            server = nothing
+            try
+                listener = NC.listen(NC.loopback_addr(0); backlog = 8)
+                laddr = NC.addr(listener)::NC.SocketAddrV4
+                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
+                client = NC.connect(NC.loopback_addr(Int(laddr.port)))
+                @test _nc_wait_task_done(accept_task, 2.0) != :timed_out
+                server = fetch(accept_task)
+                pfd = server.fd.pfd
+                future_deadline = Int64(time_ns()) + Int64(5_000_000_000)
+                NC.set_deadline!(server, future_deadline)
+                @test (@atomic :acquire pfd.pd.rd_ns) == future_deadline
+                @test (@atomic :acquire pfd.pd.wd_ns) == future_deadline
+                NC.set_deadline!(server, Int64(time_ns()) + Int64(30_000_000))
+                IP.sleep(0.06)
+                @test IP._check_error(pfd.pd, IP.PollMode.READ) == Int32(2)
+                @test IP._check_error(pfd.pd, IP.PollMode.WRITE) == Int32(2)
+                NC.set_deadline!(server, Int64(0))
+                @test IP._check_error(pfd.pd, IP.PollMode.READ) == Int32(0)
+                @test IP._check_error(pfd.pd, IP.PollMode.WRITE) == Int32(0)
+            finally
+                _close_quiet!(server)
+                _close_quiet!(client)
+                _close_quiet!(listener)
+                IP.shutdown!()
+            end
+        end
         @testset "blocked read unblocks on conn close and repeated close errors" begin
             IP.shutdown!()
             listener = nothing
@@ -343,5 +374,20 @@ end
                 _close_quiet!(listener)
                 IP.shutdown!()
             end
+        end
+        @testset "IPv6 show output uses compressed form" begin
+            @test repr(NC.loopback_addr6(443)) == "[::1]:443"
+            @test repr(NC.any_addr6(0)) == "[::]:0"
+            doc_addr = NC.SocketAddrV6((
+                    0x20, 0x01, 0x0d, 0xb8,
+                    0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x01,
+                ),
+                8443,
+            )
+            @test repr(doc_addr) == "[2001:db8::1]:8443"
+            scoped = NC.SocketAddrV6(NC.loopback_addr6(1).ip, 1; scope_id = 7)
+            @test repr(scoped) == "[::1%7]:1"
         end
     end

--- a/test/tls_tests.jl
+++ b/test/tls_tests.jl
@@ -233,10 +233,49 @@ end
             @test inferred.server_name == "Example.com"
             inferred_ip = TL._prepare_connect_config(TL.Config(verify_peer = false), "[::1]:443")
             @test inferred_ip.server_name == "::1"
+            inferred_addr = TL._prepare_connect_config(TL.Config(verify_peer = false), NC.loopback_addr(443))
+            @test inferred_addr.server_name == "127.0.0.1"
             explicit = TL.Config(server_name = "manual.example", verify_peer = false)
             @test TL._prepare_connect_config(explicit, "example.com:443") === explicit
+            @test TL._prepare_connect_config(explicit, NC.loopback_addr(443)) === explicit
             unchanged = TL._prepare_connect_config(TL.Config(verify_peer = false), "bad-address")
             @test unchanged.server_name === nothing
+        end
+        @testset "direct socket-address connect/listen passthroughs" begin
+            IP.shutdown!()
+            listener = nothing
+            client = nothing
+            server = nothing
+            try
+                listener = TL.listen(NC.loopback_addr(0), _tls_server_config(); backlog = 8)
+                laddr = TL.addr(listener)::NC.SocketAddrV4
+                accept_task = errormonitor(Threads.@spawn begin
+                    conn = TL.accept(listener)
+                    TL.handshake!(conn)
+                    return conn
+                end)
+                client = TL.connect(
+                    NC.loopback_addr(Int(laddr.port)),
+                    NC.loopback_addr(0);
+                    verify_peer = false,
+                    server_name = "localhost",
+                    handshake_timeout_ns = 1_000_000_000,
+                )
+                @test _tls_wait_task_done(accept_task, 2.0) != :timed_out
+                server = fetch(accept_task)
+                client_local = TL.local_addr(client)::NC.SocketAddrV4
+                @test client_local.ip == NC.loopback_addr(0).ip
+                payload = UInt8[0x64, 0x69, 0x72]
+                recv_buf = Vector{UInt8}(undef, length(payload))
+                @test write(client, payload) == length(payload)
+                @test read!(server, recv_buf) === recv_buf
+                @test recv_buf == payload
+            finally
+                _tls_close_quiet!(server)
+                _tls_close_quiet!(client)
+                _tls_close_quiet!(listener)
+                IP.shutdown!()
+            end
         end
         @testset "server client-auth mode mapping and runtime path" begin
             @test TL._server_verify_mode(TL.Config(client_auth = TL.ClientAuthMode.NoClientCert)) == TL._SSL_VERIFY_NONE

--- a/test/tls_trim_safe.jl
+++ b/test/tls_trim_safe.jl
@@ -19,12 +19,12 @@ function run_tls_trim_sample()::Nothing
         laddr = NC.addr(listener)::NC.SocketAddrV4
         client_tcp = NC.connect(NC.loopback_addr(Int(laddr.port)))
         server_tcp = NC.accept(listener)
-        client_cfg = TL.Config(verify_peer = false, server_name = "localhost", handshake_timeout_ns = 1_000_000_000)
+        client_cfg = TL.Config(verify_peer = false, server_name = "localhost", handshake_timeout_ns = 10_000_000_000)
         server_cfg = TL.Config(
             verify_peer = false,
             cert_file = _TLS_CERT_PATH,
             key_file = _TLS_KEY_PATH,
-            handshake_timeout_ns = 1_000_000_000,
+            handshake_timeout_ns = 10_000_000_000,
         )
         client_tls = TL.client(client_tcp, client_cfg)
         server_tls = TL.server(server_tcp, server_cfg)


### PR DESCRIPTION
## Summary
- add direct  and  socket-address entrypoints that mirror the TCP surface
- rename and split resolver errors so malformed input, lookup failures, dial timeouts, and op wrappers are clearer
- add the missing public-surface tests for , , and compressed IPv6 endpoint display
- expand the GitHub Actions matrix with macOS  and  jobs

## Testing
- 
- 
- 
- 
- 