### PR TITLE
test(tcp): repro re-armed write-deadline strand (HTTP write-timeout)

### DIFF
--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -341,6 +341,71 @@ end
                 IP.shutdown!()
             end
         end
+        @testset "re-armed write deadline fires when the write blocks (HTTP write-timeout repro)" begin
+            # Faithful repro of HTTP.jl's h1 stream write path, which re-arms the
+            # write deadline before EVERY chunk write (http_server_streams.jl:
+            # `_set_write_deadline!` then `write(conn, chunk)`), driven by a
+            # handler doing `while true; write(stream, chunk); end`. While the
+            # send buffer has room the writes succeed and the deadline is re-armed
+            # each time; once the buffer fills the write blocks and the freshly
+            # re-armed deadline must fire. A SINGLE-arm loop did NOT reproduce the
+            # intermittent Windows hang seen in HTTP.jl CI — this re-arm-per-write
+            # pattern is the difference. Small chunks maximize re-arm churn before
+            # the blocking write. Watchdog-bounded so a strand (deadline never
+            # fires, write blocks forever) is counted and FAILS fast, not hangs.
+            deadline_ns = 100_000_000   # 100ms
+            watchdog_s = 10.0
+            iterations = 50
+            chunk = fill(0x61, 4 * 1024)   # 4 KiB: many re-arms before the buffer fills
+            IP.shutdown!()
+            listener = nothing
+            try
+                listener = NC.listen(NC.loopback_addr(0); backlog = 32)
+                laddr = NC.addr(listener)::NC.SocketAddrV4
+                strands = 0
+                nondeadline = 0
+                for _ in 1:iterations
+                    client = nothing
+                    server = nothing
+                    try
+                        accept_task = errormonitor(@async NC.accept(listener))
+                        client = NC.connect(NC.loopback_addr(Int(laddr.port)))
+                        @test _nc_wait_task_done(accept_task, 5.0) != :timed_out
+                        server = fetch(accept_task)
+                        outcome = Ref{Symbol}(:pending)
+                        # Peer (client) never reads; the server re-arms the write
+                        # deadline before each chunk and writes until it blocks.
+                        op = errormonitor(@async begin
+                            try
+                                while true
+                                    NC.set_write_deadline!(server, time_ns() + deadline_ns)
+                                    write(server, chunk)
+                                end
+                                outcome[] = :no_throw
+                            catch err
+                                outcome[] = err isa NC.DeadlineExceededError ? :deadline : :other
+                            end
+                        end)
+                        if _nc_wait_task_done(op, watchdog_s) == :timed_out
+                            strands += 1
+                        elseif outcome[] !== :deadline
+                            nondeadline += 1
+                        end
+                    finally
+                        _close_quiet!(server)
+                        _close_quiet!(client)
+                    end
+                end
+                # The bug we are hunting is `strands` (deadline never fired). A
+                # `:other` error path (peer reset under load) is not the hang, so
+                # report it separately and do not fail the run on it.
+                @test strands == 0
+                nondeadline == 0 || @info "re-arm repro: $(nondeadline)/$(iterations) ended in a non-deadline error (not a strand)"
+            finally
+                _close_quiet!(listener)
+                IP.shutdown!()
+            end
+        end
         @testset "listener deadline, open state, and local_addr alias" begin
             IP.shutdown!()
             listener = nothing

--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -406,6 +406,75 @@ end
                 IP.shutdown!()
             end
         end
+        @testset "re-armed readavailable deadline fires after data then quiet (HTTP _read_until_quiet repro)" begin
+            # Faithful repro of HTTP.jl's `_read_until_quiet` test helper, whose
+            # stack was captured hanging on Windows CI: read whatever bytes are
+            # available, then RE-ARM a short read deadline and `readavailable`
+            # again expecting a quiet-period timeout. On Windows that post-data
+            # `readavailable` intermittently blocks forever — the re-armed read
+            # deadline never fires. An earlier single-arm `read!` repro missed
+            # this; the trigger is `readavailable` + re-arm-in-loop *after first
+            # receiving data*. Watchdog-bounded so a strand is counted and FAILS
+            # fast instead of hanging CI.
+            iterations = 60
+            overall_timeout_s = 2.0
+            quiet_timeout_s = 0.1
+            watchdog_s = 10.0
+            IP.shutdown!()
+            listener = nothing
+            try
+                listener = NC.listen(NC.loopback_addr(0); backlog = 32)
+                laddr = NC.addr(listener)::NC.SocketAddrV4
+                strands = 0
+                for _ in 1:iterations
+                    client = nothing
+                    server = nothing
+                    try
+                        accept_task = errormonitor(@async NC.accept(listener))
+                        client = NC.connect(NC.loopback_addr(Int(laddr.port)))
+                        @test _nc_wait_task_done(accept_task, 5.0) != :timed_out
+                        server = fetch(accept_task)
+                        # Server sends a little then idles (stays open, sends no
+                        # more), so the client's post-data read must rely on the
+                        # re-armed quiet deadline to return.
+                        write(server, Vector{UInt8}("ok"))
+                        op = errormonitor(@async begin
+                            out = UInt8[]
+                            deadline_ns = Int64(time_ns()) + round(Int64, overall_timeout_s * 1.0e9)
+                            saw_bytes = false
+                            while true
+                                remaining_ns = deadline_ns - Int64(time_ns())
+                                remaining_ns <= 0 && break
+                                read_timeout_s = saw_bytes ? min(quiet_timeout_s, remaining_ns / 1.0e9) : (remaining_ns / 1.0e9)
+                                NC.set_read_deadline!(client, Int64(time_ns()) + round(Int64, read_timeout_s * 1.0e9))
+                                try
+                                    chunk = readavailable(client)
+                                    isempty(chunk) && break
+                                    append!(out, chunk)
+                                    saw_bytes = true
+                                catch
+                                    # Any error (deadline/EOF/peer close) means the
+                                    # read returned — not a strand. Only an
+                                    # indefinite block (caught by the watchdog) is
+                                    # the bug we are hunting.
+                                    break
+                                end
+                            end
+                        end)
+                        if _nc_wait_task_done(op, watchdog_s) == :timed_out
+                            strands += 1
+                        end
+                    finally
+                        _close_quiet!(server)
+                        _close_quiet!(client)
+                    end
+                end
+                @test strands == 0
+            finally
+                _close_quiet!(listener)
+                IP.shutdown!()
+            end
+        end
         @testset "listener deadline, open state, and local_addr alias" begin
             IP.shutdown!()
             listener = nothing


### PR DESCRIPTION
Targeted follow-up to the deadline investigation: an earlier single-arm deadline stress test passed on Windows, so this reproduces the **re-arm-per-write** pattern HTTP.jl's h1 stream write path actually uses (re-arm `set_write_deadline!` before every chunk write, then write until the send buffer blocks). That re-arm-then-block sequence is the suspected trigger for the intermittent Windows write-timeout hang seen in HTTP.jl CI.

Watchdog-bounded so a strand (deadline never fires) is counted and **fails fast** instead of hanging. Verified passing on macOS (kqueue). Expected to surface a non-zero strand count on Windows if the re-arm path is the culprit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)