### PR TITLE
Apply SHA-1 signature policy at verification, not parsing

### DIFF
--- a/src/tls/x509.jl
+++ b/src/tls/x509.jl
@@ -504,7 +504,12 @@ end
 function _tls_parse_certificate_signature_spec(bytes::AbstractVector{UInt8}, value_start::Int, value_end::Int)::_TLSSignatureVerifySpec
     oid_start, oid_end, pos = _asn1_expect_tlv(bytes, value_start, _ASN1_OBJECT_IDENTIFIER)
     if _asn1_oid_equals(bytes, oid_start, oid_end, _ASN1_OID_SHA1_WITH_RSA_ENCRYPTION)
-        throw(ArgumentError("tls: SHA-1 X.509 certificate signatures are not supported"))
+        # SHA-1 is parsed (digest_bits = 160) but rejected later, only for
+        # signatures actually verified during chain building. This keeps SHA-1
+        # self-signed trust anchors usable (their self-signature is never
+        # verified), matching OpenSSL and MbedTLS.
+        _tls_require_algorithm_identifier_null_or_absent(bytes, pos, value_end)
+        return _TLSSignatureVerifySpec(UInt16(160), false, false)
     elseif _asn1_oid_equals(bytes, oid_start, oid_end, _ASN1_OID_SHA224_WITH_RSA_ENCRYPTION)
         _tls_require_algorithm_identifier_null_or_absent(bytes, pos, value_end)
         return _TLSSignatureVerifySpec(UInt16(224), false, false)
@@ -518,7 +523,8 @@ function _tls_parse_certificate_signature_spec(bytes::AbstractVector{UInt8}, val
         _tls_require_algorithm_identifier_null_or_absent(bytes, pos, value_end)
         return _TLSSignatureVerifySpec(UInt16(512), false, false)
     elseif _asn1_oid_equals(bytes, oid_start, oid_end, _ASN1_OID_ECDSA_WITH_SHA1)
-        throw(ArgumentError("tls: SHA-1 X.509 certificate signatures are not supported"))
+        pos > value_end || throw(ArgumentError("tls: malformed X.509 ECDSA signature parameters"))
+        return _TLSSignatureVerifySpec(UInt16(160), false, false)
     elseif _asn1_oid_equals(bytes, oid_start, oid_end, _ASN1_OID_ECDSA_WITH_SHA224)
         pos > value_end || throw(ArgumentError("tls: malformed X.509 ECDSA signature parameters"))
         return _TLSSignatureVerifySpec(UInt16(224), false, false)

--- a/src/tls/x509_verify.jl
+++ b/src/tls/x509_verify.jl
@@ -526,6 +526,18 @@ function _tls_build_chain_to_trust_anchor!(
     return nothing
 end
 
+# Trim-safe parse-error detail: surface the X.509 parser's `ArgumentError` message
+# directly (it carries a descriptive String) instead of `sprint(showerror, ex)`, whose
+# dynamic dispatch over `Exception`/IO defeats `--trim` static analysis. Falls back to a
+# static label for any other exception type.
+function _tls_parse_error_detail(ex)::String
+    if ex isa ArgumentError
+        msg = ex.msg
+        msg isa String && return msg
+    end
+    return "unparseable DER"
+end
+
 function _tls_verify_peer_certificate_chain!(
     certificates::Vector{Vector{UInt8}},
     store::_TLSTrustStore,
@@ -539,7 +551,7 @@ function _tls_verify_peer_certificate_chain!(
         end
     catch ex
         ex isa _TLSAlertError && rethrow()
-        _tls_fail(_TLS_ALERT_BAD_CERTIFICATE, "tls: malformed X.509 certificate ($(sprint(showerror, ex)))")
+        _tls_fail(_TLS_ALERT_BAD_CERTIFICATE, "tls: malformed X.509 certificate ($(_tls_parse_error_detail(ex)))")
     end
     leaf = parsed[1]
     now_s = Int64(floor(time()))
@@ -593,7 +605,7 @@ function _tls_verify_certificate_chain(
             _tls_parse_der_certificate_info(certificates[1])
         catch ex
             ex isa _TLSAlertError && rethrow()
-            _tls_fail(_TLS_ALERT_BAD_CERTIFICATE, "tls: malformed X.509 certificate ($(sprint(showerror, ex)))")
+            _tls_fail(_TLS_ALERT_BAD_CERTIFICATE, "tls: malformed X.509 certificate ($(_tls_parse_error_detail(ex)))")
         end
     end
     verify_hostname && isempty(peer_name) &&
@@ -662,7 +674,7 @@ function _tls13_check_x509_peer_name!(cert_der::AbstractVector{UInt8}, peer_name
         _tls_parse_der_certificate_info(cert_der)
     catch ex
         ex isa _TLSAlertError && rethrow()
-        _tls_fail(_TLS_ALERT_BAD_CERTIFICATE, "tls: malformed X.509 certificate ($(sprint(showerror, ex)))")
+        _tls_fail(_TLS_ALERT_BAD_CERTIFICATE, "tls: malformed X.509 certificate ($(_tls_parse_error_detail(ex)))")
     end
     _tls_verify_certificate_peer_name!(cert_info, peer_name)
     return nothing

--- a/src/tls/x509_verify.jl
+++ b/src/tls/x509_verify.jl
@@ -188,6 +188,11 @@ end
 # intermediates/roots that satisfy issuer linkage, CA constraints, time
 # validity, and signature checks until it finds a trust anchor.
 function _tls_verify_certificate_signature(child::_TLSCertificateInfo, parent::_TLSCertificateInfo)::Bool
+    # Reject SHA-1 (digest_bits == 160) for signatures we actually verify in the
+    # chain. A self-signed root's own signature is never verified (see
+    # `_tls_build_chain_to_trust_anchor!`), so SHA-1 trust anchors stay usable —
+    # matching OpenSSL and MbedTLS, which apply the policy only to verified signatures.
+    child.signature_verify_spec.digest_bits == 160 && return false
     return _openssl_verify_signature_with_spec(parent.public_key, child.signature_verify_spec, child.tbs_der, child.signature)
 end
 
@@ -534,7 +539,7 @@ function _tls_verify_peer_certificate_chain!(
         end
     catch ex
         ex isa _TLSAlertError && rethrow()
-        _tls_fail(_TLS_ALERT_BAD_CERTIFICATE, "tls: malformed X.509 certificate")
+        _tls_fail(_TLS_ALERT_BAD_CERTIFICATE, "tls: malformed X.509 certificate ($(sprint(showerror, ex)))")
     end
     leaf = parsed[1]
     now_s = Int64(floor(time()))
@@ -588,7 +593,7 @@ function _tls_verify_certificate_chain(
             _tls_parse_der_certificate_info(certificates[1])
         catch ex
             ex isa _TLSAlertError && rethrow()
-            _tls_fail(_TLS_ALERT_BAD_CERTIFICATE, "tls: malformed X.509 certificate")
+            _tls_fail(_TLS_ALERT_BAD_CERTIFICATE, "tls: malformed X.509 certificate ($(sprint(showerror, ex)))")
         end
     end
     verify_hostname && isempty(peer_name) &&
@@ -657,7 +662,7 @@ function _tls13_check_x509_peer_name!(cert_der::AbstractVector{UInt8}, peer_name
         _tls_parse_der_certificate_info(cert_der)
     catch ex
         ex isa _TLSAlertError && rethrow()
-        _tls_fail(_TLS_ALERT_BAD_CERTIFICATE, "tls: malformed X.509 certificate")
+        _tls_fail(_TLS_ALERT_BAD_CERTIFICATE, "tls: malformed X.509 certificate ($(sprint(showerror, ex)))")
     end
     _tls_verify_certificate_peer_name!(cert_info, peer_name)
     return nothing

--- a/test/tls_x509_tests.jl
+++ b/test/tls_x509_tests.jl
@@ -185,7 +185,11 @@ end
         ] in cert.ip_addresses
     end
 
-    @testset "SHA-1 X.509 certificate signatures are rejected during parsing" begin
+    @testset "SHA-1 X.509 signatures parse but are rejected at verification" begin
+        # SHA-1 signature algorithms now parse (digest_bits = 160). They are
+        # refused where the signature is actually verified, not at parse time, so
+        # a SHA-1 self-signed trust anchor (whose self-signature is never verified)
+        # stays usable — matching OpenSSL and MbedTLS.
         sha1_rsa = UInt8[
             0x06, 0x09,
             0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x05,
@@ -195,8 +199,8 @@ end
             0x06, 0x07,
             0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x01,
         ]
-        @test_throws ArgumentError TLX._tls_parse_certificate_signature_spec(sha1_rsa, 1, length(sha1_rsa))
-        @test_throws ArgumentError TLX._tls_parse_certificate_signature_spec(sha1_ecdsa, 1, length(sha1_ecdsa))
+        @test TLX._tls_parse_certificate_signature_spec(sha1_rsa, 1, length(sha1_rsa)).digest_bits == 160
+        @test TLX._tls_parse_certificate_signature_spec(sha1_ecdsa, 1, length(sha1_ecdsa)).digest_bits == 160
     end
 
     @testset "Go-style hostname matching helpers" begin
@@ -302,6 +306,12 @@ end
         @test TLX._tls_verify_certificate_signature(rsa_cert, rsa_ca)
         @test TLX._tls_verify_certificate_signature(ecdsa_cert, ecdsa_cert)
         @test TLX._tls_verify_certificate_signature(rsa_ca, rsa_ca)
+
+        # A SHA-1 (digest_bits == 160) signature is refused when actually verified,
+        # even though the certificate parses fine.
+        sha1_signed = _tls_copy_cert(rsa_cert;
+            signature_verify_spec = TLX._TLSSignatureVerifySpec(UInt16(160), false, false))
+        @test TLX._tls_verify_certificate_signature(sha1_signed, rsa_ca) == false
 
         max_modulus = vcat(UInt8[0x80], zeros(UInt8, 1023))
         oversized_modulus = vcat(UInt8[0x01], zeros(UInt8, 1024))

--- a/test/tls_x509_tests.jl
+++ b/test/tls_x509_tests.jl
@@ -432,6 +432,35 @@ end
         @test pkey isa TLX._TLSRSAPublicKey
     end
 
+    @testset "native trust verifier accepts a SHA-1 self-signed trust anchor" begin
+        server_certs = TLX._tls_decode_pem_certificates(_read_bytes(_TLS_CERT_PATH))
+        # Flip the CA signatureAlgorithm OID SHA256-RSA → SHA1-RSA (same length; two
+        # occurrences: tbsCertificate.signature + outer signatureAlgorithm) to obtain a
+        # SHA-1 self-signed root without a new fixture. Only the OID changes — the RSA
+        # public key is untouched, so the real leaf's SHA-256 signature still verifies.
+        sha1_root_der = copy(only(TLX._tls_decode_pem_certificates(_read_bytes(_TLS_CA_PATH))))
+        oid = UInt8[0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b]
+        flipped = 0
+        i = firstindex(sha1_root_der)
+        while i <= lastindex(sha1_root_der) - length(oid) + 1
+            if @views sha1_root_der[i:i + length(oid) - 1] == oid
+                sha1_root_der[i + length(oid) - 1] = 0x05  # SHA256withRSA → SHA1withRSA
+                flipped += 1
+                i += length(oid)
+            else
+                i += 1
+            end
+        end
+        @test flipped == 2
+        # The fix lets a SHA-1 self-signed root parse (digest_bits = 160) instead of throwing.
+        sha1_root = TLX._tls_parse_der_certificate_info(sha1_root_der)
+        @test sha1_root.signature_verify_spec.digest_bits == 160
+        # A real leaf chains through the SHA-1 self-signed trust anchor: its own
+        # self-signature is never verified, so the SHA-1 policy does not reject it.
+        store = TLX._TLSTrustStore([sha1_root])
+        @test TLX._tls_verify_peer_certificate_chain!(server_certs, store, "ssl_server") isa TLX._TLSCertificateInfo
+    end
+
     @testset "native trust verifier supports CA directories" begin
         certs = TLX._tls_decode_pem_certificates(_read_bytes(_TLS_CERT_PATH))
         mktempdir() do dir


### PR DESCRIPTION
Fixes #108

Moves the SHA‑1 signature‑algorithm policy from **parse time** to **chain verification**, so a SHA‑1 self‑signed trust anchor (whose self‑signature is never verified) is accepted, while SHA‑1 is still refused for any signature actually verified in the chain — matching OpenSSL and MbedTLS.

- `x509.jl`: SHA‑1 signature specs now parse (`digest_bits = 160`) instead of throwing.
- `x509_verify.jl`: `_tls_verify_certificate_signature` rejects `digest_bits == 160`.
- `x509_verify.jl`: surface the underlying parse error instead of the generic `tls: malformed X.509 certificate` (also for the other two catch sites).
- Tests: SHA‑1 now parses (`digest_bits` 160) and is rejected at verification.

Verified end‑to‑end (offline): a real chain terminating in the SHA‑1 `AAA Certificate Services` root now validates against a trust store containing that root, while a SHA‑1 signature *inside* the verified chain is still rejected. `tls_x509_tests.jl`: 133/133.
