### PR TITLE
 iopoll: don't un-stick the waiting task in pollwait!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Reseau"
 uuid = "802f3686-a58f-41ce-bb0c-3c43c75bba36"
-version = "1.1.2"
+version = "1.1.3"
 
 [deps]
 NetworkOptions = "ca575930-c2e3-43a9-ace4-1e988b2c1908"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Reseau"
 uuid = "802f3686-a58f-41ce-bb0c-3c43c75bba36"
-version = "1.1.3"
+version = "1.1.2"
 
 [deps]
 NetworkOptions = "ca575930-c2e3-43a9-ace4-1e988b2c1908"

--- a/src/iopoll/types.jl
+++ b/src/iopoll/types.jl
@@ -86,7 +86,11 @@ simultaneously, or if the waiter state machine is observed in an invalid state.
 """
 function pollwait!(waiter::PollWaiter)::PollWakeReason.T
     task = current_task()
-    task.sticky && (task.sticky = false)
+    # Intentionally preserve the caller's task stickiness. The poller wakes this
+    # task via `schedule(task)`; for a migratable task that drops it into the
+    # global run-queue, waking a cold parked worker whose cost scales with
+    # nthreads. Stickiness is the caller's choice (`@async` to pin a hot reader,
+    # `Threads.@spawn` to stay migratable) — don't override it here.
     waiter.task = task
     try
         # Fast path: transition directly from EMPTY -> WAITING and park.


### PR DESCRIPTION
`pollwait!` resets `task.sticky = false` on the task it parks. Since the poller wakes that task with `schedule(task)`, a *migratable* task is woken into the global run-queue, forcing the scheduler to **wake a cold parked worker out of all N threads**. That cross-thread wake cost **scales with `nthreads`**, so anything that blocks on Reseau I/O and is woken by the poller slows down as `-t` grows.

The fix is to stop overriding the caller's stickiness, let `@async` pin a hot reader and `Threads.@spawn` stay migratable. Migratable callers (the vast majority) are unaffected; only deliberately-pinned tasks are now left pinned.

We want to use HTTP@2 in [Bonito](https://github.com/SimonDanisch/Bonito.jl), and its traffic is mostly small WS frames carrying Observable updates. Profiling Bonito's HTTP.jl 2.0 migration, we found **WS receive latency/throughput collapse as thread count rises**. HTTP 1.x reads frames inline (no cross-task wake) and is flat; HTTP 2.0 parks on the poller and degrades.

## Root cause

The poller runs `epoll_wait` on a detached pthread; on readiness it does `schedule(reader_task)`. With the reader un-stuck (migratable), `schedule` hits the global queue and the scheduler must wake some parked worker, cheap at `-t 4`, expensive at `-t 32`. Even the best-case RTT floor climbs ~41 µs -> ~220 µs, so it's the per-wake cost growing, not tail jitter. Keeping the task sticky makes the wake target its warm home thread.

## Benchmark

Bonito WS round-trip + JS→server burst, Julia 1.12. "after" = reader spawned `@async` with this change (validated together — see companion PR). HTTP 1.11 is the flat reference.

| threads | RTT median (before → after) | JS→server msg/s (before → after) |
|--------:|:---------------------------:|:--------------------------------:|
| 1  | ~52 → ~57 µs | ~88k → ~87k |
| 4  | ~59 → ~58 µs | ~77k → ~86k |
| 8  | ~79 → ~58 µs | ~76k → ~85k |
| 16 | ~103 → ~58 µs | ~66k → ~85k |
| **32** | **245–318 → ~58 µs** | **~40k → ~84k** |

At `-t 32`: RTT ~5× better, p95 tail **5.4–7.4 ms → ~0.1 ms**, throughput doubled — now flat across `-t 1…32`, matching HTTP 1.11 (which sits ~50 µs / ~88k throughout). Full Reseau test suite passes.

## Companion HTTP.jl PR (separate, not yet opened)

This is **necessary but not sufficient alone**: it only helps if the reader is sticky, and HTTP.jl 2.0 currently spawns it with `Threads.@spawn`. A follow-up to `JuliaWeb/HTTP.jl` switches the WS reader to `@async` (plus two unrelated alloc fixes on the same path). It's harmless on current Reseau (`@async` just gets un-stuck = today's behavior) and its compat already allows `1.1.3`, so no hard merge-order coupling — but the `-t 32` win needs both. I'll link it here once open.


Was resetting the stickiness deliberate (e.g. to keep I/O from pinning to one thread, or for deadlock avoidance)? Claude couldn't find a correctness reason, and treating stickiness as the caller's choice seems least surprising for a primitive. 