### PR TITLE
Simplify TLS Config string argument handling

### DIFF
--- a/src/5_tls.jl
+++ b/src/5_tls.jl
@@ -341,14 +341,14 @@ const _TLS_POLICY_AUTO = UInt8(3)
 @inline _is_tls_auto_policy(policy::UInt8) = policy == _TLS_POLICY_AUTO
 
 function Config(
-        server_name::Union{Nothing, String},
+        server_name::Union{Nothing, AbstractString},
         verify_peer::Bool,
         verify_hostname::Bool,
         client_auth::ClientAuthMode.T,
-        cert_file::Union{Nothing, String},
-        key_file::Union{Nothing, String},
-        ca_file::Union{Nothing, String},
-        client_ca_file::Union{Nothing, String},
+        cert_file::Union{Nothing, AbstractString},
+        key_file::Union{Nothing, AbstractString},
+        ca_file::Union{Nothing, AbstractString},
+        client_ca_file::Union{Nothing, AbstractString},
         alpn_protocols::Vector{String},
         curve_preferences::Vector{UInt16},
         handshake_timeout_ns::Int64,
@@ -395,42 +395,6 @@ function Config(
         _TLSSessionCache(_TLS12ServerSession, session_cache_capacity),
         _TLSLocalIdentityState(),
         _TLSLocalIdentityState(),
-    )
-end
-
-function Config(
-        server_name::Union{Nothing, AbstractString},
-        verify_peer::Bool,
-        verify_hostname::Bool,
-        client_auth::ClientAuthMode.T,
-        cert_file::Union{Nothing, AbstractString},
-        key_file::Union{Nothing, AbstractString},
-        ca_file::Union{Nothing, AbstractString},
-        client_ca_file::Union{Nothing, AbstractString},
-        alpn_protocols::Vector{String},
-        curve_preferences::Vector{UInt16},
-        handshake_timeout_ns::Integer,
-        min_version::Union{Nothing, UInt16},
-        max_version::Union{Nothing, UInt16},
-        session_tickets_disabled::Bool,
-        session_cache_capacity::Integer = 64,
-    )
-    return Config(
-        server_name === nothing ? nothing : String(server_name),
-        verify_peer,
-        verify_hostname,
-        client_auth,
-        cert_file === nothing ? nothing : String(cert_file),
-        key_file === nothing ? nothing : String(key_file),
-        ca_file === nothing ? nothing : String(ca_file),
-        client_ca_file === nothing ? nothing : String(client_ca_file),
-        alpn_protocols,
-        curve_preferences,
-        Int64(handshake_timeout_ns),
-        min_version,
-        max_version,
-        session_tickets_disabled,
-        Int(session_cache_capacity),
     )
 end
 


### PR DESCRIPTION
## Summary
- allow the positional TLS `Config` constructor to accept `AbstractString` inputs directly
- remove the duplicate forwarding constructor that only normalized the same arguments

## Validation
- `RESEAU_TEST_ONLY=tls_config_tests.jl JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.test(; coverage=false)'`\n- `RESEAU_TEST_ONLY=tls_public_api_tests.jl JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.test(; coverage=false)'`\n- `JULIA_NUM_THREADS=1 julia --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'`