### PR TITLE
feat(conn): support single-read buffer APIs

### DIFF
--- a/src/3_tcp.jl
+++ b/src/3_tcp.jl
@@ -687,31 +687,7 @@ function Base.unsafe_read(conn::Conn, ptr::Ptr{UInt8}, nbytes::UInt)
     return nothing
 end
 
-"""
-    read!(conn, buf) -> buf
-
-Read exactly `length(buf)` bytes into `buf` or throw `EOFError`.
-
-Use `readbytes!` or `readavailable` when you want a count-returning read that
-may stop early.
-"""
-Base.read!(conn::Conn, buf::Vector{UInt8})
-
-"""
-    readbytes!(conn, buf, nb=length(buf)) -> Int
-
-Read up to `nb` bytes into `buf`, returning the byte count.
-
-Unlike `read!(conn, buf)`, this API may return after a short read or EOF. It is
-the count-returning TCP read entrypoint once `TCP.Conn` follows Julia's `IO`
-contract.
-"""
-function Base.readbytes!(conn::Conn, buf::Vector{UInt8}, nb::Integer = length(buf))::Int
-    Base.require_one_based_indexing(buf)
-    requested = Int(nb)
-    requested < 0 && throw(ArgumentError("nb must be >= 0"))
-    requested == 0 && return 0
-
+function _readbytes_all!(conn::Conn, buf::Vector{UInt8}, requested::Int)::Int
     original_len = length(buf)
     current_len = original_len
     bytes_read = 0
@@ -729,10 +705,75 @@ function Base.readbytes!(conn::Conn, buf::Vector{UInt8}, nb::Integer = length(bu
         end
         bytes_read += n
     end
-    if current_len > original_len
-        resize!(buf, bytes_read)
+    if current_len > original_len && current_len > bytes_read
+        resize!(buf, max(original_len, bytes_read))
     end
     return bytes_read
+end
+
+function _readbytes_some!(conn::Conn, buf::Vector{UInt8}, requested::Int)::Int
+    original_len = length(buf)
+    requested > original_len && resize!(buf, requested)
+    bytes_read = try
+        GC.@preserve buf _read_some!(conn, pointer(buf), requested)
+    catch err
+        ex = err::Exception
+        ex isa EOFError || rethrow(ex)
+        0
+    end
+    current_len = length(buf)
+    if current_len > original_len && current_len > bytes_read
+        resize!(buf, max(original_len, bytes_read))
+    end
+    return bytes_read
+end
+
+"""
+    read!(conn, buf) -> buf
+
+Read exactly `length(buf)` bytes into `buf` or throw `EOFError`.
+
+Use `readbytes!` or `readavailable` when you want a count-returning read that
+may stop early.
+"""
+Base.read!(conn::Conn, buf::Vector{UInt8})
+
+"""
+    readbytes!(conn, buf, nb=length(buf); all::Bool=true) -> Int
+
+Read up to `nb` bytes into `buf`, returning the byte count.
+
+Unlike `read!(conn, buf)`, this API may return after a short read or EOF. It is
+the count-returning TCP read entrypoint once `TCP.Conn` follows Julia's `IO`
+contract.
+
+If `all` is `true` (the default), the call keeps reading until `nb` bytes have
+been transferred, EOF is reached, or an error occurs. If `all` is `false`, at
+most one underlying socket read is performed.
+"""
+function Base.readbytes!(conn::Conn, buf::Vector{UInt8}, nb::Integer = length(buf); all::Bool = true)::Int
+    Base.require_one_based_indexing(buf)
+    requested = Int(nb)
+    requested < 0 && throw(ArgumentError("nb must be >= 0"))
+    requested == 0 && return 0
+    return all ? _readbytes_all!(conn, buf, requested) : _readbytes_some!(conn, buf, requested)
+end
+
+"""
+    read(conn, nb::Integer; all::Bool=true) -> Vector{UInt8}
+
+Read and return up to `nb` bytes from `conn`.
+
+If `all` is `true` (the default), the call keeps reading until `nb` bytes have
+been transferred, EOF is reached, or an error occurs. If `all` is `false`, at
+most one underlying socket read is performed.
+"""
+function Base.read(conn::Conn, nb::Integer; all::Bool = true)::Vector{UInt8}
+    requested = Int(nb)
+    requested < 0 && throw(ArgumentError("nb must be >= 0"))
+    buf = Vector{UInt8}(undef, all && requested == typemax(Int) ? 1024 : requested)
+    n = readbytes!(conn, buf, requested; all = all)
+    return resize!(buf, n)
 end
 
 """

--- a/src/5_tls.jl
+++ b/src/5_tls.jl
@@ -1190,27 +1190,7 @@ function Base.unsafe_read(conn::Conn, ptr::Ptr{UInt8}, nbytes::UInt)
     return nothing
 end
 
-"""
-    read!(conn, buf) -> buf
-
-Read exactly `length(buf)` decrypted bytes into `buf` or throw `EOFError`.
-
-Use `readbytes!` or `readavailable` when you want a count-returning read that
-may stop early.
-"""
-Base.read!(conn::Conn, buf::Vector{UInt8})
-
-"""
-    readbytes!(conn, buf, nb=length(buf)) -> Int
-
-Read up to `nb` decrypted bytes into `buf`, returning the byte count.
-"""
-function Base.readbytes!(conn::Conn, buf::Vector{UInt8}, nb::Integer = length(buf))::Int
-    Base.require_one_based_indexing(buf)
-    requested = Int(nb)
-    requested < 0 && throw(ArgumentError("nb must be >= 0"))
-    requested == 0 && return 0
-
+function _readbytes_all!(conn::Conn, buf::Vector{UInt8}, requested::Int)::Int
     original_len = length(buf)
     current_len = original_len
     bytes_read = 0
@@ -1228,10 +1208,71 @@ function Base.readbytes!(conn::Conn, buf::Vector{UInt8}, nb::Integer = length(bu
         end
         bytes_read += n
     end
-    if current_len > original_len
-        resize!(buf, bytes_read)
+    if current_len > original_len && current_len > bytes_read
+        resize!(buf, max(original_len, bytes_read))
     end
     return bytes_read
+end
+
+function _readbytes_some!(conn::Conn, buf::Vector{UInt8}, requested::Int)::Int
+    original_len = length(buf)
+    requested > original_len && resize!(buf, requested)
+    bytes_read = try
+        GC.@preserve buf _read_some!(conn, pointer(buf), requested)
+    catch err
+        ex = err::Exception
+        ex isa EOFError || rethrow(ex)
+        0
+    end
+    current_len = length(buf)
+    if current_len > original_len && current_len > bytes_read
+        resize!(buf, max(original_len, bytes_read))
+    end
+    return bytes_read
+end
+
+"""
+    read!(conn, buf) -> buf
+
+Read exactly `length(buf)` decrypted bytes into `buf` or throw `EOFError`.
+
+Use `readbytes!` or `readavailable` when you want a count-returning read that
+may stop early.
+"""
+Base.read!(conn::Conn, buf::Vector{UInt8})
+
+"""
+    readbytes!(conn, buf, nb=length(buf); all::Bool=true) -> Int
+
+Read up to `nb` decrypted bytes into `buf`, returning the byte count.
+
+If `all` is `true` (the default), the call keeps reading until `nb` bytes have
+been transferred, EOF is reached, or an error occurs. If `all` is `false`, at
+most one underlying TLS read is performed.
+"""
+function Base.readbytes!(conn::Conn, buf::Vector{UInt8}, nb::Integer = length(buf); all::Bool = true)::Int
+    Base.require_one_based_indexing(buf)
+    requested = Int(nb)
+    requested < 0 && throw(ArgumentError("nb must be >= 0"))
+    requested == 0 && return 0
+    return all ? _readbytes_all!(conn, buf, requested) : _readbytes_some!(conn, buf, requested)
+end
+
+"""
+    read(conn, nb::Integer; all::Bool=true) -> Vector{UInt8}
+
+Read and return up to `nb` decrypted bytes from `conn`.
+
+If `all` is `true` (the default), the call keeps reading until `nb` bytes have
+been transferred, EOF is reached, or an error occurs. If `all` is `false`, at
+most one underlying TLS read is performed.
+"""
+function Base.read(conn::Conn, nb::Integer; all::Bool = true)::Vector{UInt8}
+    requested = Int(nb)
+    requested < 0 && throw(ArgumentError("nb must be >= 0"))
+    buf = Vector{UInt8}(undef, all && requested == typemax(Int) ? 1024 : requested)
+    n = readbytes!(conn, buf, requested; all = all)
+    return resize!(buf, n)
 end
 
 """

--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -116,6 +116,48 @@ end
                 IP.shutdown!()
             end
         end
+        @testset "readbytes! and read support single-read mode" begin
+            IP.shutdown!()
+            listener = nothing
+            client = nothing
+            server = nothing
+            try
+                listener = NC.listen(NC.loopback_addr(0); backlog = 8)
+                laddr = NC.addr(listener)::NC.SocketAddrV4
+                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
+                client = NC.connect(NC.loopback_addr(Int(laddr.port)))
+                @test _nc_wait_task_done(accept_task, 2.0) != :timed_out
+                server = fetch(accept_task)
+
+                first_payload = UInt8[0x41, 0x42]
+                @test write(client, first_payload) == length(first_payload)
+                NC.set_read_deadline!(server, time_ns() + 250_000_000)
+                first_buf = Vector{UInt8}(undef, 4)
+                @test readbytes!(server, first_buf, 4; all = false) == length(first_payload)
+                @test first_buf[1:2] == first_payload
+                NC.set_read_deadline!(server, Int64(0))
+
+                second_payload = UInt8[0x43, 0x44]
+                @test write(client, second_payload) == length(second_payload)
+                NC.set_read_deadline!(server, time_ns() + 250_000_000)
+                @test read(server, 4; all = false) == second_payload
+                NC.set_read_deadline!(server, Int64(0))
+
+                third_payload = UInt8[0x45, 0x46]
+                @test write(client, third_payload) == length(third_payload)
+                NC.set_read_deadline!(server, time_ns() + 250_000_000)
+                grown_buf = fill(UInt8(0x00), 3)
+                @test readbytes!(server, grown_buf, 5; all = false) == length(third_payload)
+                @test grown_buf[1:2] == third_payload
+                @test length(grown_buf) == 3
+                NC.set_read_deadline!(server, Int64(0))
+            finally
+                _close_quiet!(server)
+                _close_quiet!(client)
+                _close_quiet!(listener)
+                IP.shutdown!()
+            end
+        end
         @testset "show methods summarize TCP endpoints" begin
             IP.shutdown!()
             listener = nothing

--- a/test/tls_tests.jl
+++ b/test/tls_tests.jl
@@ -1012,6 +1012,55 @@ end
                 IP.shutdown!()
             end
         end
+        @testset "readbytes! and read support single-read mode" begin
+            IP.shutdown!()
+            listener = nothing
+            client = nothing
+            server = nothing
+            try
+                listener = TL.listen("tcp", "127.0.0.1:0", _tls_server_config(); backlog = 8)
+                laddr = TL.addr(listener)::NC.SocketAddrV4
+                accept_task = errormonitor(Threads.@spawn begin
+                    conn = TL.accept(listener)
+                    TL.handshake!(conn)
+                    return conn
+                end)
+                client = _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", TL.Config(
+                    verify_peer = false,
+                    server_name = "localhost",
+                ))
+                @test _tls_wait_task_done(accept_task, 2.0) != :timed_out
+                server = fetch(accept_task)
+
+                first_payload = UInt8[0x41, 0x42]
+                @test write(client, first_payload) == length(first_payload)
+                TL.set_read_deadline!(server, time_ns() + 250_000_000)
+                first_buf = Vector{UInt8}(undef, 4)
+                @test readbytes!(server, first_buf, 4; all = false) == length(first_payload)
+                @test first_buf[1:2] == first_payload
+                TL.set_read_deadline!(server, Int64(0))
+
+                second_payload = UInt8[0x43, 0x44]
+                @test write(client, second_payload) == length(second_payload)
+                TL.set_read_deadline!(server, time_ns() + 250_000_000)
+                @test read(server, 4; all = false) == second_payload
+                TL.set_read_deadline!(server, Int64(0))
+
+                third_payload = UInt8[0x45, 0x46]
+                @test write(client, third_payload) == length(third_payload)
+                TL.set_read_deadline!(server, time_ns() + 250_000_000)
+                grown_buf = fill(UInt8(0x00), 3)
+                @test readbytes!(server, grown_buf, 5; all = false) == length(third_payload)
+                @test grown_buf[1:2] == third_payload
+                @test length(grown_buf) == 3
+                TL.set_read_deadline!(server, Int64(0))
+            finally
+                _tls_close_quiet!(server)
+                _tls_close_quiet!(client)
+                _tls_close_quiet!(listener)
+                IP.shutdown!()
+            end
+        end
         @testset "write timeout remains sticky across subsequent writes" begin
             IP.shutdown!()
             listener = nothing


### PR DESCRIPTION
## Summary
- add Julia-style `all=false` support to TCP/TLS conn `readbytes!`
- add matching `read(conn, nb; all=...)` helpers for both transports
- cover single-read behavior and buffer-resize semantics in TCP/TLS tests

## Verification
- `JULIA_NUM_THREADS=2 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.test(; coverage=false)'`
