### PR TITLE
Avoid GC-safe epoll wait under gVisor

### DIFF
--- a/src/iopoll/epoll.jl
+++ b/src/iopoll/epoll.jl
@@ -10,6 +10,7 @@ const EPOLL_CLOEXEC = Cint(0x80000)
 const EFD_NONBLOCK = Cint(0x800)
 const EFD_CLOEXEC = Cint(0x80000)
 const MAX_EPOLL_EVENTS = 128
+const MAX_GC_UNSAFE_EPOLL_WAIT_MS = Cint(25)
 const _WAKE_TOKEN = UInt64(0)
 
 # Mirror of Linux `struct epoll_event`.
@@ -223,16 +224,21 @@ function _backend_poll_once!(state::Poller, delay_ns::Int64)::Int32
     epoll = backend::EpollBackendState
     events = epoll.events
     waitms = _epoll_wait_timeout_ms(delay_ns)
+    # gVisor can crash when its userspace epoll implementation writes into the
+    # event buffer while this foreign poller thread is in a GC-safe ccall. Keep
+    # the wait GC-unsafe, but cap each sleep so this detached thread cannot
+    # block Julia GC indefinitely while the poller is idle.
+    waitms = waitms < 0 ? MAX_GC_UNSAFE_EPOLL_WAIT_MS : min(waitms, MAX_GC_UNSAFE_EPOLL_WAIT_MS)
     while true
         n = GC.@preserve events begin
-            @gcsafe_ccall epoll_wait(
+            @ccall epoll_wait(
                 epoll.epfd::Cint,
                 pointer(events)::Ptr{EpollEvent},
                 Cint(length(events))::Cint,
                 waitms::Cint,
             )::Cint
         end
-        if n == -1
+        if n == Cint(-1)
             errno = Int32(Base.Libc.errno())
             if errno == Int32(Base.Libc.EINTR)
                 waitms > 0 && return Int32(0)


### PR DESCRIPTION
## Summary

This is a release-shaped follow-up to the gVisor epoll segfault reported downstream in JuliaWeb/HTTP.jl#1266.

The reporter confirmed the experiment branch only crashes when Linux `epoll_wait` is restored to the GC-safe call path (`RESEAU_EPOLL_WAIT_GCSAFE=1`). The normal Julia `Vector` event buffer with `GC.@preserve` survives when `epoll_wait` is an ordinary ccall, so this keeps the event buffer shape and only changes the blocking wait.

Because this poller runs from a detached native thread, a fully unbounded GC-unsafe wait could delay Julia GC indefinitely while the poller is idle. This caps each GC-unsafe `epoll_wait` slice at 25ms so the poller periodically re-enters Julia and gives GC a bounded progress point.

## Validation

- `docker run --rm -e RESEAU_TEST_ONLY=iopoll_runtime_tests.jl -v /Users/jacob.quinn/.codex/worktrees/reseau-gvisor-epoll-release:/pkg -w /pkg julia:1.12.6 julia -t1 --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); include("test/runtests.jl")'`
- `docker run --rm -e RESEAU_TEST_ONLY=tcp_tests.jl -v /Users/jacob.quinn/.codex/worktrees/reseau-gvisor-epoll-release:/pkg -w /pkg julia:1.12.6 julia -t1 --project=. --startup-file=no --history-file=no -e 'using Pkg; Pkg.instantiate(); include("test/runtests.jl")'`

Still needs confirmation from the reporter's Scaleway/gVisor reproducer before merging/releasing.

Co-authored by Codex
