### PR TITLE
Wake timer waiters during IOPoll shutdown

### DIFF
--- a/src/iopoll/runtime.jl
+++ b/src/iopoll/runtime.jl
@@ -160,12 +160,19 @@ function shutdown!()
         isassigned(POLLER) || return nothing
         state = POLLER[]
         registrations = Registration[]
+        timers = TimerState[]
         stop_requested = false
         lock(state.lock)
         try
             append!(registrations, values(state.registrations))
+            _discard_stale_time_entries_locked!(state)
+            for entry in state.time_heap
+                entry.kind == TimeEntryKind.TIMER || continue
+                push!(timers, entry.timer::TimerState)
+            end
             empty!(state.registrations)
             empty!(state.registrations_by_token)
+            empty!(state.time_heap)
             if @atomic :acquire state.running
                 @atomic :release state.running = false
                 stop_requested = true
@@ -175,6 +182,9 @@ function shutdown!()
         end
         for registration in registrations
             _notify_registration!(registration, PollMode.READWRITE, PollWakeReason.CANCELED)
+        end
+        for timer in timers
+            _close_timer!(timer)
         end
         if stop_requested
             wake_errno = _backend_wake!(state)

--- a/test/iopoll_runtime_tests.jl
+++ b/test/iopoll_runtime_tests.jl
@@ -424,6 +424,24 @@ end
             end
         end
         _el_log_test_progress("DONE: shutdown-safe control paths")
+        _el_log_test_progress("START: shutdown wakes timer waiters")
+        @testset "shutdown wakes timer waiters" begin
+            NP.shutdown!()
+            timer = NP.TimerState()
+            @test NP.schedule_timer!(timer, Int64(time_ns()) + Int64(60_000_000_000))
+            timer_task = errormonitor(@async NP.waittimer(timer))
+            try
+                NP.shutdown!()
+                @test _el_wait_task_done(timer_task, 1.0) != :timed_out
+                @test fetch(timer_task) === false
+                @test (@atomic :acquire timer.closed)
+                @test (@atomic :acquire timer.deadline_ns) == Int64(0)
+            finally
+                timer_task isa Task && istaskdone(timer_task) && wait(timer_task)
+                NP.shutdown!()
+            end
+        end
+        _el_log_test_progress("DONE: shutdown wakes timer waiters")
         _el_log_test_progress("START: shutdown cancels active waiters and timers")
         @testset "shutdown cancels active waiters and timers" begin
             fd0, fd1 = _el_socketpair_stream()


### PR DESCRIPTION
This fixes a poller lifecycle hole where graceful `IOPoll.shutdown!()` woke fd waiters but left timer waiters parked. A task blocked in `IOPoll.sleep`/`IOPoll.timedwait` could therefore survive shutdown indefinitely.

The change collects timer waiters under the poller state lock during shutdown, clears the timer heap with the fd registrations, and closes the timers outside the lock so parked tasks are scheduled with `CANCELED`.

Validation:
- Reproduced the pre-fix minimal timer-shutdown hang against Reseau v1.1.4.
- Verified the same minimal probe wakes after this change.
- `JULIA_NUM_THREADS=1 RESEAU_TEST_ONLY=iopoll_runtime_tests.jl julia +1.12 --startup-file=no --project=. test/runtests.jl`

Co-authored by Codex