### PR TITLE
[codex] export deadline timeout errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,28 @@ TCP.set_deadline!(listener, time_ns() + 5_000_000_000)
 close(listener)
 ```
 
+When a TCP deadline expires, Reseau raises `TCP.DeadlineExceededError` so
+downstream code can catch the timeout without reaching into internal modules:
+
+```julia
+using Reseau
+
+try
+    TCP.set_read_deadline!(conn, time_ns() + 100_000_000)
+    read!(conn, Vector{UInt8}(undef, 1))
+catch err
+    if err isa TCP.DeadlineExceededError
+        TCP.set_read_deadline!(conn, 0) # clear or move the deadline before retrying
+    else
+        rethrow()
+    end
+end
+```
+
+TLS exposes the same timeout type as `TLS.DeadlineExceededError` for direct
+transport waits like `accept(listener)`. Higher-level TLS operations may wrap
+that timeout in `TLSError` or `TLSHandshakeTimeoutError`.
+
 ### TLS client
 
 ```julia

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -66,6 +66,7 @@ Base.closewrite(::Conn)
 set_deadline!
 set_read_deadline!
 set_write_deadline!
+DeadlineExceededError
 set_nodelay!
 set_keepalive!
 local_addr
@@ -89,6 +90,7 @@ Listener
 ConfigError
 TLSError
 TLSHandshakeTimeoutError
+DeadlineExceededError
 ```
 
 ### Client and Server Construction

--- a/docs/src/tcp.md
+++ b/docs/src/tcp.md
@@ -95,6 +95,7 @@ external timeout wrappers:
 set_deadline!
 set_read_deadline!
 set_write_deadline!
+DeadlineExceededError
 set_nodelay!
 set_keepalive!
 local_addr
@@ -105,6 +106,22 @@ addr
 Use absolute monotonic nanoseconds from `time_ns()` for deadline APIs. Setting
 a deadline to `0` clears it, while setting it to a time in the past makes the
 next blocking wait time out immediately.
+
+Deadline expiry is surfaced as [`TCP.DeadlineExceededError`](@ref). Catch that
+alias instead of reaching into `Reseau.IOPoll` directly:
+
+```julia
+try
+    TCP.set_read_deadline!(conn, time_ns() + 100_000_000)
+    read!(conn, buf)
+catch err
+    if err isa TCP.DeadlineExceededError
+        TCP.set_read_deadline!(conn, 0) # clear or move the deadline before retrying
+    else
+        rethrow()
+    end
+end
+```
 
 Listeners use the same `set_deadline!` name for `accept` deadlines. That
 deadline applies only to `accept(listener)`; established connections still use

--- a/docs/src/tls.md
+++ b/docs/src/tls.md
@@ -29,6 +29,7 @@ Listener
 ConfigError
 TLSError
 TLSHandshakeTimeoutError
+DeadlineExceededError
 ```
 
 `ClientAuthMode` is an enum-like policy surface with the following cases:
@@ -100,6 +101,12 @@ Two details matter in practice:
   record emission leaves future writes unsafe.
 - `close(conn)` and `close(listener)` are idempotent, and `isopen` is available
   on both TLS connections and listeners.
+
+[`TLS.DeadlineExceededError`](@ref) is the public alias for the underlying
+transport timeout type. `accept(listener)` throws it directly when the listener
+deadline expires. Higher-level TLS operations may instead raise
+[`TLSError`](@ref) with the timeout in `cause`, or a handshake-specific
+[`TLSHandshakeTimeoutError`](@ref).
 
 ## Practical Usage Notes
 

--- a/src/3_tcp.jl
+++ b/src/3_tcp.jl
@@ -11,12 +11,25 @@ including:
   `SO_ERROR`
 - accept returns already-initialized child descriptors that are ready for the
   same poll-driven read/write paths as outbound connections
+- deadline expiry is surfaced as `TCP.DeadlineExceededError` for transport I/O
 """
 module TCP
 
 using ..Reseau: ByteMemory, MutableByteBuffer
 using ..Reseau.IOPoll
 using ..Reseau.SocketOps
+
+"""
+    DeadlineExceededError
+
+Raised when blocking TCP I/O or `accept(listener)` exceeds the active deadline.
+
+Catch `TCP.DeadlineExceededError` when a deadline set by `set_deadline!`,
+`set_read_deadline!`, or `set_write_deadline!` expires. This aliases the
+underlying poller timeout type so downstream code does not need to depend on
+`Reseau.IOPoll` directly.
+"""
+const DeadlineExceededError = IOPoll.DeadlineExceededError
 
 """
     connect
@@ -648,8 +661,8 @@ end
 
 Accept a new `Conn` from `listener`.
 
-Throws `SystemError`, `IOPoll.DeadlineExceededError`, or other poll/transport
-errors if the underlying accept path fails.
+Throws `SystemError`, `DeadlineExceededError`, or other poll/transport errors if
+the underlying accept path fails.
 """
 function accept(listener::Listener)::Conn
     listener_fd = listener.fd
@@ -1058,7 +1071,7 @@ Set both read and write deadlines on `conn`.
 - `deadline_ns <= time_ns()` marks both sides as immediately timed out.
 
 After the deadline is reached, blocking `read!`/`write` operations fail with
-`IOPoll.DeadlineExceededError` until the deadline is cleared or moved forward.
+`DeadlineExceededError` until the deadline is cleared or moved forward.
 """
 function set_deadline!(conn::Conn, deadline_ns::Integer)
     IOPoll.set_deadline!(conn.fd.pfd, deadline_ns)

--- a/src/5_tls.jl
+++ b/src/5_tls.jl
@@ -8,6 +8,7 @@ This layer provides:
 - `Conn` wrappers that can handshake eagerly or lazily on first I/O
 - deadline handling delegated to the wrapped transport so TLS retries follow
   the same timeout model as plain TCP
+- transport timeout handling is available as `TLS.DeadlineExceededError`
 """
 module TLS
 
@@ -19,6 +20,18 @@ using ..Reseau.IOPoll
 using ..Reseau.SocketOps
 using ..Reseau.TCP
 using ..Reseau.HostResolvers
+
+"""
+    DeadlineExceededError
+
+Alias for the transport deadline timeout type used by `TLS`.
+
+Catch `TLS.DeadlineExceededError` for direct listener `accept` timeouts and when
+inspecting `TLSError.cause`. Higher-level TLS operations may wrap deadline
+expiry in `TLSError` or `TLSHandshakeTimeoutError` so callers can keep
+operation-specific handling.
+"""
+const DeadlineExceededError = IOPoll.DeadlineExceededError
 
 const _LIBSSL = OpenSSL_jll.libssl
 const _LIBCRYPTO = OpenSSL_jll.libcrypto
@@ -1613,7 +1626,8 @@ end
 Set the accept deadline on the underlying TCP listener.
 
 This affects `accept(listener)` only. The returned `Conn` still uses its own
-connection and handshake deadlines afterward.
+connection and handshake deadlines afterward. Expired accept waits throw
+`DeadlineExceededError`.
 """
 function set_deadline!(listener::Listener, deadline_ns::Integer)
     TCP.set_deadline!(listener.listener, deadline_ns)
@@ -1750,7 +1764,8 @@ end
 
 Accept one inbound TCP connection and wrap it in server-side TLS state.
 
-The returned `Conn` has not handshaken yet.
+The returned `Conn` has not handshaken yet. If the listener deadline expires,
+`accept(listener)` throws `DeadlineExceededError`.
 """
 function accept(listener::Listener)::Conn
     tcp = TCP.accept(listener.listener)

--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -25,6 +25,7 @@ end
 
 @testset "TCP phase 4" begin
         @test NC.Conn <: IO
+        @test NC.DeadlineExceededError === IP.DeadlineExceededError
         @testset "connect/listen/accept and address snapshots" begin
             IP.shutdown!()
             listener = nothing
@@ -302,7 +303,7 @@ end
                 @test status != :timed_out
                 server = fetch(accept_task)
                 NC.set_read_deadline!(server, time_ns() + 30_000_000)
-                @test_throws IP.DeadlineExceededError read!(server, Vector{UInt8}(undef, 1))
+                @test_throws NC.DeadlineExceededError read!(server, Vector{UInt8}(undef, 1))
                 NC.set_read_deadline!(server, Int64(0))
                 @test write(client, UInt8[0x77]) == 1
                 recv_buf = Vector{UInt8}(undef, 1)
@@ -358,7 +359,7 @@ end
                 @test NC.local_addr(listener) == laddr
 
                 NC.set_deadline!(listener, Int64(time_ns()) - Int64(1))
-                @test_throws IP.DeadlineExceededError NC.accept(listener)
+                @test_throws NC.DeadlineExceededError NC.accept(listener)
 
                 NC.set_deadline!(listener, Int64(0))
                 accept_task = errormonitor(@async NC.accept(listener))

--- a/test/tls_tests.jl
+++ b/test/tls_tests.jl
@@ -82,6 +82,8 @@ end
 
 @testset "TLS phase 6" begin
         @test TL.Conn <: IO
+        @test TL.DeadlineExceededError === NC.DeadlineExceededError
+        @test TL.DeadlineExceededError === IP.DeadlineExceededError
         _tls_trace("START: config validation")
         @testset "config validation" begin
             cfg_default = TL.Config()
@@ -530,7 +532,7 @@ end
                 @test TL.local_addr(listener) == laddr
 
                 TL.set_deadline!(listener, Int64(time_ns()) - Int64(1))
-                @test_throws IP.DeadlineExceededError TL.accept(listener)
+                @test_throws TL.DeadlineExceededError TL.accept(listener)
 
                 TL.set_deadline!(listener, Int64(0))
                 accept_task = errormonitor(Threads.@spawn TL.accept(listener))


### PR DESCRIPTION
## Summary
- expose the deadline timeout type as `TCP.DeadlineExceededError` and `TLS.DeadlineExceededError`
- update transport docstrings, docs, and README so downstream code can catch deadline expiry without depending on `Reseau.IOPoll`
- switch TCP/TLS tests to assert against the public aliases while preserving identity with the underlying poller error type

## Why
Deadline expiry was already part of the transport behavior, but callers had to reach into the internal `IOPoll` module to catch it intentionally. This makes the timeout contract discoverable on the public TCP/TLS surfaces while keeping the concrete error type unchanged.

## Impact
Downstream users can now catch `TCP.DeadlineExceededError` or `TLS.DeadlineExceededError` directly. TLS docs also call out that higher-level operations may wrap timeout expiry in `TLSError` or `TLSHandshakeTimeoutError`.

## Validation
- `RESEAU_TEST_ONLY=tcp_tests.jl JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no test/runtests.jl`
- `RESEAU_TEST_ONLY=tls_tests.jl JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no test/runtests.jl`
- `julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'`
- `julia --project=. --startup-file=no --history-file=no -e 'using Reseau; @assert Reseau.TCP.DeadlineExceededError === Reseau.IOPoll.DeadlineExceededError; @assert Reseau.TLS.DeadlineExceededError === Reseau.IOPoll.DeadlineExceededError; @assert Docs.hasdoc(Reseau.TCP, :DeadlineExceededError); @assert Docs.hasdoc(Reseau.TLS, :DeadlineExceededError); println("deadline aliases documented")'`