### PR TITLE
Skip trim tests when no C compiler is available

### DIFF
--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -108,6 +108,16 @@ function _trim_use_bundle()::Bool
     return get(ENV, "RESEAU_TRIM_BUNDLE", default) == "1"
 end
 
+function _trim_compiler_available()::Bool
+    julia_cc = strip(get(ENV, "JULIA_CC", ""))
+    !isempty(julia_cc) && return true
+    @static if Sys.iswindows()
+        return true
+    else
+        return Sys.which("gcc") !== nothing || Sys.which("clang") !== nothing
+    end
+end
+
 function _trim_output_path(dir::String, output_name::String)::String
     path = joinpath(dir, output_name)
     isfile(path) && return path
@@ -175,6 +185,9 @@ end
         @test true
     elseif _TRIM_PRE_RELEASE
         println("[trim] skip prerelease Julia: trim verifier behavior is not stable yet")
+        @test true
+    elseif !_trim_compiler_available()
+        @warn "Reseau trim compile tests are being skipped." reason = "no C compiler found" action = "install gcc/clang or set JULIA_CC to run trim compilation tests"
         @test true
     else
         project_path = normpath(joinpath(@__DIR__, ".."))


### PR DESCRIPTION
## Summary
- detect when JuliaC trim tests cannot find a usable C compiler
- skip the trim compile testset with a loud warning instead of failing ordinary `Pkg.test` on machines without build tools
- keep `JULIA_CC` as an explicit opt-in path for users with a custom compiler

## Testing
- `PATH=/tmp/reseau-no-compiler-path julia --startup-file=no --project=/tmp/reseau-119-trim-compiler -e 'include("/tmp/reseau-119-trim-compiler/test/trim_compile_tests.jl")'`\n- `RESEAU_TEST_ONLY=trim_compile_tests.jl RESEAU_TRIM_ONLY=iopoll_runtime_trim_safe.jl JULIA_PKG_PRECOMPILE_AUTO=0 julia --startup-file=no --project=/tmp/reseau-119-trim-compiler -e 'using Pkg; Pkg.test()'`\n\nCo-authored by Codex