### PR TITLE
test(windows): debug min tls codeunits hang

### DIFF
--- a/.github/workflows/windows-min-tls-debug.yml
+++ b/.github/workflows/windows-min-tls-debug.yml
@@ -1,0 +1,30 @@
+name: Windows Min TLS Debug
+
+on:
+  push:
+    branches:
+      - codex/windows-min-codeunits-debug
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  windows-min-tls:
+    name: Julia min - windows-latest - x64 - tls-debug
+    runs-on: windows-latest
+    timeout-minutes: 30
+    env:
+      JULIA_NUM_THREADS: 1
+      RESEAU_RUN_TLS_TESTS: '1'
+      RESEAU_RUN_NETWORK_TESTS: '1'
+      RESEAU_TEST_ONLY: tls_tests.jl
+      RESEAU_TRIM_EXE_TIMEOUT_S: "60.0"
+      RESEAU_TRIM_BUNDLE: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: 'min'
+          arch: x64
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/windows-min-tls-debug.yml
+++ b/.github/workflows/windows-min-tls-debug.yml
@@ -1,9 +1,6 @@
 name: Windows Min TLS Debug
 
 on:
-  push:
-    branches:
-      - codex/windows-min-codeunits-debug
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/windows-min-tls-debug.yml
+++ b/.github/workflows/windows-min-tls-debug.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - codex/windows-min-codeunits-debug
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/src/iopoll/fd.jl
+++ b/src/iopoll/fd.jl
@@ -283,7 +283,7 @@ function Base.close(pd::PollState)
     finally
         unlock(pd.lock)
     end
-    was_pollable && pd.sysfd >= 0 && deregister!(pd.sysfd)
+    was_pollable && pd.sysfd >= 0 && deregister!(pd)
     return nothing
 end
 

--- a/src/iopoll/runtime.jl
+++ b/src/iopoll/runtime.jl
@@ -256,6 +256,46 @@ function deregister!(fd::Integer)
 end
 
 """
+    deregister!(pd)
+
+Unregister the active runtime-poller registration that matches `pd`'s full
+descriptor identity.
+
+Unlike `deregister!(fd)`, this overload validates the current registration by
+token and `PollState` object identity before removing it. That prevents a stale
+`PollState` close from tearing down a newer registration that happens to reuse
+the same raw fd value after a shutdown/re-register cycle.
+"""
+function deregister!(pd::PollState)
+    isassigned(POLLER) || return nothing
+    state = POLLER[]
+    (@atomic :acquire state.running) || return nothing
+    registration = nothing
+    errno = Int32(0)
+    lock(state.lock)
+    try
+        (@atomic :acquire state.running) || return nothing
+        registration = get(state.registrations_by_token, pd.token, nothing)
+        if registration === nothing
+            return nothing
+        end
+        current = registration::Registration
+        current.fd == pd.sysfd || return nothing
+        current.pollstate === pd || return nothing
+        registered = get(state.registrations, pd.sysfd, nothing)
+        registered === current || return nothing
+        delete!(state.registrations, pd.sysfd)
+        delete!(state.registrations_by_token, current.token)
+        errno = _backend_close_fd!(state, pd.sysfd)
+    finally
+        unlock(state.lock)
+    end
+    registration === nothing || _notify_registration!(registration::Registration, PollMode.READWRITE, PollWakeReason.CANCELED)
+    errno == Int32(0) || _throw_errno("iopoll deregister", errno)
+    return nothing
+end
+
+"""
     arm_waiter!(registration, mode)
 
 Backend hook invoked immediately before waiting so platforms that need explicit

--- a/test/iopoll_runtime_tests.jl
+++ b/test/iopoll_runtime_tests.jl
@@ -372,6 +372,48 @@ end
             end
         end
         _el_log_test_progress("DONE: stale token suppression")
+        _el_log_test_progress("START: stale pollstate close preserves active registration")
+        @testset "stale pollstate close preserves active registration" begin
+            fd0, fd1 = _el_socketpair_stream()
+            waiter_task = nothing
+            try
+                registration = NP.register!(fd0; mode = NP.PollMode.READ)
+                stale_pd = NP.PollState(fd0, registration.token - UInt64(1))
+                @atomic :release stale_pd.pollable = true
+                close(stale_pd)
+                @test NP.current_registration(registration.pollstate) === registration
+                wait_ch = Channel{Nothing}(1)
+                waiter_task = errormonitor(@async begin
+                    NP.arm_waiter!(registration, NP.PollMode.READ)
+                    NP.pollwait!(registration.read_waiter)
+                    put!(wait_ch, nothing)
+                    return nothing
+                end)
+                sleep(0.02)
+                _el_write_byte(fd1, 0x55)
+                status = timedwait(() -> isready(wait_ch), 2.0; pollint = 0.001)
+                @test status != :timed_out
+                if status != :timed_out
+                    take!(wait_ch)
+                    wait(waiter_task)
+                    @test _el_read_byte(fd0) == 0x55
+                end
+                NP.deregister!(fd0)
+            finally
+                if waiter_task !== nothing && !istaskdone(waiter_task)
+                    try
+                        NP.deregister!(fd0)
+                    catch
+                    end
+                    @test _el_wait_task_done(waiter_task, 1.0) != :timed_out
+                end
+                waiter_task isa Task && istaskdone(waiter_task) && wait(waiter_task)
+                _el_close_fd(fd0)
+                _el_close_fd(fd1)
+                NP.shutdown!()
+            end
+        end
+        _el_log_test_progress("DONE: stale pollstate close preserves active registration")
         _el_log_test_progress("START: shutdown-safe control paths")
         @testset "shutdown-safe control paths" begin
             NP.init!()

--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -36,7 +36,7 @@ end
                 laddr = NC.addr(listener)
                 @test laddr isa NC.SocketAddrV4
                 @test (laddr::NC.SocketAddrV4).port > 0
-                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
+                accept_task = errormonitor(@async NC.accept(listener))
                 pre = _nc_wait_task_done(accept_task, 0.05)
                 @test pre == :timed_out
                 client = NC.connect(NC.loopback_addr(Int((laddr::NC.SocketAddrV4).port)))
@@ -96,7 +96,7 @@ end
             try
                 listener = NC.listen("tcp", "127.0.0.1:0"; backlog = 8)
                 laddr = NC.addr(listener)::NC.SocketAddrV4
-                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
+                accept_task = errormonitor(@async NC.accept(listener))
                 client = NC.connect("tcp", "127.0.0.1:$(Int(laddr.port))"; local_addr = NC.loopback_addr(0))
                 @test _nc_wait_task_done(accept_task, 2.0) != :timed_out
                 server = fetch(accept_task)
@@ -128,7 +128,7 @@ end
             try
                 listener = NC.listen(NC.loopback_addr(0); backlog = 8)
                 laddr = NC.addr(listener)::NC.SocketAddrV4
-                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
+                accept_task = errormonitor(@async NC.accept(listener))
                 client = NC.connect(NC.loopback_addr(Int(laddr.port)))
                 @test _nc_wait_task_done(accept_task, 2.0) != :timed_out
                 server = fetch(accept_task)
@@ -170,7 +170,7 @@ end
             try
                 listener = NC.listen(NC.loopback_addr(0); backlog = 8)
                 laddr = NC.addr(listener)
-                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
+                accept_task = errormonitor(@async NC.accept(listener))
                 client = NC.connect(NC.loopback_addr(Int((laddr::NC.SocketAddrV4).port)))
                 @test _nc_wait_task_done(accept_task, 2.0) != :timed_out
                 server = fetch(accept_task)
@@ -206,7 +206,7 @@ end
             try
                 listener = NC.listen(NC.loopback_addr(0); backlog = 8)
                 laddr = NC.addr(listener)::NC.SocketAddrV4
-                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
+                accept_task = errormonitor(@async NC.accept(listener))
                 client = NC.connect(NC.loopback_addr(Int(laddr.port)))
                 @test _nc_wait_task_done(accept_task, 2.0) != :timed_out
                 server = fetch(accept_task)
@@ -282,7 +282,7 @@ end
             try
                 listener = NC.listen(NC.loopback_addr(0); backlog = 8)
                 laddr = NC.addr(listener)
-                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
+                accept_task = errormonitor(@async NC.accept(listener))
                 client = NC.connect(NC.loopback_addr(Int((laddr::NC.SocketAddrV4).port)))
                 status = _nc_wait_task_done(accept_task, 2.0)
                 @test status != :timed_out
@@ -309,7 +309,7 @@ end
             try
                 listener = NC.listen(NC.loopback_addr(0); backlog = 8)
                 laddr = NC.addr(listener)::NC.SocketAddrV4
-                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
+                accept_task = errormonitor(@async NC.accept(listener))
                 client = NC.connect(NC.loopback_addr(Int(laddr.port)))
                 @test _nc_wait_task_done(accept_task, 2.0) != :timed_out
                 server = fetch(accept_task)
@@ -341,7 +341,7 @@ end
             try
                 listener = NC.listen(NC.loopback_addr(0); backlog = 8)
                 laddr = NC.addr(listener)
-                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
+                accept_task = errormonitor(@async NC.accept(listener))
                 client = NC.connect(NC.loopback_addr(Int((laddr::NC.SocketAddrV4).port)))
                 status = _nc_wait_task_done(accept_task, 2.0)
                 @test status != :timed_out
@@ -397,7 +397,7 @@ end
             try
                 listener = NC.listen(NC.loopback_addr(0); backlog = 8)
                 laddr = NC.addr(listener)::NC.SocketAddrV4
-                accept_task = errormonitor(Threads.@spawn NC.accept(listener))
+                accept_task = errormonitor(@async NC.accept(listener))
                 client = NC.connect(NC.loopback_addr(Int(laddr.port)))
                 @test _nc_wait_task_done(accept_task, 2.0) != :timed_out
                 server = fetch(accept_task)

--- a/test/tls_tests.jl
+++ b/test/tls_tests.jl
@@ -27,6 +27,12 @@ function _tls_close_quiet!(x)
     return nothing
 end
 
+function _tls_trace(label::AbstractString)
+    println("[tls_tests] ", label)
+    flush(stdout)
+    return nothing
+end
+
 @inline function _tls_handshake_connect_error(ex)
     return ex isa TL.TLSError || ex isa TL.TLSHandshakeTimeoutError
 end
@@ -76,6 +82,7 @@ end
 
 @testset "TLS phase 6" begin
         @test TL.Conn <: IO
+        _tls_trace("START: config validation")
         @testset "config validation" begin
             cfg_default = TL.Config()
             @test cfg_default.min_version == TL.TLS1_2_VERSION
@@ -436,6 +443,8 @@ end
                 IP.shutdown!()
             end
         end
+        _tls_trace("DONE: config validation")
+        _tls_trace("START: show methods summarize TLS endpoints and handshake state")
         @testset "show methods summarize TLS endpoints and handshake state" begin
             IP.shutdown!()
             tls_listener = nothing
@@ -567,6 +576,8 @@ end
                 TL._CTX_CACHE_MAX[] = old_max
             end
         end
+        _tls_trace("DONE: show methods summarize TLS endpoints and handshake state")
+        _tls_trace("START: connect/listen handshake and roundtrip")
         @testset "connect/listen handshake and roundtrip" begin
             IP.shutdown!()
             listener = nothing
@@ -620,46 +631,46 @@ end
                 IP.shutdown!()
             end
         end
+        _tls_trace("DONE: connect/listen handshake and roundtrip")
+        _tls_trace("START: write accepts string codeunits buffers")
         @testset "write accepts string codeunits buffers" begin
-            if Sys.iswindows() && VERSION < v"1.11.0"
-                @test true
-            else
+            IP.shutdown!()
+            listener = nothing
+            client = nothing
+            server = nothing
+            try
+                listener = TL.listen("tcp", "127.0.0.1:0", _tls_server_config(); backlog = 8)
+                laddr = TL.addr(listener)::NC.SocketAddrV4
+                accept_task = errormonitor(Threads.@spawn begin
+                    conn = TL.accept(listener)
+                    TL.handshake!(conn)
+                    TL.set_read_deadline!(conn, time_ns() + 5_000_000_000)
+                    server_codeunits_buf = Vector{UInt8}(undef, 2)
+                    read!(conn, server_codeunits_buf)
+                    write(conn, server_codeunits_buf)
+                    return conn
+                end)
+                client = _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", TL.Config(
+                    verify_peer = false,
+                    server_name = "localhost",
+                    handshake_timeout_ns = 10_000_000_000,
+                ))
+                TL.set_read_deadline!(client, time_ns() + 5_000_000_000)
+                @test write(client, codeunits("hi")) == 2
+                client_codeunits_buf = Vector{UInt8}(undef, 2)
+                @test read!(client, client_codeunits_buf) === client_codeunits_buf
+                @test String(client_codeunits_buf) == "hi"
+                @test _tls_wait_task_done(accept_task, 12.0) != :timed_out
+                server = fetch(accept_task)
+            finally
+                _tls_close_quiet!(server)
+                _tls_close_quiet!(client)
+                _tls_close_quiet!(listener)
                 IP.shutdown!()
-                listener = nothing
-                client = nothing
-                server = nothing
-                try
-                    listener = TL.listen("tcp", "127.0.0.1:0", _tls_server_config(); backlog = 8)
-                    laddr = TL.addr(listener)::NC.SocketAddrV4
-                    accept_task = errormonitor(Threads.@spawn begin
-                        conn = TL.accept(listener)
-                        TL.handshake!(conn)
-                        TL.set_read_deadline!(conn, time_ns() + 5_000_000_000)
-                        server_codeunits_buf = Vector{UInt8}(undef, 2)
-                        read!(conn, server_codeunits_buf)
-                        write(conn, server_codeunits_buf)
-                        return conn
-                    end)
-                    client = _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", TL.Config(
-                        verify_peer = false,
-                        server_name = "localhost",
-                        handshake_timeout_ns = 10_000_000_000,
-                    ))
-                    TL.set_read_deadline!(client, time_ns() + 5_000_000_000)
-                    @test write(client, codeunits("hi")) == 2
-                    client_codeunits_buf = Vector{UInt8}(undef, 2)
-                    @test read!(client, client_codeunits_buf) === client_codeunits_buf
-                    @test String(client_codeunits_buf) == "hi"
-                    @test _tls_wait_task_done(accept_task, 12.0) != :timed_out
-                    server = fetch(accept_task)
-                finally
-                    _tls_close_quiet!(server)
-                    _tls_close_quiet!(client)
-                    _tls_close_quiet!(listener)
-                    IP.shutdown!()
-                end
             end
         end
+        _tls_trace("DONE: write accepts string codeunits buffers")
+        _tls_trace("START: peer read observes clean EOF after close_notify")
         @testset "peer read observes clean EOF after close_notify" begin
             IP.shutdown!()
             listener = nothing


### PR DESCRIPTION
## Summary
- re-enable the TLS `codeunits` regression on Windows + Julia 1.10
- add milestone tracing in `tls_tests.jl` to locate where the hang occurs
- add a focused Windows min TLS workflow for faster debugging signal

## Context
`main` is green, but only because the TLS `codeunits` regression is currently gated on Windows 1.10. This branch removes that gate so we can debug the remaining hang in a dedicated PR branch.

## Local Verification
- `env RESEAU_TEST_ONLY=tls_tests.jl JULIA_NUM_THREADS=2 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.test(; coverage=false)'`
