### PR TITLE
fix(tls): keep verifier paths trim-clean

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Reseau"
 uuid = "802f3686-a58f-41ce-bb0c-3c43c75bba36"
-version = "1.1.1"
+version = "1.1.2"
 
 [deps]
 NetworkOptions = "ca575930-c2e3-43a9-ace4-1e988b2c1908"

--- a/src/tls/crypto.jl
+++ b/src/tls/crypto.jl
@@ -123,6 +123,10 @@ const _TLS12_SERVER_FINISHED_LABEL = "server finished"
 const _EMPTY_SHA256_DIGEST = SHA.sha256(UInt8[])
 const _EMPTY_SHA384_DIGEST = SHA.sha384(UInt8[])
 
+@noinline function _unsupported_tls_hash_kind()
+    throw(ArgumentError("unsupported TLS hash kind"))
+end
+
 """
     _TranscriptHash
 
@@ -208,19 +212,19 @@ end
 @inline function _hash_len(hash_kind::_TLSHashKind)::Int
     hash_kind == _HASH_SHA256 && return 32
     hash_kind == _HASH_SHA384 && return 48
-    throw(ArgumentError("unsupported TLS hash kind: $(hash_kind)"))
+    _unsupported_tls_hash_kind()
 end
 
 @inline function _new_hash_context(hash_kind::_TLSHashKind)
     hash_kind == _HASH_SHA256 && return SHA.SHA256_CTX()
     hash_kind == _HASH_SHA384 && return SHA.SHA384_CTX()
-    throw(ArgumentError("unsupported TLS hash kind: $(hash_kind)"))
+    _unsupported_tls_hash_kind()
 end
 
 @inline function _hash_block_len(hash_kind::_TLSHashKind)::Int
     hash_kind == _HASH_SHA256 && return 64
     hash_kind == _HASH_SHA384 && return 128
-    throw(ArgumentError("unsupported TLS hash kind: $(hash_kind)"))
+    _unsupported_tls_hash_kind()
 end
 
 struct _TLSHMACTemplate{CTX<:SHA.SHA_CTX}
@@ -264,7 +268,7 @@ end
 @inline function _empty_hash_digest(hash_kind::_TLSHashKind)::Vector{UInt8}
     hash_kind == _HASH_SHA256 && return copy(_EMPTY_SHA256_DIGEST)
     hash_kind == _HASH_SHA384 && return copy(_EMPTY_SHA384_DIGEST)
-    throw(ArgumentError("unsupported TLS hash kind: $(hash_kind)"))
+    _unsupported_tls_hash_kind()
 end
 
 @inline function _hash_data(hash_kind::_TLSHashKind, data::AbstractVector{UInt8})::Vector{UInt8}
@@ -325,7 +329,7 @@ function _TranscriptHash(hash_kind::_TLSHashKind; buffer_handshake::Bool = true)
             buffer_handshake ? UInt8[] : nothing,
         )
     end
-    throw(ArgumentError("unsupported TLS hash kind: $(hash_kind)"))
+    _unsupported_tls_hash_kind()
 end
 
 # Transcript updates intentionally own buffered handshake bytes. The handshake

--- a/src/tls/handshake_client_tls13.jl
+++ b/src/tls/handshake_client_tls13.jl
@@ -462,13 +462,13 @@ end
 function _new_tls13_binder_transcript(hash_kind::_TLSHashKind)
     hash_kind == _HASH_SHA256 && return _TranscriptHash(_HASH_SHA256; buffer_handshake = false)
     hash_kind == _HASH_SHA384 && return _TranscriptHash(_HASH_SHA384; buffer_handshake = false)
-    throw(ArgumentError("unsupported TLS hash kind: $(hash_kind)"))
+    _unsupported_tls_hash_kind()
 end
 
 function _new_tls13_handshake_transcript(hash_kind::_TLSHashKind)::_TLS13TranscriptState
     hash_kind == _HASH_SHA256 && return _TranscriptHash(_HASH_SHA256)
     hash_kind == _HASH_SHA384 && return _TranscriptHash(_HASH_SHA384)
-    throw(ArgumentError("unsupported TLS hash kind: $(hash_kind)"))
+    _unsupported_tls_hash_kind()
 end
 
 @inline function _tls13_selected_transcript(state::_TLS13ClientHandshakeState)::_TLS13TranscriptState

--- a/src/tls/x509_verify.jl
+++ b/src/tls/x509_verify.jl
@@ -230,7 +230,7 @@ end
 @inline function _tls_ip_range_matches(range::_TLSIPRangeConstraint, ip::AbstractVector{UInt8})::Bool
     length(ip) == length(range.network) || return false
     length(ip) == length(range.mask) || return false
-    @inbounds for i in eachindex(ip, range.network, range.mask)
+    @inbounds for i in 1:length(ip)
         (ip[i] & range.mask[i]) == (range.network[i] & range.mask[i]) || return false
     end
     return true
@@ -245,15 +245,34 @@ struct _TLSParsedMailbox
     domain::String
 end
 
+@inline function _tls_findfirst_ascii_byte(text::String, byte::UInt8, start::Int = 1)::Union{Nothing, Int}
+    i = max(start, 1)
+    n = ncodeunits(text)
+    while i <= n
+        codeunit(text, i) == byte && return i
+        i += 1
+    end
+    return nothing
+end
+
+@inline function _tls_findlast_ascii_byte(text::String, byte::UInt8)::Union{Nothing, Int}
+    i = ncodeunits(text)
+    while i >= 1
+        codeunit(text, i) == byte && return i
+        i -= 1
+    end
+    return nothing
+end
+
 @inline function _tls_parse_rfc2821_mailbox(value::AbstractString)::Union{Nothing, _TLSParsedMailbox}
     text = String(value)
-    at = findfirst(==('@'), text)
+    at = _tls_findfirst_ascii_byte(text, UInt8('@'))
     at === nothing && return nothing
     local_end = at - 1
     domain_start = at + 1
     local_end >= 1 || return nothing
     domain_start <= ncodeunits(text) || return nothing
-    findnext(==('@'), text, domain_start) === nothing || return nothing
+    _tls_findfirst_ascii_byte(text, UInt8('@'), domain_start) === nothing || return nothing
     local_part = text[1:local_end]
     domain = text[domain_start:end]
     isempty(local_part) && return nothing
@@ -263,7 +282,7 @@ end
 
 function _tls_parse_uri_host_domain(uri::AbstractString)::Union{Nothing, String}
     text = String(uri)
-    scheme_end = findfirst(==(':'), text)
+    scheme_end = _tls_findfirst_ascii_byte(text, UInt8(':'))
     scheme_end === nothing && return nothing
     authority_start = scheme_end + 1
     authority_start + 1 <= ncodeunits(text) || return nothing
@@ -279,16 +298,16 @@ function _tls_parse_uri_host_domain(uri::AbstractString)::Union{Nothing, String}
     end
     authority_end >= authority_start || return nothing
     authority = text[authority_start:authority_end]
-    userinfo_end = findlast(==('@'), authority)
+    userinfo_end = _tls_findlast_ascii_byte(authority, UInt8('@'))
     hostport = userinfo_end === nothing ? authority : authority[(userinfo_end + 1):end]
     isempty(hostport) && return nothing
     host = if startswith(hostport, "[")
-        bracket_end = findfirst(==(']'), hostport)
+        bracket_end = _tls_findfirst_ascii_byte(hostport, UInt8(']'))
         bracket_end === nothing && return nothing
         bracket_end == lastindex(hostport) || startswith(hostport[(bracket_end + 1):end], ":") || return nothing
         hostport[2:(bracket_end - 1)]
     else
-        colon = findlast(==(':'), hostport)
+        colon = _tls_findlast_ascii_byte(hostport, UInt8(':'))
         colon === nothing ? hostport : hostport[1:(colon - 1)]
     end
     isempty(host) && return nothing


### PR DESCRIPTION
## Summary
- replace verifier-hostile higher-order string searches in TLS x509 helpers with explicit byte scans
- avoid `eachindex` mismatch error construction in IP range matching after length checks
- keep unsupported TLS hash-kind error paths from pulling value interpolation into trim verification
- bump version to v1.1.2 for a patch release after merge

## Verification
- `JULIA_NUM_THREADS=2 julia --project=/Users/jacob.quinn/.julia/dev/Reseau -e 'using Pkg; Pkg.test(; coverage=false)'`
- HTTP trim suite reproduced clean locally on Julia 1.13.0-beta3 with this Reseau checkout before opening this PR