### PR TITLE
feat(conn): accept contiguous read buffers

### DIFF
--- a/src/0_compat.jl
+++ b/src/0_compat.jl
@@ -2,9 +2,19 @@
 
 if VERSION < v"1.11"
     const ByteMemory = Vector{UInt8}
+    const MutableByteBuffer = Union{
+        Vector{UInt8},
+        Base.FastContiguousSubArray{UInt8,1,<:Array},
+    }
     bytememory(n::Integer)::ByteMemory = Vector{UInt8}(undef, Int(n))
 else
     const ByteMemory = Memory{UInt8}
+    const MutableByteBuffer = Union{
+        Vector{UInt8},
+        ByteMemory,
+        Base.FastContiguousSubArray{UInt8,1,<:Array},
+        Base.FastContiguousSubArray{UInt8,1,<:Memory},
+    }
     bytememory(n::Integer)::ByteMemory = Memory{UInt8}(undef, Int(n))
 end
 

--- a/src/2_iopoll.jl
+++ b/src/2_iopoll.jl
@@ -15,7 +15,7 @@ handles directly.
 """
 module IOPoll
 
-using ..Reseau: ByteMemory, @gcsafe_ccall
+using ..Reseau: ByteMemory, MutableByteBuffer, @gcsafe_ccall
 using ..Reseau.SocketOps
 
 include("iopoll/types.jl")

--- a/src/3_tcp.jl
+++ b/src/3_tcp.jl
@@ -14,7 +14,7 @@ including:
 """
 module TCP
 
-using ..Reseau: ByteMemory
+using ..Reseau: ByteMemory, MutableByteBuffer
 using ..Reseau.IOPoll
 using ..Reseau.SocketOps
 
@@ -626,7 +626,7 @@ function accept(listener::Listener)::Conn
     end
 end
 
-@inline function _read_some!(conn::Conn, buf::Vector{UInt8})::Int
+@inline function _read_some!(conn::Conn, buf::MutableByteBuffer)::Int
     return IOPoll.read!(conn.fd.pfd, buf)
 end
 
@@ -728,15 +728,45 @@ function _readbytes_some!(conn::Conn, buf::Vector{UInt8}, requested::Int)::Int
     return bytes_read
 end
 
+function _readbytes_all!(conn::Conn, buf::MutableByteBuffer, requested::Int)::Int
+    requested <= length(buf) || throw(ArgumentError("nb exceeds fixed-size buffer length"))
+    bytes_read = 0
+    while bytes_read < requested
+        n = try
+            GC.@preserve buf _read_some!(conn, pointer(buf, bytes_read + 1), requested - bytes_read)
+        catch err
+            ex = err::Exception
+            ex isa EOFError || rethrow(ex)
+            break
+        end
+        bytes_read += n
+    end
+    return bytes_read
+end
+
+function _readbytes_some!(conn::Conn, buf::MutableByteBuffer, requested::Int)::Int
+    requested <= length(buf) || throw(ArgumentError("nb exceeds fixed-size buffer length"))
+    return try
+        GC.@preserve buf _read_some!(conn, pointer(buf), requested)
+    catch err
+        ex = err::Exception
+        ex isa EOFError || rethrow(ex)
+        0
+    end
+end
+
 """
     read!(conn, buf) -> buf
 
 Read exactly `length(buf)` bytes into `buf` or throw `EOFError`.
 
+Because `Conn <: IO`, Base's generic `read!` implementation already supports
+mutable byte views like `@view bytes[2:5]` in addition to plain vectors.
+
 Use `readbytes!` or `readavailable` when you want a count-returning read that
 may stop early.
 """
-Base.read!(conn::Conn, buf::Vector{UInt8})
+Base.read!(conn::Conn, buf)
 
 """
     readbytes!(conn, buf, nb=length(buf); all::Bool=true) -> Int
@@ -750,8 +780,12 @@ contract.
 If `all` is `true` (the default), the call keeps reading until `nb` bytes have
 been transferred, EOF is reached, or an error occurs. If `all` is `false`, at
 most one underlying socket read is performed.
+
+Resizable `Vector{UInt8}` buffers grow when needed, matching Julia's standard
+`readbytes!` behavior. Fixed-size contiguous byte views must satisfy
+`nb <= length(buf)`.
 """
-function Base.readbytes!(conn::Conn, buf::Vector{UInt8}, nb::Integer = length(buf); all::Bool = true)::Int
+function Base.readbytes!(conn::Conn, buf::MutableByteBuffer, nb::Integer = length(buf); all::Bool = true)::Int
     Base.require_one_based_indexing(buf)
     requested = Int(nb)
     requested < 0 && throw(ArgumentError("nb must be >= 0"))

--- a/src/5_tls.jl
+++ b/src/5_tls.jl
@@ -13,7 +13,7 @@ module TLS
 
 using OpenSSL_jll
 using NetworkOptions
-using ..Reseau: ByteMemory
+using ..Reseau: ByteMemory, MutableByteBuffer
 using ..Reseau: @gcsafe_ccall
 using ..Reseau.IOPoll
 using ..Reseau.SocketOps
@@ -1089,7 +1089,7 @@ end
     return Int(ccall((:SSL_pending, _LIBSSL), Cint, (Ptr{Cvoid},), conn.ssl))
 end
 
-@inline function _read_some!(conn::Conn, buf::Vector{UInt8})::Int
+@inline function _read_some!(conn::Conn, buf::MutableByteBuffer)::Int
     GC.@preserve buf begin
         return _read_some!(conn, pointer(buf), length(buf))
     end
@@ -1231,15 +1231,45 @@ function _readbytes_some!(conn::Conn, buf::Vector{UInt8}, requested::Int)::Int
     return bytes_read
 end
 
+function _readbytes_all!(conn::Conn, buf::MutableByteBuffer, requested::Int)::Int
+    requested <= length(buf) || throw(ArgumentError("nb exceeds fixed-size buffer length"))
+    bytes_read = 0
+    while bytes_read < requested
+        n = try
+            GC.@preserve buf _read_some!(conn, pointer(buf, bytes_read + 1), requested - bytes_read)
+        catch err
+            ex = err::Exception
+            ex isa EOFError || rethrow(ex)
+            break
+        end
+        bytes_read += n
+    end
+    return bytes_read
+end
+
+function _readbytes_some!(conn::Conn, buf::MutableByteBuffer, requested::Int)::Int
+    requested <= length(buf) || throw(ArgumentError("nb exceeds fixed-size buffer length"))
+    return try
+        GC.@preserve buf _read_some!(conn, pointer(buf), requested)
+    catch err
+        ex = err::Exception
+        ex isa EOFError || rethrow(ex)
+        0
+    end
+end
+
 """
     read!(conn, buf) -> buf
 
 Read exactly `length(buf)` decrypted bytes into `buf` or throw `EOFError`.
 
+Because `Conn <: IO`, Base's generic `read!` implementation already supports
+mutable byte views like `@view bytes[2:5]` in addition to plain vectors.
+
 Use `readbytes!` or `readavailable` when you want a count-returning read that
 may stop early.
 """
-Base.read!(conn::Conn, buf::Vector{UInt8})
+Base.read!(conn::Conn, buf)
 
 """
     readbytes!(conn, buf, nb=length(buf); all::Bool=true) -> Int
@@ -1249,8 +1279,12 @@ Read up to `nb` decrypted bytes into `buf`, returning the byte count.
 If `all` is `true` (the default), the call keeps reading until `nb` bytes have
 been transferred, EOF is reached, or an error occurs. If `all` is `false`, at
 most one underlying TLS read is performed.
+
+Resizable `Vector{UInt8}` buffers grow when needed, matching Julia's standard
+`readbytes!` behavior. Fixed-size contiguous byte views must satisfy
+`nb <= length(buf)`.
 """
-function Base.readbytes!(conn::Conn, buf::Vector{UInt8}, nb::Integer = length(buf); all::Bool = true)::Int
+function Base.readbytes!(conn::Conn, buf::MutableByteBuffer, nb::Integer = length(buf); all::Bool = true)::Int
     Base.require_one_based_indexing(buf)
     requested = Int(nb)
     requested < 0 && throw(ArgumentError("nb must be >= 0"))

--- a/src/iopoll/fd.jl
+++ b/src/iopoll/fd.jl
@@ -629,8 +629,11 @@ Important behavior notes:
 Throws `EOFError` when the peer cleanly closes a stream whose
 `zero_read_is_eof` flag is set, `DeadlineExceededError` when the read deadline
 expires while waiting, and `SystemError` for OS-level read failures.
+
+`p` may be a `Vector{UInt8}` or any other mutable contiguous byte view accepted
+by `pointer`, such as `@view bytes[2:5]`.
 """
-function read!(fd::FD, p::Vector{UInt8})::Int
+function read!(fd::FD, p::MutableByteBuffer)::Int
     GC.@preserve p begin
         return _read_ptr_some!(fd, pointer(p), length(p))
     end

--- a/test/internal_poll_tests.jl
+++ b/test/internal_poll_tests.jl
@@ -125,6 +125,25 @@ end
                 IP.shutdown!()
             end
         end
+        @testset "read accepts contiguous byte views" begin
+            fd0, fd1 = _ip_socketpair_stream()
+            ipfd = IP.FD(fd0)
+            fd0 = Cint(-1)
+            try
+                IP._set_nonblocking!(ipfd.sysfd)
+                IP.register!(ipfd)
+                _ip_write_byte(fd1, 0x6a)
+                backing = fill(UInt8(0x00), 3)
+                buf = @view backing[2:2]
+                n = IP.read!(ipfd, buf)
+                @test n == 1
+                @test backing == UInt8[0x00, 0x6a, 0x00]
+            finally
+                ipfd.sysfd >= 0 && close(ipfd)
+                _ip_close_fd(fd1)
+                IP.shutdown!()
+            end
+        end
         @testset "read deadline timeout" begin
             fd0, fd1 = _ip_socketpair_stream()
             ipfd = IP.FD(fd0)

--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -77,6 +77,11 @@ end
                 codeunits_buf = Vector{UInt8}(undef, 2)
                 @test read!(server, codeunits_buf) === codeunits_buf
                 @test String(codeunits_buf) == "hi"
+                @test write(client, UInt8[0x6a, 0x6b, 0x6c]) == 3
+                view_backing = fill(UInt8(0x00), 5)
+                view_buf = @view view_backing[2:4]
+                @test read!(server, view_buf) === view_buf
+                @test view_backing == UInt8[0x00, 0x6a, 0x6b, 0x6c, 0x00]
                 @test write(client, UInt8[0x31, 0x32, 0x33]) == 3
                 short_buf = UInt8[]
                 @test readbytes!(server, short_buf, 3) == 3
@@ -154,6 +159,15 @@ end
                 @test readbytes!(server, grown_buf, 5; all = false) == length(third_payload)
                 @test grown_buf[1:2] == third_payload
                 @test length(grown_buf) == 3
+                NC.set_read_deadline!(server, Int64(0))
+
+                fourth_payload = UInt8[0x47, 0x48]
+                @test write(client, fourth_payload) == length(fourth_payload)
+                NC.set_read_deadline!(server, time_ns() + 250_000_000)
+                view_backing = fill(UInt8(0x00), 5)
+                view_buf = @view view_backing[2:4]
+                @test readbytes!(server, view_buf, 3; all = false) == length(fourth_payload)
+                @test view_backing == UInt8[0x00, 0x47, 0x48, 0x00, 0x00]
                 NC.set_read_deadline!(server, Int64(0))
             finally
                 _close_quiet!(server)

--- a/test/tls_tests.jl
+++ b/test/tls_tests.jl
@@ -593,7 +593,8 @@ end
                         buf = Vector{UInt8}(undef, 4)
                         read!(conn, buf)
                         write(conn, buf)
-                        view_buf = Vector{UInt8}(undef, 3)
+                        view_backing = fill(UInt8(0x00), 5)
+                        view_buf = @view view_backing[2:4]
                         read!(conn, view_buf)
                         write(conn, view_buf)
                         return conn
@@ -1104,6 +1105,15 @@ end
                 @test readbytes!(server, grown_buf, 5; all = false) == length(third_payload)
                 @test grown_buf[1:2] == third_payload
                 @test length(grown_buf) == 3
+                TL.set_read_deadline!(server, Int64(0))
+
+                fourth_payload = UInt8[0x47, 0x48]
+                @test write(client, fourth_payload) == length(fourth_payload)
+                TL.set_read_deadline!(server, time_ns() + 250_000_000)
+                view_backing = fill(UInt8(0x00), 5)
+                view_buf = @view view_backing[2:4]
+                @test readbytes!(server, view_buf, 3; all = false) == length(fourth_payload)
+                @test view_backing == UInt8[0x00, 0x47, 0x48, 0x00, 0x00]
                 TL.set_read_deadline!(server, Int64(0))
             finally
                 _tls_close_quiet!(server)


### PR DESCRIPTION
## Summary
- widen the low-level read buffer plumbing to accept contiguous mutable byte views
- let TCP/TLS readbytes! support view-backed destinations while keeping vector growth semantics
- add coverage for IOPoll, TCP, and TLS reads into views

## Testing
- JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=internal_poll_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl
- JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=tcp_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl
- JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=tls_tests.jl julia --project=. --startup-file=no --history-file=no test/runtests.jl