### PR TITLE
Fixes for FreeBSD support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,47 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.GITHUB_TOKEN }}
+  test-freebsd:
+    name: Julia ${{ matrix.version }} - FreeBSD ${{ matrix.release }} - ${{ matrix.arch }} - t${{ matrix.threads }} - ${{ github.event_name }}
+    runs-on: ubuntu-latest
+    env:
+      JULIA_NUM_THREADS: ${{ matrix.threads }}
+      RESEAU_RUN_TLS_TESTS: '1'
+      RESEAU_RUN_NETWORK_TESTS: '1'
+      RESEAU_TRIM_EXE_TIMEOUT_S: "60.0"
+      RESEAU_TRIM_BUNDLE: '1'
+    strategy:
+      fast-fail: false
+      matrix:
+        include:
+          - version: '1'
+            threads: 1
+            arch: "x86_64"
+            release: "15.0"
+          - version: '1'
+            threads: 2
+            arch: "x86_64"
+            release: "15.0"
+      steps:
+        - uses: actions/checkout@v6
+        - uses: vmactions/freebsd-vm@v1
+          with:
+            release: ${{ matrix.release }}
+            arch: ${{ matrix.arch }}
+            envs: 'JULIA_NUM_THREADS RESEAU_RUN_TLS_TESTS RESEAU_RUN_NETWORK_TESTS RESEAU_TRIM_EXE_TIMEOUT_S RESEAU_TRIM_BUNDLE'
+            usesh: true
+            copyback: false
+            prepare: |
+              # Pretend we're running on Cirrus CI (RIP) to reuse FreeBSD testing setup
+              export JULIA_VERSION="${{ matrix.version }}"
+              export CIRRUS_CI="true"
+              export CIRRUS_OS="freebsd"
+              export CIRRUS_WORKING_DIR="${PWD}"
+              export CIRRUS_REPO_NAME="${GITHUB_REPOSITORY}"
+              sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
+            run: |
+              cirrusjl build
+              cirrusjl test
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
           copyback: false
           prepare: |
             pkg install -y git
+            chown -R $(whoami) .  # Work around file ownership differences between runner and VM
             # Pretend we're running on Cirrus CI (RIP) to reuse FreeBSD testing setup
             export JULIA_VERSION="${{ matrix.version }}"
             export CIRRUS_CI="true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
           usesh: true
           copyback: false
           prepare: |
+            pkg install -y git
             # Pretend we're running on Cirrus CI (RIP) to reuse FreeBSD testing setup
             export JULIA_VERSION="${{ matrix.version }}"
             export CIRRUS_CI="true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
       JULIA_NUM_THREADS: ${{ matrix.threads }}
       RESEAU_RUN_TLS_TESTS: '1'
       RESEAU_RUN_NETWORK_TESTS: '1'
+      RESEAU_RUN_TRIM_TESTS: '0'  # TODO: Reenable once FreeBSD support in PackageCompiler and JuliaC is fixed
       RESEAU_TRIM_EXE_TIMEOUT_S: "60.0"
       RESEAU_TRIM_BUNDLE: '1'
     strategy:
@@ -111,7 +112,7 @@ jobs:
         with:
           release: ${{ matrix.release }}
           arch: ${{ matrix.arch }}
-          envs: 'JULIA_NUM_THREADS RESEAU_RUN_TLS_TESTS RESEAU_RUN_NETWORK_TESTS RESEAU_TRIM_EXE_TIMEOUT_S RESEAU_TRIM_BUNDLE'
+          envs: 'JULIA_NUM_THREADS RESEAU_RUN_TLS_TESTS RESEAU_RUN_NETWORK_TESTS RESEAU_RUN_TRIM_TESTS RESEAU_TRIM_EXE_TIMEOUT_S RESEAU_TRIM_BUNDLE'
           usesh: true
           copyback: false
           prepare: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       RESEAU_TRIM_EXE_TIMEOUT_S: "60.0"
       RESEAU_TRIM_BUNDLE: '1'
     strategy:
-      fast-fail: false
+      fail-fast: false
       matrix:
         include:
           - version: '1'
@@ -105,26 +105,26 @@ jobs:
             threads: 2
             arch: "x86_64"
             release: "15.0"
-      steps:
-        - uses: actions/checkout@v6
-        - uses: vmactions/freebsd-vm@v1
-          with:
-            release: ${{ matrix.release }}
-            arch: ${{ matrix.arch }}
-            envs: 'JULIA_NUM_THREADS RESEAU_RUN_TLS_TESTS RESEAU_RUN_NETWORK_TESTS RESEAU_TRIM_EXE_TIMEOUT_S RESEAU_TRIM_BUNDLE'
-            usesh: true
-            copyback: false
-            prepare: |
-              # Pretend we're running on Cirrus CI (RIP) to reuse FreeBSD testing setup
-              export JULIA_VERSION="${{ matrix.version }}"
-              export CIRRUS_CI="true"
-              export CIRRUS_OS="freebsd"
-              export CIRRUS_WORKING_DIR="${PWD}"
-              export CIRRUS_REPO_NAME="${GITHUB_REPOSITORY}"
-              sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
-            run: |
-              cirrusjl build
-              cirrusjl test
+    steps:
+      - uses: actions/checkout@v6
+      - uses: vmactions/freebsd-vm@v1
+        with:
+          release: ${{ matrix.release }}
+          arch: ${{ matrix.arch }}
+          envs: 'JULIA_NUM_THREADS RESEAU_RUN_TLS_TESTS RESEAU_RUN_NETWORK_TESTS RESEAU_TRIM_EXE_TIMEOUT_S RESEAU_TRIM_BUNDLE'
+          usesh: true
+          copyback: false
+          prepare: |
+            # Pretend we're running on Cirrus CI (RIP) to reuse FreeBSD testing setup
+            export JULIA_VERSION="${{ matrix.version }}"
+            export CIRRUS_CI="true"
+            export CIRRUS_OS="freebsd"
+            export CIRRUS_WORKING_DIR="${PWD}"
+            export CIRRUS_REPO_NAME="${GITHUB_REPOSITORY}"
+            sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
+          run: |
+            cirrusjl build
+            cirrusjl test
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/src/1_socket_ops.jl
+++ b/src/1_socket_ops.jl
@@ -24,7 +24,12 @@ const SockLen = @static Sys.iswindows() ? Cint : UInt32
 
 const AF_UNIX = Cint(1)
 const AF_INET = Cint(2)
-const AF_INET6 = @static Sys.iswindows() ? Cint(23) : Sys.islinux() ? Cint(10) : Cint(30)
+const AF_INET6 = @static Sys.iswindows() ? Cint(23) :
+                         Sys.islinux()   ? Cint(10) :
+                         Sys.isapple()   ? Cint(30) :
+                         Sys.isfreebsd() || Sys.isdragonfly() ? Cint(28) :
+                         Sys.isopenbsd() || Sys.isnetbsd()    ? Cint(24) :
+                         Cint(10)  # an error might be more appropriate here
 
 const SOCK_STREAM = Cint(1)
 const SOCK_DGRAM = Cint(2)
@@ -41,9 +46,9 @@ const SO_REUSEADDR = @static Sys.islinux() ? Cint(0x0002) : Cint(0x0004)
 const SO_KEEPALIVE = @static Sys.islinux() ? Cint(0x0009) : Cint(0x0008)
 const TCP_NODELAY = Cint(0x01)
 
-@static if Sys.isapple()
+@static if Sys.isbsd()
     """
-    Darwin-compatible `sockaddr_in` for IPv4 operations.
+    BSD-compatible `sockaddr_in` for IPv4 operations.
     """
     struct SockAddrIn
         sin_len::UInt8
@@ -54,7 +59,7 @@ const TCP_NODELAY = Cint(0x01)
     end
 
     """
-    Darwin-compatible `sockaddr_in6` for IPv6 operations.
+    BSD-compatible `sockaddr_in6` for IPv6 operations.
     """
     struct SockAddrIn6
         sin6_len::UInt8
@@ -191,7 +196,7 @@ Throws `ArgumentError` if the port is out of range.
 """
 function sockaddr_in(ip::NTuple{4, UInt8}, port::Integer)::SockAddrIn
     p = _hton16(_port_u16(port))
-    @static if Sys.isapple()
+    @static if Sys.isbsd()
         return SockAddrIn(
             UInt8(sizeof(SockAddrIn)),
             UInt8(AF_INET),
@@ -251,7 +256,7 @@ function sockaddr_in6(
     (flowinfo < 0 || flowinfo > typemax(UInt32)) && throw(ArgumentError("flowinfo must be in [0, 2^32-1]"))
     (scope_id < 0 || scope_id > typemax(UInt32)) && throw(ArgumentError("scope_id must be in [0, 2^32-1]"))
     p = _hton16(_port_u16(port))
-    @static if Sys.isapple()
+    @static if Sys.isbsd()
         return SockAddrIn6(
             UInt8(sizeof(SockAddrIn6)),
             UInt8(AF_INET6),
@@ -375,7 +380,7 @@ end
 
 @static if Sys.isapple()
 include("socket_ops/darwin.jl")
-elseif Sys.islinux()
+elseif Sys.islinux() || Sys.isbsd()
 include("socket_ops/linux.jl")
 elseif Sys.iswindows()
 include("socket_ops/windows.jl")

--- a/src/iopoll/kqueue.jl
+++ b/src/iopoll/kqueue.jl
@@ -17,7 +17,7 @@ const WAKE_IDENT = UInt(1)
 const MAX_KQUEUE_EVENTS = 64
 
 """
-Mirror of `struct kevent`, excluding extensions present on some platforms.
+Mirror of `struct kevent`.
 """
 struct Kevent
     ident::UInt
@@ -26,6 +26,9 @@ struct Kevent
     fflags::UInt32
     data::Int
     udata::Ptr{Cvoid}
+    @static if Sys.isfreebsd()
+        ext::NTuple{4,UInt64}
+    end
 end
 
 """
@@ -55,7 +58,11 @@ end
         data::Int,
         udata::Ptr{Cvoid},
     )
-    return Kevent(ident, filter, flags, fflags, data, udata)
+    @static if Sys.isfreebsd()
+        return Kevent(ident, filter, flags, fflags, data, udata, ntuple(_ -> UInt64(0), 4))
+    else
+        return Kevent(ident, filter, flags, fflags, data, udata)
+    end
 end
 
 function _fcntl(fd::Cint, cmd::Cint)::Cint

--- a/src/iopoll/kqueue.jl
+++ b/src/iopoll/kqueue.jl
@@ -1,8 +1,8 @@
-@static if Sys.isapple()
+@static if Sys.isbsd()
 
 const EVFILT_READ = Int16(-1)
 const EVFILT_WRITE = Int16(-2)
-const EVFILT_USER = Int16(-10)
+const EVFILT_USER = Sys.isfreebsd() ? Int16(-11) : Int16(-10)
 const EV_ADD = UInt16(0x0001)
 const EV_DELETE = UInt16(0x0002)
 const EV_ENABLE = UInt16(0x0004)
@@ -17,7 +17,7 @@ const WAKE_IDENT = UInt(1)
 const MAX_KQUEUE_EVENTS = 64
 
 """
-Mirror of Darwin's `struct kevent`.
+Mirror of `struct kevent`, excluding extensions present on some platforms.
 """
 struct Kevent
     ident::UInt

--- a/src/iopoll/runtime.jl
+++ b/src/iopoll/runtime.jl
@@ -18,7 +18,7 @@ end
 end
 
 @inline function _runtime_supported()::Bool
-    return Sys.isapple() || Sys.islinux() || Sys.iswindows()
+    return Sys.isapple() || Sys.islinux() || Sys.iswindows() || Sys.isfreebsd()
 end
 
 function _new_registration(fd::Cint, token::UInt64, mode::PollMode.T)::Registration

--- a/src/socket_ops/linux.jl
+++ b/src/socket_ops/linux.jl
@@ -1,4 +1,4 @@
-# Linux socket syscall bindings used by `SocketOps`.
+# Linux and BSD socket syscall bindings used by `SocketOps`.
 #
 # The higher layers assume these invariants:
 # - newly created sockets are non-blocking and close-on-exec before they escape
@@ -6,7 +6,7 @@
 # - connect/accept can surface raw errno so the poll layer can finish the state
 #   machine after readiness notifications
 #
-# Linux gives us the best-case primitives (`SOCK_NONBLOCK`, `SOCK_CLOEXEC`,
+# Linux and FreeBSD give us the best-case primitives (`SOCK_NONBLOCK`, `SOCK_CLOEXEC`,
 # `accept4`) so this backend mostly tries to take the atomic fast path first and
 # only falls back to older-kernel behavior when required.
 const _F_GETFD = Cint(1)
@@ -14,16 +14,23 @@ const _F_SETFD = Cint(2)
 const _F_GETFL = Cint(3)
 const _F_SETFL = Cint(4)
 const _FD_CLOEXEC = Cint(0x0001)
-const _O_NONBLOCK = Cint(0x0800)
-const _SOCK_CLOEXEC = Cint(0x80000)
-const _SOCK_NONBLOCK = Cint(0x0800)
+const _O_NONBLOCK = Sys.isfreebsd() ? Cint(0x0004) : Cint(0x0800)
+const _SOCK_CLOEXEC = Sys.isfreebsd() ? Cint(0x10000000) : Cint(0x80000)
+const _SOCK_NONBLOCK = Sys.isfreebsd() ? Cint(0x20000000) : Cint(0x0800)
 const _ACCEPT_ADDRBUF_LEN = 128
 const _ACCEPT4_UNSET = Int32(0)
 const _ACCEPT4_ENABLED = Int32(1)
 const _ACCEPT4_DISABLED = Int32(2)
 
-struct _SockAddrHeader
-    sa_family::UInt16
+if Sys.islinux()
+    struct _SockAddrHeader
+        sa_family::UInt16
+    end
+else
+    struct _SockAddrHeader
+        sa_len::UInt8
+        sa_family::UInt8
+    end
 end
 
 const _accept4_state = Ref{Int32}(_ACCEPT4_UNSET)

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -170,7 +170,7 @@ end
     if !Base.get_bool_env("RESEAU_RUN_TRIM_TESTS", true)
         println("[trim] skip RESEAU_RUN_TRIM_TESTS=false: user requested to skip trim compilation tests")
         @test true
-    if !_TRIM_SUPPORTED
+    elseif !_TRIM_SUPPORTED
         println("[trim] skip Julia < 1.12: JuliaC trim compilation is unavailable")
         @test true
     elseif _TRIM_PRE_RELEASE

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -167,6 +167,9 @@ function _parse_trim_verify_totals(output::String)
 end
 
 @testset "Trim compile" begin
+    if !Base.get_bool_env("RESEAU_RUN_TRIM_TESTS", true)
+        println("[trim] skip RESEAU_RUN_TRIM_TESTS=false: user requested to skip trim compilation tests")
+        @test true
     if !_TRIM_SUPPORTED
         println("[trim] skip Julia < 1.12: JuliaC trim compilation is unavailable")
         @test true


### PR DESCRIPTION
The move to Reseau.jl unfortunately broke FreeBSD support in HTTP.jl, as Reseau.jl only handles Linux, macOS, and Windows.

With these changes, all tests pass for me with Julia v1.14.0-DEV.2243 on FreeBSD 14.3-RELEASE AArch64.