### PR TITLE
ci(windows): probe ICE precompile behavior

### DIFF
--- a/.github/workflows/windows-compute-trycatch-rootcause.yml
+++ b/.github/workflows/windows-compute-trycatch-rootcause.yml
@@ -1,6 +1,7 @@
 name: Windows ComputeTryCatch Rootcause
 
 on:
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/windows-compute-trycatch-rootcause.yml
+++ b/.github/workflows/windows-compute-trycatch-rootcause.yml
@@ -1,0 +1,25 @@
+name: Windows ComputeTryCatch Rootcause
+
+on:
+  workflow_dispatch:
+
+jobs:
+  debug:
+    name: Julia 1 - windows-latest - x64 - compute-trycatch-rootcause
+    runs-on: windows-latest
+    timeout-minutes: 20
+    env:
+      JULIA_NUM_THREADS: 1
+      RESEAU_RUN_TLS_TESTS: '1'
+      RESEAU_RUN_NETWORK_TESTS: '1'
+      RESEAU_TRIM_BUNDLE: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+          arch: x64
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - name: Run ComputeTryCatch root-cause probe
+        run: julia --project=. --startup-file=no --history-file=no test/windows_compute_trycatch_rootcause.jl

--- a/.github/workflows/windows-ice-precompile-probe.yml
+++ b/.github/workflows/windows-ice-precompile-probe.yml
@@ -1,0 +1,125 @@
+name: Windows ICE Precompile Probe
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  windows-ice-probe:
+    name: Julia 1 - windows-latest - x64 - t${{ matrix.threads }} - ${{ matrix.scenario }}
+    runs-on: windows-latest
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario: [baseline, explicit-precompile]
+        threads: [1, 2]
+    env:
+      JULIA_NUM_THREADS: ${{ matrix.threads }}
+      RESEAU_RUN_TLS_TESTS: '1'
+      RESEAU_RUN_NETWORK_TESTS: '1'
+      RESEAU_TRIM_EXE_TIMEOUT_S: "60.0"
+      RESEAU_TRIM_BUNDLE: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+          arch: x64
+      - name: Prepare isolated depot
+        shell: pwsh
+        run: |
+          $depot = Join-Path $env:RUNNER_TEMP "reseau-ice-${{ matrix.scenario }}-t${{ matrix.threads }}"
+          if (Test-Path $depot) {
+            Remove-Item -Recurse -Force $depot
+          }
+          New-Item -ItemType Directory -Path $depot | Out-Null
+          "JULIA_DEPOT_PATH=$depot" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "RESEAU_WINDOWS_ICE_SCENARIO=${{ matrix.scenario }}" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+      - name: Precompile package
+        shell: pwsh
+        run: |
+          if ("${{ matrix.scenario }}" -eq "explicit-precompile") {
+            $env:RESEAU_WINDOWS_ICE_PRECOMPILE_PROBE = "1"
+          }
+          & julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()' 2>&1 | Tee-Object -FilePath precompile.log
+      - name: Run public runtime probe
+        shell: pwsh
+        run: |
+          Remove-Item Env:RESEAU_WINDOWS_ICE_PRECOMPILE_PROBE -ErrorAction Ignore
+          & julia --project=. --startup-file=no --history-file=no test/windows_ice_precompile_probe.jl 2>&1 | Tee-Object -FilePath runtime-probe.log
+      - name: Run package test suite
+        shell: pwsh
+        run: |
+          & julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.test(; coverage=false)' 2>&1 | Tee-Object -FilePath package-tests.log
+      - name: Summarize ICE counts
+        if: always()
+        shell: pwsh
+        run: |
+          function Get-IceFunctions([string]$Path) {
+            if (-not (Test-Path $Path)) {
+              return @()
+            }
+            $lines = Get-Content $Path
+            $hits = @()
+            for ($i = 0; $i -lt ($lines.Count - 1); $i++) {
+              if ($lines[$i] -match 'Internal error: during type inference of') {
+                $hits += $lines[$i + 1].Trim()
+              }
+            }
+            return $hits
+          }
+
+          function Get-IceCount([string]$Path) {
+            if (-not (Test-Path $Path)) {
+              return 0
+            }
+            return @((Select-String -Path $Path -Pattern 'Internal error: during type inference')).Count
+          }
+
+          $precompileCount = Get-IceCount "precompile.log"
+          $runtimeCount = Get-IceCount "runtime-probe.log"
+          $suiteCount = Get-IceCount "package-tests.log"
+
+          $runtimeLines = if (Test-Path "runtime-probe.log") { Get-Content "runtime-probe.log" } else { @() }
+          $pass2Index = -1
+          for ($i = 0; $i -lt $runtimeLines.Count; $i++) {
+            if ($runtimeLines[$i] -eq "[windows-ice-probe] pass=2 begin") {
+              $pass2Index = $i
+              break
+            }
+          }
+          if ($pass2Index -ge 0) {
+            $pass1File = Join-Path $env:RUNNER_TEMP "runtime-pass1.log"
+            $pass2File = Join-Path $env:RUNNER_TEMP "runtime-pass2.log"
+            $runtimeLines[0..($pass2Index - 1)] | Set-Content $pass1File
+            $runtimeLines[$pass2Index..($runtimeLines.Count - 1)] | Set-Content $pass2File
+            $runtimePass1Count = Get-IceCount $pass1File
+            $runtimePass2Count = Get-IceCount $pass2File
+          } else {
+            $runtimePass1Count = $runtimeCount
+            $runtimePass2Count = 0
+          }
+
+          "precompile_ice_count=$precompileCount"
+          "runtime_probe_ice_count=$runtimeCount"
+          "runtime_probe_pass1_ice_count=$runtimePass1Count"
+          "runtime_probe_pass2_ice_count=$runtimePass2Count"
+          "package_test_ice_count=$suiteCount"
+
+          $precompileFunctions = Get-IceFunctions "precompile.log" | Sort-Object -Unique
+          $runtimeFunctions = Get-IceFunctions "runtime-probe.log" | Sort-Object -Unique
+          $suiteFunctions = Get-IceFunctions "package-tests.log" | Sort-Object -Unique
+
+          if ($precompileFunctions.Count -gt 0) {
+            "precompile_unique_functions="
+            $precompileFunctions | ForEach-Object { "  $_" }
+          }
+          if ($runtimeFunctions.Count -gt 0) {
+            "runtime_probe_unique_functions="
+            $runtimeFunctions | ForEach-Object { "  $_" }
+          }
+          if ($suiteFunctions.Count -gt 0) {
+            "package_test_unique_functions="
+            $suiteFunctions | ForEach-Object { "  $_" }
+          }

--- a/src/6_precompile_workload.jl
+++ b/src/6_precompile_workload.jl
@@ -16,6 +16,15 @@ end
     return Sys.isapple() || Sys.islinux()
 end
 
+@inline function _pc_windows_ice_probe_enabled()::Bool
+    return Sys.iswindows() && get(ENV, "RESEAU_WINDOWS_ICE_PRECOMPILE_PROBE", "0") == "1"
+end
+
+@inline function _pc_precompile_signature!(sig::Type{<:Tuple})
+    Base.precompile(sig)
+    return nothing
+end
+
 function _pc_socketpair_stream()
     fds = Vector{Cint}(undef, 2)
     ret = ccall(:socketpair, Cint, (Cint, Cint, Cint, Ptr{Cint}), Cint(1), Cint(1), Cint(0), pointer(fds))
@@ -307,11 +316,53 @@ function _pc_run_tls_workload!()
     return nothing
 end
 
+function _pc_precompile_windows_ice_signatures!()
+    _pc_windows_ice_probe_enabled() || return nothing
+
+    tcp_local_addr_v4 = NamedTuple{(:local_addr,), Tuple{NC.SocketAddrV4}}
+    tcp_local_addr_v6 = NamedTuple{(:local_addr,), Tuple{NC.SocketAddrV6}}
+    tcp_deadline = NamedTuple{(:deadline_ns,), Tuple{Int64}}
+    tcp_resolver_timeout_fallback = NamedTuple{
+        (:resolver, :timeout_ns, :fallback_delay_ns),
+        Tuple{ND.StaticResolver, Int64, Int64},
+    }
+
+    tls_direct_addr = NamedTuple{
+        (:verify_peer, :server_name, :handshake_timeout_ns),
+        Tuple{Bool, String, Int64},
+    }
+    tls_string_system = NamedTuple{
+        (:timeout_ns, :deadline_ns, :local_addr, :fallback_delay_ns, :resolver, :policy, :server_name, :verify_peer, :client_auth, :cert_file, :key_file, :ca_file, :client_ca_file, :alpn_protocols, :handshake_timeout_ns, :min_version, :max_version),
+        Tuple{Int64, Int64, Nothing, Int64, ND.SystemResolver, ND.ResolverPolicy, String, Bool, TL.ClientAuthMode.T, Nothing, Nothing, Nothing, Nothing, Vector{String}, Int64, UInt16, Nothing},
+    }
+    tls_string_singleflight = NamedTuple{
+        (:timeout_ns, :deadline_ns, :local_addr, :fallback_delay_ns, :resolver, :policy, :server_name, :verify_peer, :client_auth, :cert_file, :key_file, :ca_file, :client_ca_file, :alpn_protocols, :handshake_timeout_ns, :min_version, :max_version),
+        Tuple{Int64, Int64, Nothing, Int64, ND.SingleflightResolver{ND.SystemResolver}, ND.ResolverPolicy, String, Bool, TL.ClientAuthMode.T, Nothing, Nothing, Nothing, Nothing, Vector{String}, Int64, UInt16, Nothing},
+    }
+
+    @info "Running Windows ICE precompile signature probe"
+    _pc_precompile_signature!(Tuple{typeof(NC.connect), NC.SocketAddrV4})
+    _pc_precompile_signature!(Tuple{typeof(Core.kwcall), tcp_local_addr_v4, typeof(NC.connect), String, String})
+    _pc_precompile_signature!(Tuple{typeof(Core.kwcall), tcp_local_addr_v6, typeof(NC.connect), String, String})
+    _pc_precompile_signature!(Tuple{typeof(Core.kwcall), tcp_deadline, typeof(NC.connect), String, String})
+    _pc_precompile_signature!(Tuple{typeof(Core.kwcall), tcp_resolver_timeout_fallback, typeof(NC.connect), String, String})
+    _pc_precompile_signature!(Tuple{typeof(NC._connect_socketaddr_impl), NC.SocketAddrV4, NC.SocketAddrV4, Int64, ND.DNSRaceState})
+    _pc_precompile_signature!(Tuple{typeof(NC._connect_socketaddr_impl), NC.SocketAddrV6, NC.SocketAddrV6, Int64, ND.DNSRaceState})
+    _pc_precompile_signature!(Tuple{typeof(NC._connect_socketaddr_impl), NC.SocketAddrV6, Nothing, Int64, ND.DNSRaceState})
+
+    _pc_precompile_signature!(Tuple{typeof(TL.connect), String, String})
+    _pc_precompile_signature!(Tuple{typeof(Core.kwcall), tls_direct_addr, typeof(TL.connect), NC.SocketAddrV4, NC.SocketAddrV4})
+    _pc_precompile_signature!(Tuple{typeof(Core.kwcall), tls_string_system, typeof(TL.connect), String, String})
+    _pc_precompile_signature!(Tuple{typeof(Core.kwcall), tls_string_singleflight, typeof(TL.connect), String, String})
+    return nothing
+end
+
 try
     @setup_workload begin
         IP.__init__()
         @assert isassigned(IP.POLLER)
         @compile_workload begin
+            _pc_precompile_windows_ice_signatures!()
             _pc_run_eventloops_workload!()
             _pc_run_internal_poll_workload!()
             _pc_run_socket_ops_workload!()

--- a/test/windows_compute_trycatch_rootcause.jl
+++ b/test/windows_compute_trycatch_rootcause.jl
@@ -1,0 +1,196 @@
+using Reseau
+
+const CC = Base.Compiler
+const NC = Reseau.TCP
+
+function stmt_summary(stmt)
+    if stmt isa Core.EnterNode
+        return "EnterNode(catch_dest=$(stmt.catch_dest))"
+    elseif stmt isa Expr && stmt.head === :leave
+        args = join(map(stmt.args) do arg
+            if arg === nothing
+                return "nothing"
+            elseif arg isa Core.SSAValue
+                return "SSA($(arg.id))"
+            end
+            return repr(arg)
+        end, ", ")
+        return "Expr(:leave, $args)"
+    elseif stmt isa Expr && stmt.head === :pop_exception
+        args = join(map(stmt.args) do arg
+            arg isa Core.SSAValue ? "SSA($(arg.id))" : repr(arg)
+        end, ", ")
+        return "Expr(:pop_exception, $args)"
+    elseif stmt isa Core.GotoNode
+        return "GotoNode($(stmt.label))"
+    elseif stmt isa Core.GotoIfNot
+        return "GotoIfNot(dest=$(stmt.dest))"
+    elseif stmt isa Core.ReturnNode
+        return "ReturnNode($(isdefined(stmt, :val) ? repr(stmt.val) : "<undef>"))"
+    end
+    return repr(stmt)
+end
+
+function print_special_statements(ci::Core.CodeInfo)
+    println("[rootcause] relevant lowered statements")
+    for (idx, stmt) in pairs(ci.code)
+        if stmt isa Core.EnterNode ||
+           stmt isa Core.GotoNode ||
+           stmt isa Core.GotoIfNot ||
+           stmt isa Core.ReturnNode ||
+           (stmt isa Expr && stmt.head in (:leave, :pop_exception))
+            println("[rootcause]   ", lpad(idx, 3), " | ", stmt_summary(stmt))
+        end
+    end
+    return nothing
+end
+
+function debug_compute_trycatch(code::Vector{Any}, bbs::Union{Vector{CC.BasicBlock}, Nothing}=nothing)
+    n = length(code)
+    ip = BitSet()
+    ip.offset = 0
+    push!(ip, n + 1)
+    handler_info = nothing
+
+    for pc = 1:n
+        stmt = code[pc]
+        if isa(stmt, Core.EnterNode)
+            (; handlers, handler_at) = handler_info =
+                (handler_info === nothing ? CC.HandlerInfo{CC.TryCatchFrame}(CC.TryCatchFrame[], fill((0, 0), n)) : handler_info)
+            l = stmt.catch_dest
+            (bbs !== nothing) && (l != 0) && (l = first(bbs[l].stmts))
+            push!(handlers, CC.TryCatchFrame(stmt, pc))
+            handler_id = length(handlers)
+            handler_at[pc + 1] = (handler_id, 0)
+            push!(ip, pc + 1)
+            if l != 0
+                handler_at[l] = (0, handler_id)
+                push!(ip, l)
+            end
+            println("[rootcause] seed enter pc=$pc handler_id=$handler_id mapped_catch_dest=$l")
+        end
+    end
+
+    handler_info === nothing && return false
+    (; handlers, handler_at) = handler_info
+
+    while true
+        pc = CC._bits_findnext(ip.bits, 0)::Int
+        pc > n && break
+        while true
+            pc_next = pc + 1
+            delete!(ip, pc)
+            cur_stacks = handler_at[pc]
+            stmt = code[pc]
+            if isa(stmt, Core.GotoNode)
+                pc_next = stmt.label
+                (bbs !== nothing) && (pc_next = first(bbs[pc_next].stmts))
+            elseif isa(stmt, Core.GotoIfNot)
+                l = stmt.dest::Int
+                (bbs !== nothing) && (l = first(bbs[l].stmts))
+                if handler_at[l] != cur_stacks
+                    handler_at[l] = cur_stacks
+                    push!(ip, l)
+                end
+            elseif isa(stmt, Core.ReturnNode)
+                break
+            elseif isa(stmt, Core.EnterNode)
+                l = stmt.catch_dest
+                (bbs !== nothing) && (l != 0) && (l = first(bbs[l].stmts))
+                if l != 0
+                    handler_at[l] = (cur_stacks[1], handler_at[l][2])
+                end
+                cur_stacks = (handler_at[pc_next][1], cur_stacks[2])
+            elseif isa(stmt, Expr)
+                head = stmt.head
+                if head === :leave
+                    println("[rootcause] visiting leave pc=$pc cur_stacks=$cur_stacks stmt=$(stmt_summary(stmt))")
+                    leave_targets = Int[]
+                    l = 0
+                    for arg in stmt.args
+                        if arg === nothing
+                            continue
+                        end
+                        ssa = arg::Core.SSAValue
+                        enter_stmt = code[ssa.id]
+                        println("[rootcause]   leave arg SSA($(ssa.id)) -> $(stmt_summary(enter_stmt))")
+                        if enter_stmt === nothing
+                            continue
+                        end
+                        @assert isa(enter_stmt, Core.EnterNode) "malformed :leave"
+                        l += 1
+                        push!(leave_targets, ssa.id)
+                    end
+                    cur_hand = cur_stacks[1]
+                    for pop_idx = 1:l
+                        if cur_hand == 0
+                            println("[rootcause]   UNDERFLOW at pc=$pc pop_idx=$pop_idx cur_stacks=$cur_stacks leave_targets=$leave_targets")
+                            println("[rootcause]   handler table snapshot:")
+                            for (hid, handler) in enumerate(handlers)
+                                enter_idx = CC.get_enter_idx(handler)
+                                println("[rootcause]     handler_id=$hid enter_idx=$enter_idx handler_at_enter=$(handler_at[enter_idx]) stmt=$(stmt_summary(code[enter_idx]))")
+                            end
+                            return true
+                        end
+                        enter_idx = CC.get_enter_idx(handlers[cur_hand])
+                        outer = handler_at[enter_idx][1]
+                        println("[rootcause]   pop #$pop_idx cur_hand=$cur_hand enter_idx=$enter_idx outer=$outer")
+                        cur_hand = outer
+                    end
+                    cur_stacks = (cur_hand, cur_stacks[2])
+                    cur_stacks == (0, 0) && break
+                elseif head === :pop_exception
+                    println("[rootcause] visiting pop_exception pc=$pc cur_stacks=$cur_stacks stmt=$(stmt_summary(stmt))")
+                    cur_stacks = (cur_stacks[1], handler_at[(stmt.args[1]::Core.SSAValue).id][2])
+                    cur_stacks == (0, 0) && break
+                end
+            end
+
+            pc_next > n && break
+            if handler_at[pc_next] != cur_stacks
+                handler_at[pc_next] = cur_stacks
+            elseif !in(pc_next, ip)
+                break
+            end
+            pc = pc_next
+        end
+    end
+
+    return false
+end
+
+function analyze_method(name::AbstractString, f, argtypes::Type)
+    println("[rootcause] ===== analyzing $name =====")
+    cis = code_lowered(f, argtypes)
+    println("[rootcause] codeinfos=$(length(cis))")
+    any_underflow = false
+    for (idx, ci) in enumerate(cis)
+        println("[rootcause] -- codeinfo $idx")
+        print_special_statements(ci)
+        try
+            CC.ComputeTryCatch{CC.TryCatchFrame}()(ci.code)
+            println("[rootcause] ComputeTryCatch completed without error")
+        catch err
+            println("[rootcause] ComputeTryCatch threw:")
+            showerror(stdout, err, catch_backtrace())
+            println()
+            any_underflow |= debug_compute_trycatch(ci.code)
+        end
+    end
+    return any_underflow
+end
+
+underflow_found = false
+underflow_found |= analyze_method(
+    "TCP.connect(::SocketAddrV4)",
+    NC.connect,
+    Tuple{NC.SocketAddrV4},
+)
+underflow_found |= analyze_method(
+    "TCP._connect_socketaddr_impl(::SocketAddrV4, Nothing, Int64, Nothing)",
+    NC._connect_socketaddr_impl,
+    Tuple{NC.SocketAddrV4, Nothing, Int64, Nothing},
+)
+
+underflow_found || error("expected a ComputeTryCatch underflow, but no underflow was reproduced")
+println("[rootcause] reproduced handler underflow")

--- a/test/windows_compute_trycatch_rootcause.jl
+++ b/test/windows_compute_trycatch_rootcause.jl
@@ -261,6 +261,112 @@ function install_fixed_compute_trycatch!()
     return nothing
 end
 
+function install_fixed_inference_state!()
+    @eval CC begin
+        function InferenceState(
+            result::InferenceResult,
+            src::Core.CodeInfo,
+            cache_mode::UInt8,
+            interp::AbstractInterpreter,
+        )
+            mi = result.linfo
+            world = get_inference_world(interp)
+            if world == typemax(UInt)
+                error("Entering inference from a generated function with an invalid world")
+            end
+            def = mi.def
+            mod = isa(def, Method) ? def.module : def
+            sptypes = sptypes_from_meth_instance(mi)
+            code = src.code::Vector{Any}
+            cfg = compute_basic_blocks(code)
+            spec_info = SpecInfo(src)
+
+            currbb = currpc = 1
+            ip = BitSet(1)
+            handler_info = Main.compute_trycatch_fixed(code, nothing, TryCatchFrame)
+            nssavalues = src.ssavaluetypes::Int
+            ssavalue_uses = find_ssavalue_uses(code, nssavalues)
+            nstmts = length(code)
+            edges = []
+            stmt_info = CallInfo[NoCallInfo() for _ = 1:nstmts]
+
+            nslots = length(src.slotflags)
+            slottypes = Vector{Any}(undef, nslots)
+            bb_vartables = Union{Nothing, VarTable}[nothing for _ = 1:length(cfg.blocks)]
+            bb_saw_latestworld = Bool[false for _ = 1:length(cfg.blocks)]
+            bb_vartable1 = bb_vartables[1] = VarTable(undef, nslots)
+            argtypes = result.argtypes
+
+            argtypes = va_process_argtypes(typeinf_lattice(interp), argtypes, src.nargs, src.isva)
+
+            nargtypes = length(argtypes)
+            for i = 1:nslots
+                argtyp = (i > nargtypes) ? Bottom : argtypes[i]
+                if argtyp === Bool && has_conditional(typeinf_lattice(interp))
+                    argtyp = Conditional(i, Const(true), Const(false))
+                end
+                slottypes[i] = argtyp
+                bb_vartable1[i] = VarState(argtyp, i > nargtypes)
+            end
+            src.ssavaluetypes = ssavaluetypes = Any[NOT_FOUND for _ = 1:nssavalues]
+            ssaflags = copy(src.ssaflags)
+
+            unreachable = BitSet()
+            pclimitations = IdSet{InferenceState}()
+            limitations = IdSet{InferenceState}()
+            cycle_backedges = Tuple{InferenceState, Int}[]
+            callstack = AbsIntState[]
+            tasks = WorkThunk[]
+
+            valid_worlds = WorldRange(1, get_world_counter())
+            bestguess = Bottom
+            exc_bestguess = Bottom
+            ipo_effects = EFFECTS_TOTAL
+
+            insert_coverage = should_insert_coverage(mod, src.debuginfo)
+            if insert_coverage
+                ipo_effects = Effects(ipo_effects; effect_free = ALWAYS_FALSE)
+            end
+
+            if def isa Method
+                nonoverlayed = is_nonoverlayed(def) ? ALWAYS_TRUE :
+                    is_effect_overridden(def, :consistent_overlay) ? CONSISTENT_OVERLAY :
+                    ALWAYS_FALSE
+                ipo_effects = Effects(ipo_effects; nonoverlayed)
+            end
+
+            restrict_abstract_call_sites = isa(def, Module)
+
+            parentid = frameid = cycleid = 0
+
+            this = new(
+                mi, WorldWithRange(world, valid_worlds), mod, sptypes, slottypes, src, cfg, spec_info,
+                currbb, currpc, ip, handler_info, ssavalue_uses, bb_vartables, bb_saw_latestworld, ssavaluetypes, ssaflags, edges, stmt_info,
+                tasks, pclimitations, limitations, cycle_backedges, callstack, parentid, frameid, cycleid,
+                result, unreachable, bestguess, exc_bestguess, ipo_effects,
+                _time_ns(), 0.0, 0, 0,
+                restrict_abstract_call_sites, cache_mode, insert_coverage,
+                interp,
+            )
+
+            if !iszero(cache_mode & CACHE_MODE_LOCAL)
+                push!(get_inference_cache(interp), result)
+            end
+            if !iszero(cache_mode & CACHE_MODE_GLOBAL)
+                push!(callstack, this)
+                this.cycleid = this.frameid = length(callstack)
+            end
+
+            if src.min_world != 1 || src.max_world != typemax(UInt)
+                update_valid_age!(this, WorldRange(src.min_world, src.max_world))
+            end
+
+            return this
+        end
+    end
+    return nothing
+end
+
 function capture_stderr(f::F) where {F}
     path, io = mktemp()
     value = nothing
@@ -336,6 +442,7 @@ fixed_info = compute_trycatch_fixed(ci.code, nothing, CC.TryCatchFrame)
 println("[rootcause] fixed compute_trycatch handler_count=$(fixed_info === nothing ? 0 : length(fixed_info.handlers))")
 
 install_fixed_compute_trycatch!()
+install_fixed_inference_state!()
 patched = summarize_code_typed(
     "patched _connect_socketaddr_impl",
     NC._connect_socketaddr_impl,

--- a/test/windows_compute_trycatch_rootcause.jl
+++ b/test/windows_compute_trycatch_rootcause.jl
@@ -159,6 +159,138 @@ function debug_compute_trycatch(code::Vector{Any}, bbs::Union{Vector{CC.BasicBlo
     return false
 end
 
+function compute_trycatch_fixed(
+    code::Vector{Any},
+    bbs::Union{Vector{CC.BasicBlock}, Nothing},
+    ::Type{Handler},
+) where {Handler}
+    n = length(code)
+    ip = BitSet()
+    ip.offset = 0
+    push!(ip, n + 1)
+    handler_info = nothing
+
+    for pc = 1:n
+        stmt = code[pc]
+        if isa(stmt, Core.EnterNode)
+            (; handlers, handler_at) = handler_info =
+                (handler_info === nothing ? CC.HandlerInfo{Handler}(Handler[], fill((0, 0), n)) : handler_info)
+            l = stmt.catch_dest
+            (bbs !== nothing) && (l != 0) && (l = first(bbs[l].stmts))
+            push!(handlers, Handler(stmt, pc))
+            handler_id = length(handlers)
+            handler_at[pc + 1] = (handler_id, 0)
+            push!(ip, pc + 1)
+            if l != 0
+                handler_at[l] = (0, handler_id)
+                push!(ip, l)
+            end
+        end
+    end
+
+    handler_info === nothing && return nothing
+    (; handlers, handler_at) = handler_info
+
+    while true
+        pc = CC._bits_findnext(ip.bits, 0)::Int
+        pc > n && break
+        while true
+            pc_next = pc + 1
+            delete!(ip, pc)
+            cur_stacks = handler_at[pc]
+            stmt = code[pc]
+            if isa(stmt, Core.GotoNode)
+                pc_next = stmt.label
+                (bbs !== nothing) && (pc_next = first(bbs[pc_next].stmts))
+            elseif isa(stmt, Core.GotoIfNot)
+                l = stmt.dest::Int
+                (bbs !== nothing) && (l = first(bbs[l].stmts))
+                if handler_at[l] != cur_stacks
+                    handler_at[l] = cur_stacks
+                    push!(ip, l)
+                end
+            elseif isa(stmt, Core.ReturnNode)
+                break
+            elseif isa(stmt, Core.EnterNode)
+                l = stmt.catch_dest
+                (bbs !== nothing) && (l != 0) && (l = first(bbs[l].stmts))
+                if l != 0
+                    handler_at[l] = (cur_stacks[1], handler_at[l][2])
+                end
+                cur_stacks = (handler_at[pc_next][1], cur_stacks[2])
+            elseif isa(stmt, Expr)
+                head = stmt.head
+                if head === :leave
+                    cur_hand = cur_stacks[1]
+                    for arg in stmt.args
+                        arg === nothing && continue
+                        ssa = arg::Core.SSAValue
+                        enter_stmt = code[ssa.id]
+                        enter_stmt === nothing && continue
+                        @assert isa(enter_stmt, Core.EnterNode) "malformed :leave"
+                        cur_hand = handler_at[ssa.id][1]
+                    end
+                    cur_stacks = (cur_hand, cur_stacks[2])
+                    cur_stacks == (0, 0) && break
+                elseif head === :pop_exception
+                    cur_stacks = (cur_stacks[1], handler_at[(stmt.args[1]::Core.SSAValue).id][2])
+                    cur_stacks == (0, 0) && break
+                end
+            end
+
+            pc_next > n && break
+            if handler_at[pc_next] != cur_stacks
+                handler_at[pc_next] = cur_stacks
+            elseif !in(pc_next, ip)
+                break
+            end
+            pc = pc_next
+        end
+    end
+
+    @assert first(ip) == n + 1
+    return handler_info
+end
+
+function install_fixed_compute_trycatch!()
+    @eval CC begin
+        function (::ComputeTryCatch{Handler})(code::Vector{Any}, bbs::Union{Vector{BasicBlock}, Nothing}=nothing) where {Handler}
+            return Main.compute_trycatch_fixed(code, bbs, Handler)
+        end
+    end
+    return nothing
+end
+
+function capture_stderr(f::F) where {F}
+    path, io = mktemp()
+    value = nothing
+    err = nothing
+    try
+        redirect_stderr(io) do
+            try
+                value = f()
+            catch ex
+                err = ex
+            end
+        end
+    finally
+        close(io)
+    end
+    stderr = read(path, String)
+    rm(path; force = true)
+    return (; value, err, stderr)
+end
+
+function summarize_code_typed(label::AbstractString, f, argtypes::Type)
+    result = capture_stderr() do
+        Base.code_typed(f, argtypes; optimize = false)
+    end
+    typed_count = result.value === nothing ? 0 : length(result.value)
+    internal_error = occursin("Internal error: during type inference", result.stderr)
+    println("[rootcause] code_typed $label typed_count=$typed_count internal_error=$internal_error err=$(result.err === nothing ? "nothing" : sprint(showerror, result.err))")
+    return result
+end
+
 function analyze_method(name::AbstractString, f, argtypes::Type)
     println("[rootcause] ===== analyzing $name =====")
     cis = code_lowered(f, argtypes)
@@ -191,6 +323,25 @@ underflow_found |= analyze_method(
     NC._connect_socketaddr_impl,
     Tuple{NC.SocketAddrV4, Nothing, Int64, Nothing},
 )
+
+baseline = summarize_code_typed(
+    "baseline _connect_socketaddr_impl",
+    NC._connect_socketaddr_impl,
+    Tuple{NC.SocketAddrV4, Nothing, Int64, Nothing},
+)
+println("[rootcause] baseline stderr bytes=$(ncodeunits(baseline.stderr))")
+
+ci = only(code_lowered(NC._connect_socketaddr_impl, Tuple{NC.SocketAddrV4, Nothing, Int64, Nothing}))
+fixed_info = compute_trycatch_fixed(ci.code, nothing, CC.TryCatchFrame)
+println("[rootcause] fixed compute_trycatch handler_count=$(fixed_info === nothing ? 0 : length(fixed_info.handlers))")
+
+install_fixed_compute_trycatch!()
+patched = summarize_code_typed(
+    "patched _connect_socketaddr_impl",
+    NC._connect_socketaddr_impl,
+    Tuple{NC.SocketAddrV4, Nothing, Int64, Nothing},
+)
+println("[rootcause] patched stderr bytes=$(ncodeunits(patched.stderr))")
 
 underflow_found || error("expected a ComputeTryCatch underflow, but no underflow was reproduced")
 println("[rootcause] reproduced handler underflow")

--- a/test/windows_ice_precompile_probe.jl
+++ b/test/windows_ice_precompile_probe.jl
@@ -1,0 +1,221 @@
+using Reseau
+
+const TL = Reseau.TLS
+const NC = Reseau.TCP
+const ND = Reseau.HostResolvers
+const IP = Reseau.IOPoll
+
+const _CERT_PATH = joinpath(@__DIR__, "resources", "unittests.crt")
+const _KEY_PATH = joinpath(@__DIR__, "resources", "unittests.key")
+
+function _trace(label::AbstractString)
+    println("[windows-ice-probe] ", label)
+    flush(stdout)
+    return nothing
+end
+
+function _close_quiet!(x)
+    x === nothing && return nothing
+    try
+        close(x)
+    catch
+    end
+    return nothing
+end
+
+function _wait_task_done(task::Task, timeout_s::Float64 = 2.0)
+    return IP.timedwait(() -> istaskdone(task), timeout_s; pollint = 0.001)
+end
+
+function _ipv6_supported()::Bool
+    listener = nothing
+    try
+        listener = NC.listen("tcp6", "[::1]:0"; backlog = 1)
+        return true
+    catch
+        return false
+    finally
+        _close_quiet!(listener)
+        IP.shutdown!()
+    end
+end
+
+function _write_and_readback!(client, server)
+    payload = UInt8[0x52, 0x45, 0x53]
+    write(client, payload)
+    recv_buf = Vector{UInt8}(undef, length(payload))
+    read!(server, recv_buf)
+    return nothing
+end
+
+function _tcp_server_pair(f::F) where {F}
+    listener = nothing
+    client = nothing
+    server = nothing
+    accept_task = nothing
+    try
+        listener = NC.listen("tcp", "127.0.0.1:0"; backlog = 4)
+        port = Int((NC.addr(listener)::NC.SocketAddrV4).port)
+        accept_task = errormonitor(@async NC.accept(listener))
+        client = f(port)
+        status = _wait_task_done(accept_task)
+        status == :timed_out && error("timed out waiting for TCP accept")
+        server = fetch(accept_task)
+        _write_and_readback!(client, server)
+    finally
+        _close_quiet!(server)
+        _close_quiet!(client)
+        _close_quiet!(listener)
+        IP.shutdown!()
+    end
+    return nothing
+end
+
+function _tcp6_server_pair(f::F) where {F}
+    !_ipv6_supported() && return :skipped
+    listener = nothing
+    client = nothing
+    server = nothing
+    accept_task = nothing
+    try
+        listener = NC.listen("tcp6", "[::1]:0"; backlog = 4)
+        port = Int((NC.addr(listener)::NC.SocketAddrV6).port)
+        accept_task = errormonitor(@async NC.accept(listener))
+        client = f(port)
+        status = _wait_task_done(accept_task)
+        status == :timed_out && error("timed out waiting for TCP6 accept")
+        server = fetch(accept_task)
+        _write_and_readback!(client, server)
+    finally
+        _close_quiet!(server)
+        _close_quiet!(client)
+        _close_quiet!(listener)
+        IP.shutdown!()
+    end
+    return nothing
+end
+
+function _tls_server_pair(f::F) where {F}
+    listener = nothing
+    client = nothing
+    server = nothing
+    accept_task = nothing
+    try
+        server_cfg = TL.Config(
+            verify_peer = false,
+            cert_file = _CERT_PATH,
+            key_file = _KEY_PATH,
+            handshake_timeout_ns = 1_000_000_000,
+        )
+        listener = TL.listen(NC.loopback_addr(0), server_cfg; backlog = 4)
+        port = Int((TL.addr(listener)::NC.SocketAddrV4).port)
+        accept_task = errormonitor(@async begin
+            conn = TL.accept(listener)
+            TL.handshake!(conn)
+            return conn
+        end)
+        client = f(port)
+        status = _wait_task_done(accept_task, 3.0)
+        status == :timed_out && error("timed out waiting for TLS accept")
+        server = fetch(accept_task)
+        _write_and_readback!(client, server)
+    finally
+        _close_quiet!(server)
+        _close_quiet!(client)
+        _close_quiet!(listener)
+        IP.shutdown!()
+    end
+    return nothing
+end
+
+function probe_tcp_direct_v4()
+    return _tcp_server_pair() do port
+        NC.connect(NC.loopback_addr(port))
+    end
+end
+
+function probe_tcp_kw_local_v4()
+    return _tcp_server_pair() do port
+        NC.connect("tcp", "127.0.0.1:$port"; local_addr = NC.loopback_addr(0))
+    end
+end
+
+function probe_tcp_kw_local_v6()
+    return _tcp6_server_pair() do port
+        NC.connect("tcp6", ND.join_host_port("::1", port); local_addr = NC.loopback_addr6(0))
+    end
+end
+
+function probe_tcp_kw_resolver()
+    return _tcp_server_pair() do port
+        resolver = ND.StaticResolver(hosts = Dict(
+            "probe.test" => NC.SocketEndpoint[NC.loopback_addr(port)],
+        ))
+        NC.connect(
+            "tcp",
+            "probe.test:$port";
+            resolver = resolver,
+            timeout_ns = 1_000_000_000,
+            fallback_delay_ns = -1,
+        )
+    end
+end
+
+function probe_tcp_deadline_error()
+    err = try
+        NC.connect("tcp", "127.0.0.1:1"; deadline_ns = time_ns() - 1)
+        nothing
+    catch ex
+        ex
+    end
+    err === nothing && error("expected deadline failure")
+    return nothing
+end
+
+function probe_tls_string()
+    return _tls_server_pair() do port
+        TL.connect(
+            "tcp",
+            "127.0.0.1:$port";
+            server_name = "localhost",
+            verify_peer = false,
+            handshake_timeout_ns = 1_000_000_000,
+        )
+    end
+end
+
+function probe_tls_socketaddr()
+    return _tls_server_pair() do port
+        TL.connect(
+            NC.loopback_addr(port),
+            NC.loopback_addr(0);
+            server_name = "localhost",
+            verify_peer = false,
+            handshake_timeout_ns = 1_000_000_000,
+        )
+    end
+end
+
+const PROBES = [
+    ("tcp_direct_v4", probe_tcp_direct_v4),
+    ("tcp_kw_local_v4", probe_tcp_kw_local_v4),
+    ("tcp_kw_local_v6", probe_tcp_kw_local_v6),
+    ("tcp_kw_resolver", probe_tcp_kw_resolver),
+    ("tcp_deadline_error", probe_tcp_deadline_error),
+    ("tls_string", probe_tls_string),
+    ("tls_socketaddr", probe_tls_socketaddr),
+]
+
+for pass in 1:2
+    _trace("pass=$pass begin")
+    for (name, probe) in PROBES
+        _trace("pass=$pass probe=$name start")
+        outcome = try
+            probe()
+            "ok"
+        catch err
+            sprint(showerror, err, catch_backtrace())
+        end
+        _trace("pass=$pass probe=$name done outcome=$(replace(outcome, '\n' => ' '))")
+    end
+end


### PR DESCRIPTION
## Summary
- add a focused Windows ICE probe workflow for baseline vs explicit precompile scenarios
- add a runtime probe script that exercises the public TCP/HostResolver/TLS call shapes twice in one process
- add a debug-only Windows precompile hook so we can test whether front-loading the hot signatures suppresses later runtime ICEs

## Why
This PR is for investigation only. The goal is to answer three questions with CI evidence:
1. Are the Windows ICEs coming from one call shape or several?
2. Do they only happen on first compilation in a process?
3. If we explicitly precompile the hot Reseau signatures, do later runtime/test processes stop emitting them?
