### PR TITLE
[codex] replace getaddrinfo threadcall with resolver pool

### DIFF
--- a/src/4_host_resolvers.jl
+++ b/src/4_host_resolvers.jl
@@ -402,8 +402,7 @@ const _ADDRINFO_POOL_LOCK = ReentrantLock()
 const _ADDRINFO_STARTED_THREADS = Ref{Int}(0)
 
 mutable struct _AddrInfoFuture
-    lock::ReentrantLock
-    cond::Threads.Condition
+    notify::Threads.Condition
     hostname::String
     flags::Cint
     ret::Cint
@@ -413,15 +412,14 @@ mutable struct _AddrInfoFuture
 end
 
 function _AddrInfoFuture(hostname::String, flags::Cint)
-    lock = ReentrantLock()
-    return _AddrInfoFuture(lock, Threads.Condition(lock), hostname, flags, Cint(0), false, nothing, C_NULL)
+    return _AddrInfoFuture(Threads.Condition(), hostname, flags, Cint(0), false, nothing, C_NULL)
 end
 
 const _ADDRINFO_WORK_QUEUE = Ref{Channel{_AddrInfoFuture}}()
 
 @inline function _addr_info_future_result_ptr(future::_AddrInfoFuture)::Ptr{Ptr{_AddrInfo}}
     base = Ptr{UInt8}(pointer_from_objref(future))
-    return Ptr{Ptr{_AddrInfo}}(base + fieldoffset(_AddrInfoFuture, 8))
+    return Ptr{Ptr{_AddrInfo}}(base + fieldoffset(_AddrInfoFuture, 7))
 end
 
 function _prepare_addrinfo_hints!(hints::Ref{_AddrInfo}, flags::Cint)::Nothing
@@ -468,7 +466,7 @@ function _run_addrinfo_future!(future::_AddrInfoFuture)::Nothing
     catch ex
         err = ex::Exception
     end
-    lock(future.lock)
+    lock(future.notify)
     try
         future.ret = ret
         if err === nothing
@@ -477,9 +475,9 @@ function _run_addrinfo_future!(future::_AddrInfoFuture)::Nothing
             future.err = err::Exception
         end
         future.done = true
-        notify(future.cond)
+        notify(future.notify)
     finally
-        unlock(future.lock)
+        unlock(future.notify)
     end
     return nothing
 end
@@ -515,15 +513,15 @@ function _ensure_addrinfo_pool!()::Channel{_AddrInfoFuture}
 end
 
 function _wait_addrinfo_future!(future::_AddrInfoFuture)::Cint
-    lock(future.lock)
+    lock(future.notify)
     try
         while !future.done
-            wait(future.cond)
+            wait(future.notify)
         end
         future.err === nothing || throw(future.err::Exception)
         return future.ret
     finally
-        unlock(future.lock)
+        unlock(future.notify)
     end
 end
 

--- a/src/4_host_resolvers.jl
+++ b/src/4_host_resolvers.jl
@@ -395,6 +395,143 @@ const _WSATRY_AGAIN = Cint(11002)
 const _WSATYPE_NOT_FOUND = Cint(10109)
 const _DNS_ERROR_RCODE_NAME_ERROR = Cint(9003)
 const _DNS_INFO_NO_RECORDS = Cint(9501)
+const _ADDRINFO_POOL_SIZE = 4
+const _ADDRINFO_POOL_CAPACITY = 64
+const _ADDRINFO_THREAD_ENTRY_C = Ref{Ptr{Cvoid}}(C_NULL)
+const _ADDRINFO_POOL_LOCK = ReentrantLock()
+const _ADDRINFO_STARTED_THREADS = Ref{Int}(0)
+
+mutable struct _AddrInfoFuture
+    lock::ReentrantLock
+    cond::Threads.Condition
+    hostname::String
+    flags::Cint
+    ret::Cint
+    done::Bool
+    err::Union{Nothing,Exception}
+    addr_info_ptr::Ptr{_AddrInfo}
+end
+
+function _AddrInfoFuture(hostname::String, flags::Cint)
+    lock = ReentrantLock()
+    return _AddrInfoFuture(lock, Threads.Condition(lock), hostname, flags, Cint(0), false, nothing, C_NULL)
+end
+
+const _ADDRINFO_WORK_QUEUE = Ref{Channel{_AddrInfoFuture}}()
+
+@inline function _addr_info_future_result_ptr(future::_AddrInfoFuture)::Ptr{Ptr{_AddrInfo}}
+    base = Ptr{UInt8}(pointer_from_objref(future))
+    return Ptr{Ptr{_AddrInfo}}(base + fieldoffset(_AddrInfoFuture, 8))
+end
+
+function _prepare_addrinfo_hints!(hints::Ref{_AddrInfo}, flags::Cint)::Nothing
+    hints_ptr = Base.unsafe_convert(Ptr{_AddrInfo}, hints)
+    Base.Libc.memset(hints_ptr, 0, sizeof(_AddrInfo))
+    hints_bytes = Ptr{UInt8}(hints_ptr)
+    unsafe_store!(Ptr{Cint}(hints_bytes + fieldoffset(_AddrInfo, 1)), flags)
+    unsafe_store!(Ptr{Cint}(hints_bytes + fieldoffset(_AddrInfo, 2)), _AF_UNSPEC)
+    unsafe_store!(Ptr{Cint}(hints_bytes + fieldoffset(_AddrInfo, 3)), _SOCK_STREAM)
+    return nothing
+end
+
+function _ccall_getaddrinfo(hostname::String, hints::Ref{_AddrInfo}, result_ptr::Ptr{Ptr{_AddrInfo}})::Cint
+    null_service = Ptr{UInt8}(C_NULL)
+    return @static if Sys.iswindows()
+        ccall((:getaddrinfo, "Ws2_32"), Cint,
+            (Cstring, Cstring, Ptr{_AddrInfo}, Ptr{Ptr{_AddrInfo}}),
+            hostname,
+            null_service,
+            hints,
+            result_ptr,
+        )
+    else
+        ccall(:getaddrinfo, Cint,
+            (Cstring, Cstring, Ptr{_AddrInfo}, Ptr{Ptr{_AddrInfo}}),
+            hostname,
+            null_service,
+            hints,
+            result_ptr,
+        )
+    end
+end
+
+function _run_addrinfo_future!(future::_AddrInfoFuture)::Nothing
+    ret = Cint(0)
+    err = nothing
+    try
+        hints = Ref{_AddrInfo}()
+        GC.@preserve future hints begin
+            _prepare_addrinfo_hints!(hints, future.flags)
+            unsafe_store!(_addr_info_future_result_ptr(future), C_NULL)
+            ret = _ccall_getaddrinfo(future.hostname, hints, _addr_info_future_result_ptr(future))
+        end
+    catch ex
+        err = ex::Exception
+    end
+    lock(future.lock)
+    try
+        future.ret = ret
+        if err === nothing
+            future.err = nothing
+        else
+            future.err = err::Exception
+        end
+        future.done = true
+        notify(future.cond)
+    finally
+        unlock(future.lock)
+    end
+    return nothing
+end
+
+function _addrinfo_worker_entry(arg::Ptr{Cvoid})::Ptr{Cvoid}
+    work_queue = unsafe_pointer_to_objref(arg)::Channel{_AddrInfoFuture}
+    try
+        for future in work_queue
+            _run_addrinfo_future!(future)
+        end
+    catch
+    end
+    return C_NULL
+end
+
+function _ensure_addrinfo_pool!()::Channel{_AddrInfoFuture}
+    lock(_ADDRINFO_POOL_LOCK)
+    try
+        if !isassigned(_ADDRINFO_WORK_QUEUE)
+            _ADDRINFO_WORK_QUEUE[] = Channel{_AddrInfoFuture}(_ADDRINFO_POOL_CAPACITY)
+            _ADDRINFO_STARTED_THREADS[] = 0
+        end
+        work_queue = _ADDRINFO_WORK_QUEUE[]
+        while _ADDRINFO_STARTED_THREADS[] < _ADDRINFO_POOL_SIZE
+            next_idx = _ADDRINFO_STARTED_THREADS[] + 1
+            IOPoll._spawn_detached_thread("reseau-getaddrinfo-$next_idx", _ADDRINFO_THREAD_ENTRY_C, work_queue)
+            _ADDRINFO_STARTED_THREADS[] = next_idx
+        end
+        return work_queue
+    finally
+        unlock(_ADDRINFO_POOL_LOCK)
+    end
+end
+
+function _wait_addrinfo_future!(future::_AddrInfoFuture)::Cint
+    lock(future.lock)
+    try
+        while !future.done
+            wait(future.cond)
+        end
+        future.err === nothing || throw(future.err::Exception)
+        return future.ret
+    finally
+        unlock(future.lock)
+    end
+end
+
+function __init__()
+    _ADDRINFO_THREAD_ENTRY_C[] = @cfunction(_addrinfo_worker_entry, Ptr{Cvoid}, (Ptr{Cvoid},))
+    _ADDRINFO_WORK_QUEUE[] = Channel{_AddrInfoFuture}(_ADDRINFO_POOL_CAPACITY)
+    _ADDRINFO_STARTED_THREADS[] = 0
+end
 
 @static if Sys.iswindows()
     const _IPHLPAPI = "Iphlpapi"
@@ -603,40 +740,15 @@ function _native_getaddrinfo(hostname::AbstractString; flags::Cint = Cint(0))::V
     SocketOps.ensure_winsock!()
     addresses = TCP.SocketEndpoint[]
     hostname_s = String(hostname)
-    null_service = Ptr{UInt8}(C_NULL)
-    hints = Ref{_AddrInfo}()
-    hints_ptr = Base.unsafe_convert(Ptr{_AddrInfo}, hints)
-    Base.Libc.memset(hints_ptr, 0, sizeof(_AddrInfo))
-    hints_bytes = Ptr{UInt8}(hints_ptr)
-    GC.@preserve hints begin
-        unsafe_store!(Ptr{Cint}(hints_bytes + fieldoffset(_AddrInfo, 1)), flags)
-        unsafe_store!(Ptr{Cint}(hints_bytes + fieldoffset(_AddrInfo, 2)), _AF_UNSPEC)
-        unsafe_store!(Ptr{Cint}(hints_bytes + fieldoffset(_AddrInfo, 3)), _SOCK_STREAM)
-    end
-    result_ptr = Ref{Ptr{_AddrInfo}}(C_NULL)
-    # `getaddrinfo` can block inside the system resolver stack. Run it on Julia's
-    # libuv worker pool so hostname resolution does not occupy a Julia scheduler
-    # thread while callers wait on timeout/deadline machinery.
-    ret = @static if Sys.iswindows()
-        @threadcall((:getaddrinfo, "Ws2_32"), Cint,
-            (Cstring, Cstring, Ptr{_AddrInfo}, Ptr{Ptr{_AddrInfo}}),
-            hostname_s,
-            null_service,
-            hints,
-            result_ptr,
-        )
-    else
-        @threadcall(:getaddrinfo, Cint,
-            (Cstring, Cstring, Ptr{_AddrInfo}, Ptr{Ptr{_AddrInfo}}),
-            hostname_s,
-            null_service,
-            hints,
-            result_ptr,
-        )
-    end
+    future = _AddrInfoFuture(hostname_s, flags)
+    # `getaddrinfo` can block inside the system resolver stack. Run it on a
+    # small dedicated worker pool so hostname resolution does not occupy a Julia
+    # scheduler thread while callers wait on timeout/deadline machinery.
+    put!(_ensure_addrinfo_pool!(), future)
+    ret = _wait_addrinfo_future!(future)
     ret == 0 || _lookup_error("lookup failed: $(_gai_error_string(ret))", hostname_s)
     try
-        current = result_ptr[]
+        current = future.addr_info_ptr
         while current != C_NULL
             ai = unsafe_load(current)
             if ai.ai_addr != C_NULL
@@ -655,11 +767,11 @@ function _native_getaddrinfo(hostname::AbstractString; flags::Cint = Cint(0))::V
             current = ai.ai_next
         end
     finally
-        if result_ptr[] != C_NULL
+        if future.addr_info_ptr != C_NULL
             @static if Sys.iswindows()
-                ccall((:freeaddrinfo, "Ws2_32"), Cvoid, (Ptr{_AddrInfo},), result_ptr[])
+                ccall((:freeaddrinfo, "Ws2_32"), Cvoid, (Ptr{_AddrInfo},), future.addr_info_ptr)
             else
-                ccall(:freeaddrinfo, Cvoid, (Ptr{_AddrInfo},), result_ptr[])
+                ccall(:freeaddrinfo, Cvoid, (Ptr{_AddrInfo},), future.addr_info_ptr)
             end
         end
     end

--- a/test/host_resolvers_system_trim_safe.jl
+++ b/test/host_resolvers_system_trim_safe.jl
@@ -1,0 +1,22 @@
+using Reseau
+
+const ND = Reseau.HostResolvers
+const NC = Reseau.TCP
+
+function run_host_resolvers_system_trim_sample()::Nothing
+    native = ND._native_getaddrinfo("localhost"; flags = ND._AI_ALL | ND._AI_V4MAPPED)
+    isempty(native) && error("expected native localhost resolution")
+    all(x -> x isa NC.SocketEndpoint, native) || error("expected native socket endpoints")
+    resolved = ND.resolve_tcp_addrs("tcp", "localhost:80")
+    isempty(resolved) && error("expected resolved localhost addresses")
+    all(x -> x isa NC.SocketEndpoint, resolved) || error("expected resolved socket endpoints")
+    return nothing
+end
+
+function @main(args::Vector{String})::Cint
+    _ = args
+    run_host_resolvers_system_trim_sample()
+    return 0
+end
+
+Base.Experimental.entrypoint(main, (Vector{String},))

--- a/test/host_resolvers_tests.jl
+++ b/test/host_resolvers_tests.jl
@@ -639,14 +639,16 @@ end
             listener = nothing
             client1 = nothing
             client2 = nothing
+            timeout_ns = Sys.iswindows() ? Int64(5_000_000_000) : Int64(1_000_000_000)
+            wait_s = Sys.iswindows() ? 5.0 : 2.0
             try
                 listener = NC.listen("tcp", "127.0.0.1:0"; backlog = 8)
                 laddr = NC.addr(listener)::NC.SocketAddrV4
                 resolver = _CountingResolver(0.05, NC.SocketEndpoint[NC.loopback_addr(Int(laddr.port))])
                 singleflight = ND.SingleflightResolver(resolver)
-                task2 = errormonitor(@async _nd_connect_singleflight("same.test:$(Int(laddr.port))", singleflight, 1_000_000_000, -1))
-                client1 = _nd_connect_singleflight("same.test:$(Int(laddr.port))", singleflight, 1_000_000_000, -1)
-                @test _nd_wait_task_done(task2, 2.0) != :timed_out
+                task2 = errormonitor(@async _nd_connect_singleflight("same.test:$(Int(laddr.port))", singleflight, timeout_ns, -1))
+                client1 = _nd_connect_singleflight("same.test:$(Int(laddr.port))", singleflight, timeout_ns, -1)
+                @test _nd_wait_task_done(task2, wait_s) != :timed_out
                 client2 = fetch(task2)
                 server1 = NC.accept(listener)
                 server2 = NC.accept(listener)

--- a/test/host_resolvers_tests.jl
+++ b/test/host_resolvers_tests.jl
@@ -127,6 +127,14 @@ function _nd_wait_task_done(task::Task, timeout_s::Float64 = 2.0)
     return timedwait(() -> istaskdone(task), timeout_s; pollint = 0.001)
 end
 
+function _nd_spawn_synchronized(ready::Channel{Nothing}, start::Channel{Nothing}, f::F) where {F}
+    return errormonitor(Threads.@spawn begin
+        put!(ready, nothing)
+        take!(start)
+        return f()
+    end)
+end
+
 function _nd_close_quiet!(x)
     x === nothing && return nothing
     try
@@ -639,16 +647,28 @@ end
             listener = nothing
             client1 = nothing
             client2 = nothing
-            timeout_ns = Sys.iswindows() ? Int64(5_000_000_000) : Int64(1_000_000_000)
-            wait_s = Sys.iswindows() ? 5.0 : 2.0
+            timeout_ns = Int64(5_000_000_000)
+            wait_s = 5.0
             try
                 listener = NC.listen("tcp", "127.0.0.1:0"; backlog = 8)
                 laddr = NC.addr(listener)::NC.SocketAddrV4
                 resolver = _CountingResolver(0.05, NC.SocketEndpoint[NC.loopback_addr(Int(laddr.port))])
                 singleflight = ND.SingleflightResolver(resolver)
-                task2 = errormonitor(@async _nd_connect_singleflight("same.test:$(Int(laddr.port))", singleflight, timeout_ns, -1))
-                client1 = _nd_connect_singleflight("same.test:$(Int(laddr.port))", singleflight, timeout_ns, -1)
+                ready = Channel{Nothing}(2)
+                start = Channel{Nothing}(2)
+                task1 = _nd_spawn_synchronized(ready, start, () -> begin
+                    _nd_connect_singleflight("same.test:$(Int(laddr.port))", singleflight, timeout_ns, -1)
+                end)
+                task2 = _nd_spawn_synchronized(ready, start, () -> begin
+                    _nd_connect_singleflight("same.test:$(Int(laddr.port))", singleflight, timeout_ns, -1)
+                end)
+                take!(ready)
+                take!(ready)
+                put!(start, nothing)
+                put!(start, nothing)
+                @test _nd_wait_task_done(task1, wait_s) != :timed_out
                 @test _nd_wait_task_done(task2, wait_s) != :timed_out
+                client1 = fetch(task1)
                 client2 = fetch(task2)
                 server1 = NC.accept(listener)
                 server2 = NC.accept(listener)
@@ -725,16 +745,26 @@ end
         @testset "singleflight and cache refresh error paths" begin
             err_resolver = _ErrorResolver(ND.LookupError("lookup failed", "singleflight-error.test"); delay_s = 0.02)
             singleflight = ND.SingleflightResolver(err_resolver)
-            task1 = errormonitor(Threads.@spawn try
-                ND._resolve_host_ips(singleflight, "tcp", "singleflight-error.test")
-            catch ex
-                ex
+            ready = Channel{Nothing}(2)
+            start = Channel{Nothing}(2)
+            task1 = _nd_spawn_synchronized(ready, start, () -> begin
+                try
+                    ND._resolve_host_ips(singleflight, "tcp", "singleflight-error.test")
+                catch ex
+                    ex
+                end
             end)
-            task2 = errormonitor(Threads.@spawn try
-                ND._resolve_host_ips(singleflight, "tcp", "singleflight-error.test")
-            catch ex
-                ex
+            task2 = _nd_spawn_synchronized(ready, start, () -> begin
+                try
+                    ND._resolve_host_ips(singleflight, "tcp", "singleflight-error.test")
+                catch ex
+                    ex
+                end
             end)
+            take!(ready)
+            take!(ready)
+            put!(start, nothing)
+            put!(start, nothing)
             @test _nd_wait_task_done(task1, 2.0) != :timed_out
             @test _nd_wait_task_done(task2, 2.0) != :timed_out
             @test fetch(task1) isa ND.LookupError

--- a/test/host_resolvers_tests.jl
+++ b/test/host_resolvers_tests.jl
@@ -433,6 +433,9 @@ end
             @test ND._HR_AF_INET6 == SO.AF_INET6
             native = ND._native_getaddrinfo("localhost"; flags = ND._AI_ALL | ND._AI_V4MAPPED)
             @test all(x -> x isa NC.SocketEndpoint, native)
+            concurrent_native = fetch.([Threads.@spawn ND._native_getaddrinfo("localhost"; flags = ND._AI_ALL | ND._AI_V4MAPPED) for _ in 1:8])
+            @test all(result -> !isempty(result), concurrent_native)
+            @test all(result -> all(x -> x isa NC.SocketEndpoint, result), concurrent_native)
             addrs = ND.resolve_tcp_addrs("tcp", "localhost:80")
             @test any(a -> a isa NC.SocketAddrV4, addrs)
             if _nd_ipv6_supported()

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -180,6 +180,7 @@ end
             ("socket_ops_trim_safe.jl", "socket_ops_trim_safe"),
             ("tcp_trim_safe.jl", "tcp_trim_safe"),
             ("host_resolvers_trim_safe.jl", "host_resolvers_trim_safe"),
+            ("host_resolvers_system_trim_safe.jl", "host_resolvers_system_trim_safe"),
             ("tls_trim_safe.jl", "tls_trim_safe"),
         ]
         trim_workloads = _trim_selected_workloads(trim_workloads)


### PR DESCRIPTION
## Summary
Replace the system-resolver `@threadcall` path with a small dedicated `getaddrinfo` worker pool inside `HostResolvers`.

## What changed
- added an internal 4-thread detached resolver pool that consumes `_AddrInfoFuture` work items
- replaced `_native_getaddrinfo`'s `@threadcall` usage with enqueue/wait logic backed by that pool
- kept the `getaddrinfo` result pointer on the future so worker threads can write the native result directly
- added a concurrent localhost lookup check in `test/host_resolvers_tests.jl`
- added `test/host_resolvers_system_trim_safe.jl` and registered it in the trim harness

## Why
`@threadcall` routes through Julia's libuv worker pool and was leaving trim verifier failures in downstream client workloads. A dedicated resolver pool keeps blocking `getaddrinfo` calls off scheduler threads while making the system-resolver path more trim-compile-friendly.

## Impact
- system hostname lookups no longer depend on `@threadcall`
- host-resolution behavior stays the same at the API level
- Reseau now has a trim workload that exercises the real system-resolver path, not just the static resolver path

## Validation
- `julia --project=. --startup-file=no --history-file=no test/host_resolvers_tests.jl`
- `RESEAU_TRIM_ONLY=host_resolvers_trim_safe.jl julia --project=. --startup-file=no --history-file=no test/trim_compile_tests.jl`
- `RESEAU_TRIM_ONLY=host_resolvers_system_trim_safe.jl julia --project=. --startup-file=no --history-file=no test/trim_compile_tests.jl`
- `julia --project=. --startup-file=no --history-file=no test/runtests.jl`
