### PR TITLE
Add SOCKS5 connect support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Reseau"
 uuid = "802f3686-a58f-41ce-bb0c-3c43c75bba36"
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 NetworkOptions = "ca575930-c2e3-43a9-ace4-1e988b2c1908"

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -142,6 +142,13 @@ Reseau.SocketOps
 Reseau.IOPoll
 Reseau.IOPoll.PollMode
 Reseau.HostResolvers
+Reseau.SOCKS
+Reseau.SOCKS.BoundAddr
+Reseau.SOCKS.TargetAddressError
+Reseau.SOCKS.ProtocolError
+Reseau.SOCKS.AuthenticationError
+Reseau.SOCKS.ReplyError
+Reseau.SOCKS.connect!
 ```
 
 ## Docstring Index

--- a/src/4_host_resolvers.jl
+++ b/src/4_host_resolvers.jl
@@ -855,6 +855,11 @@ end
 
 function _parse_ipv6_literal(host::AbstractString)::Union{Nothing, NTuple{16, UInt8}}
     h = String(host)
+    # Zone-scoped literals ("fe80::1%en0") are rejected so results are
+    # platform-independent: macOS inet_pton accepts them and embeds the zone
+    # index into the address bytes, while Linux and Windows reject them.
+    # Callers that support zones split them off first via _split_host_zone.
+    occursin('%', h) && return nothing
     bytes = Vector{UInt8}(undef, 16)
     rc = GC.@preserve bytes begin
         @gcsafe_ccall inet_pton(

--- a/src/5_socks.jl
+++ b/src/5_socks.jl
@@ -1,7 +1,8 @@
 """
     SOCKS
 
-Internal SOCKS client helpers layered on `TCP.Conn`.
+Internal SOCKS5 (RFC 1928) client helpers layered on `TCP.Conn`, including
+username/password authentication (RFC 1929).
 """
 module SOCKS
 
@@ -118,6 +119,17 @@ function _read_exact!(conn::TCP.Conn, n::Integer)::Vector{UInt8}
     return buf
 end
 
+function _parse_decimal_port(text::String)::Union{Nothing, UInt16}
+    isempty(text) && return nothing
+    n = 0
+    for ch in text
+        '0' <= ch <= '9' || return nothing
+        n = 10 * n + Int(ch - '0')
+        n > 0xffff && return nothing
+    end
+    return UInt16(n)
+end
+
 function _parse_target(address::AbstractString)::Tuple{String, UInt16}
     text = String(address)
     host, port_text = try
@@ -128,13 +140,22 @@ function _parse_target(address::AbstractString)::Tuple{String, UInt16}
         throw(TargetAddressError("invalid SOCKS target address", text))
     end
     isempty(host) && throw(TargetAddressError("SOCKS target host must not be empty", text))
-    port = tryparse(Int, port_text)
+    port = _parse_decimal_port(port_text)
     port === nothing && throw(TargetAddressError("invalid SOCKS target port", text))
-    1 <= port <= 0xffff || throw(TargetAddressError("SOCKS target port out of range", text))
+    port == 0 && throw(TargetAddressError("SOCKS target port out of range", text))
+    # Zone-scoped IPv6 literals are rejected before the inet_pton-based literal
+    # parse: a remote proxy cannot resolve a client-local zone, and macOS
+    # inet_pton accepts "fe80::1%en0" while embedding the zone index into the
+    # address bytes. '%' never appears in a valid FQDN either.
+    occursin('%', host) && throw(TargetAddressError("SOCKS target host must not contain a zone", text))
     if HostResolvers._parse_ipv4_literal(host) === nothing && HostResolvers._parse_ipv6_literal(host) === nothing
         length(codeunits(host)) <= 255 || throw(TargetAddressError("SOCKS target FQDN is too long", text))
+        # Bracketed-but-invalid IPv6 literals must not leak to the proxy as a
+        # domain name; ':' never appears in a valid FQDN.
+        occursin(':', host) &&
+            throw(TargetAddressError("SOCKS target host must be an IP literal or hostname", text))
     end
-    return host, UInt16(port)
+    return host, port
 end
 
 @inline function _append_port!(buf::Vector{UInt8}, port::UInt16)::Nothing
@@ -176,16 +197,14 @@ function _read_bound_addr!(conn::TCP.Conn, atyp::UInt8)::BoundAddr
         return BoundAddr(host, port)
     elseif atyp == _ADDR_IPV6
         data = _read_exact!(conn, 18)
-        addr = TCP.SocketAddrV6((
-                data[1], data[2], data[3], data[4],
-                data[5], data[6], data[7], data[8],
-                data[9], data[10], data[11], data[12],
-                data[13], data[14], data[15], data[16],
-            ),
-            0,
+        ip = (
+            data[1], data[2], data[3], data[4],
+            data[5], data[6], data[7], data[8],
+            data[9], data[10], data[11], data[12],
+            data[13], data[14], data[15], data[16],
         )
         port = (UInt16(data[17]) << 8) | UInt16(data[18])
-        return BoundAddr(TCP._format_ipv6(addr.ip), port)
+        return BoundAddr(TCP._format_ipv6(ip), port)
     elseif atyp == _ADDR_FQDN
         len = Int(_read_exact!(conn, 1)[1])
         data = _read_exact!(conn, len + 2)
@@ -198,6 +217,23 @@ end
 
 @inline function _auth_enabled(username)::Bool
     return username !== nothing
+end
+
+function _validate_credentials(
+        username::Union{Nothing, AbstractString},
+        password::Union{Nothing, AbstractString},
+    )::Nothing
+    if username === nothing
+        password === nothing || throw(AuthenticationError("SOCKS password provided without a username"))
+        return nothing
+    end
+    username_len = length(codeunits(username))
+    username_len >= 1 || throw(AuthenticationError("SOCKS username must not be empty"))
+    username_len <= 255 || throw(AuthenticationError("SOCKS username is too long"))
+    if password !== nothing
+        length(codeunits(password)) <= 255 || throw(AuthenticationError("SOCKS password is too long"))
+    end
+    return nothing
 end
 
 function _write_greeting!(conn::TCP.Conn, has_auth::Bool)::Nothing
@@ -266,8 +302,25 @@ end
 """
     connect!(conn, target_address; username=nothing, password=nothing, deadline_ns=0)
 
-Perform a SOCKS5 CONNECT handshake over `conn` and return the proxy bound
-address. On success, `conn` is the established stream to `target_address`.
+Perform a SOCKS5 (RFC 1928) CONNECT handshake over `conn` and return the proxy
+bound address as a `BoundAddr`. On success, `conn` is the established stream to
+`target_address`, a `"host:port"` (or `"[ipv6]:port"`) string.
+
+When `username` is provided, username/password authentication (RFC 1929) is
+offered alongside no-auth and performed if the proxy selects it. `username`
+must be 1-255 bytes, `password` at most 255 bytes, and a `password` without a
+`username` is rejected.
+
+A nonzero `deadline_ns` (absolute monotonic nanoseconds on the `time_ns()`
+clock) sets the read and write deadlines on `conn` for the duration of the
+handshake and clears them on exit, overwriting any deadlines previously set on
+`conn`. With `deadline_ns == 0`, existing deadlines are left untouched.
+
+Target and credential validation failures (`TargetAddressError`,
+`AuthenticationError`) are thrown before any proxy I/O. During the handshake,
+`AuthenticationError`, `ReplyError`, `ProtocolError`, `EOFError`, or
+`TCP.DeadlineExceededError` may be thrown; after any error the proxy stream
+state is indeterminate and `conn` should be closed.
 """
 function connect!(
         conn::TCP.Conn,
@@ -279,6 +332,7 @@ function connect!(
     deadline = Int64(deadline_ns)
     target = String(target_address)
     host, port = _parse_target(target)
+    _validate_credentials(username, password)
     if deadline != 0
         TCP.set_deadline!(conn, deadline)
     end

--- a/src/5_socks.jl
+++ b/src/5_socks.jl
@@ -1,0 +1,295 @@
+"""
+    SOCKS
+
+Internal SOCKS client helpers layered on `TCP.Conn`.
+"""
+module SOCKS
+
+using ..Reseau.TCP
+using ..Reseau.HostResolvers
+
+const _VERSION5 = UInt8(0x05)
+const _AUTH_NO_AUTH = UInt8(0x00)
+const _AUTH_USERNAME_PASSWORD = UInt8(0x02)
+const _AUTH_NO_ACCEPTABLE = UInt8(0xff)
+const _AUTH_USERNAME_PASSWORD_VERSION = UInt8(0x01)
+const _AUTH_STATUS_SUCCEEDED = UInt8(0x00)
+const _CMD_CONNECT = UInt8(0x01)
+const _ADDR_IPV4 = UInt8(0x01)
+const _ADDR_FQDN = UInt8(0x03)
+const _ADDR_IPV6 = UInt8(0x04)
+const _STATUS_SUCCEEDED = UInt8(0x00)
+
+"""
+    BoundAddr
+
+SOCKS proxy bound address returned by a successful command reply.
+"""
+struct BoundAddr
+    host::String
+    port::UInt16
+end
+
+"""
+    TargetAddressError
+
+Raised when a SOCKS command target cannot be encoded.
+"""
+struct TargetAddressError <: Exception
+    message::String
+    address::String
+end
+
+"""
+    ProtocolError
+
+Raised when the SOCKS proxy sends malformed protocol bytes.
+"""
+struct ProtocolError <: Exception
+    message::String
+end
+
+"""
+    AuthenticationError
+
+Raised when SOCKS authentication negotiation fails.
+"""
+struct AuthenticationError <: Exception
+    message::String
+end
+
+"""
+    ReplyError
+
+Raised when a SOCKS command reply has a non-success status.
+"""
+struct ReplyError <: Exception
+    code::UInt8
+    message::String
+end
+
+function Base.show(io::IO, addr::BoundAddr)
+    print(io, string(addr))
+    return nothing
+end
+
+function Base.string(addr::BoundAddr)
+    return HostResolvers.join_host_port(addr.host, Int(addr.port))
+end
+
+function Base.showerror(io::IO, err::TargetAddressError)
+    print(io, err.message, ": ", err.address)
+    return nothing
+end
+
+function Base.showerror(io::IO, err::ProtocolError)
+    print(io, err.message)
+    return nothing
+end
+
+function Base.showerror(io::IO, err::AuthenticationError)
+    print(io, err.message)
+    return nothing
+end
+
+function Base.showerror(io::IO, err::ReplyError)
+    print(io, "SOCKS command failed: ", err.message)
+    return nothing
+end
+
+@inline function _reply_message(code::UInt8)::String
+    code == 0x01 && return "general SOCKS server failure"
+    code == 0x02 && return "connection not allowed by ruleset"
+    code == 0x03 && return "network unreachable"
+    code == 0x04 && return "host unreachable"
+    code == 0x05 && return "connection refused"
+    code == 0x06 && return "TTL expired"
+    code == 0x07 && return "command not supported"
+    code == 0x08 && return "address type not supported"
+    return "unknown code: $(Int(code))"
+end
+
+function _read_exact!(conn::TCP.Conn, n::Integer)::Vector{UInt8}
+    count = Int(n)
+    count < 0 && throw(ArgumentError("read size must be >= 0"))
+    buf = Vector{UInt8}(undef, count)
+    got = readbytes!(conn, buf, count; all = true)
+    got == count || throw(EOFError())
+    return buf
+end
+
+function _parse_target(address::AbstractString)::Tuple{String, UInt16}
+    text = String(address)
+    host, port_text = try
+        HostResolvers.split_host_port(text)
+    catch err
+        ex = err::Exception
+        ex isa HostResolvers.AddressError || rethrow(ex)
+        throw(TargetAddressError("invalid SOCKS target address", text))
+    end
+    isempty(host) && throw(TargetAddressError("SOCKS target host must not be empty", text))
+    port = tryparse(Int, port_text)
+    port === nothing && throw(TargetAddressError("invalid SOCKS target port", text))
+    1 <= port <= 0xffff || throw(TargetAddressError("SOCKS target port out of range", text))
+    if HostResolvers._parse_ipv4_literal(host) === nothing && HostResolvers._parse_ipv6_literal(host) === nothing
+        length(codeunits(host)) <= 255 || throw(TargetAddressError("SOCKS target FQDN is too long", text))
+    end
+    return host, UInt16(port)
+end
+
+@inline function _append_port!(buf::Vector{UInt8}, port::UInt16)::Nothing
+    push!(buf, UInt8(port >> 8))
+    push!(buf, UInt8(port & 0x00ff))
+    return nothing
+end
+
+function _append_target!(buf::Vector{UInt8}, host::String, port::UInt16, address::String)::Nothing
+    ip4 = HostResolvers._parse_ipv4_literal(host)
+    if ip4 !== nothing
+        push!(buf, _ADDR_IPV4)
+        append!(buf, ip4::NTuple{4, UInt8})
+        _append_port!(buf, port)
+        return nothing
+    end
+    ip6 = HostResolvers._parse_ipv6_literal(host)
+    if ip6 !== nothing
+        push!(buf, _ADDR_IPV6)
+        append!(buf, ip6::NTuple{16, UInt8})
+        _append_port!(buf, port)
+        return nothing
+    end
+    host_bytes = codeunits(host)
+    n = length(host_bytes)
+    n <= 255 || throw(TargetAddressError("SOCKS target FQDN is too long", address))
+    push!(buf, _ADDR_FQDN)
+    push!(buf, UInt8(n))
+    append!(buf, host_bytes)
+    _append_port!(buf, port)
+    return nothing
+end
+
+function _read_bound_addr!(conn::TCP.Conn, atyp::UInt8)::BoundAddr
+    if atyp == _ADDR_IPV4
+        data = _read_exact!(conn, 6)
+        host = string(data[1], ".", data[2], ".", data[3], ".", data[4])
+        port = (UInt16(data[5]) << 8) | UInt16(data[6])
+        return BoundAddr(host, port)
+    elseif atyp == _ADDR_IPV6
+        data = _read_exact!(conn, 18)
+        addr = TCP.SocketAddrV6((
+                data[1], data[2], data[3], data[4],
+                data[5], data[6], data[7], data[8],
+                data[9], data[10], data[11], data[12],
+                data[13], data[14], data[15], data[16],
+            ),
+            0,
+        )
+        port = (UInt16(data[17]) << 8) | UInt16(data[18])
+        return BoundAddr(TCP._format_ipv6(addr.ip), port)
+    elseif atyp == _ADDR_FQDN
+        len = Int(_read_exact!(conn, 1)[1])
+        data = _read_exact!(conn, len + 2)
+        host = String(data[1:len])
+        port = (UInt16(data[len + 1]) << 8) | UInt16(data[len + 2])
+        return BoundAddr(host, port)
+    end
+    throw(ProtocolError("unknown SOCKS address type $(Int(atyp))"))
+end
+
+@inline function _auth_enabled(username)::Bool
+    return username !== nothing
+end
+
+function _write_greeting!(conn::TCP.Conn, has_auth::Bool)::Nothing
+    if has_auth
+        write(conn, UInt8[_VERSION5, 0x02, _AUTH_NO_AUTH, _AUTH_USERNAME_PASSWORD])
+    else
+        write(conn, UInt8[_VERSION5, 0x01, _AUTH_NO_AUTH])
+    end
+    return nothing
+end
+
+function _negotiate_auth!(
+        conn::TCP.Conn,
+        username::Union{Nothing, AbstractString},
+        password::Union{Nothing, AbstractString},
+    )::Nothing
+    has_auth = _auth_enabled(username)
+    _write_greeting!(conn, has_auth)
+    reply = _read_exact!(conn, 2)
+    reply[1] == _VERSION5 || throw(ProtocolError("unexpected SOCKS version $(Int(reply[1]))"))
+    method = reply[2]
+    method == _AUTH_NO_ACCEPTABLE && throw(AuthenticationError("no acceptable SOCKS authentication methods"))
+    if method == _AUTH_NO_AUTH
+        return nothing
+    end
+    if method == _AUTH_USERNAME_PASSWORD && has_auth
+        _authenticate_username_password!(conn, String(username::AbstractString), password === nothing ? "" : String(password::AbstractString))
+        return nothing
+    end
+    throw(AuthenticationError("unsupported SOCKS authentication method $(Int(method))"))
+end
+
+function _authenticate_username_password!(conn::TCP.Conn, username::String, password::String)::Nothing
+    username_bytes = codeunits(username)
+    password_bytes = codeunits(password)
+    isempty(username_bytes) && throw(AuthenticationError("SOCKS username must not be empty"))
+    length(username_bytes) <= 255 || throw(AuthenticationError("SOCKS username is too long"))
+    length(password_bytes) <= 255 || throw(AuthenticationError("SOCKS password is too long"))
+    request = UInt8[_AUTH_USERNAME_PASSWORD_VERSION, UInt8(length(username_bytes))]
+    append!(request, username_bytes)
+    push!(request, UInt8(length(password_bytes)))
+    append!(request, password_bytes)
+    write(conn, request)
+    reply = _read_exact!(conn, 2)
+    reply[1] == _AUTH_USERNAME_PASSWORD_VERSION || throw(AuthenticationError("invalid SOCKS username/password auth version"))
+    reply[2] == _AUTH_STATUS_SUCCEEDED || throw(AuthenticationError("SOCKS username/password authentication failed"))
+    return nothing
+end
+
+function _send_connect!(
+        conn::TCP.Conn,
+        target_address::String,
+        host::String,
+        port::UInt16,
+    )::BoundAddr
+    request = UInt8[_VERSION5, _CMD_CONNECT, 0x00]
+    _append_target!(request, host, port, target_address)
+    write(conn, request)
+    reply = _read_exact!(conn, 4)
+    reply[1] == _VERSION5 || throw(ProtocolError("unexpected SOCKS version $(Int(reply[1]))"))
+    reply[2] == _STATUS_SUCCEEDED || throw(ReplyError(reply[2], _reply_message(reply[2])))
+    reply[3] == 0x00 || throw(ProtocolError("non-zero SOCKS reserved field"))
+    return _read_bound_addr!(conn, reply[4])
+end
+
+"""
+    connect!(conn, target_address; username=nothing, password=nothing, deadline_ns=0)
+
+Perform a SOCKS5 CONNECT handshake over `conn` and return the proxy bound
+address. On success, `conn` is the established stream to `target_address`.
+"""
+function connect!(
+        conn::TCP.Conn,
+        target_address::AbstractString;
+        username::Union{Nothing, AbstractString}=nothing,
+        password::Union{Nothing, AbstractString}=nothing,
+        deadline_ns::Integer=0,
+    )::BoundAddr
+    deadline = Int64(deadline_ns)
+    target = String(target_address)
+    host, port = _parse_target(target)
+    if deadline != 0
+        TCP.set_deadline!(conn, deadline)
+    end
+    try
+        _negotiate_auth!(conn, username, password)
+        return _send_connect!(conn, target, host, port)
+    finally
+        if deadline != 0
+            TCP.set_deadline!(conn, Int64(0))
+        end
+    end
+end
+
+end

--- a/src/5_socks.jl
+++ b/src/5_socks.jl
@@ -143,10 +143,9 @@ function _parse_target(address::AbstractString)::Tuple{String, UInt16}
     port = _parse_decimal_port(port_text)
     port === nothing && throw(TargetAddressError("invalid SOCKS target port", text))
     port == 0 && throw(TargetAddressError("SOCKS target port out of range", text))
-    # Zone-scoped IPv6 literals are rejected before the inet_pton-based literal
-    # parse: a remote proxy cannot resolve a client-local zone, and macOS
-    # inet_pton accepts "fe80::1%en0" while embedding the zone index into the
-    # address bytes. '%' never appears in a valid FQDN either.
+    # A remote proxy cannot resolve a client-local zone, so zone-scoped IPv6
+    # literals get a specific error up front; '%' never appears in a valid IP
+    # literal (_parse_ipv6_literal rejects zones) or FQDN.
     occursin('%', host) && throw(TargetAddressError("SOCKS target host must not contain a zone", text))
     if HostResolvers._parse_ipv4_literal(host) === nothing && HostResolvers._parse_ipv6_literal(host) === nothing
         length(codeunits(host)) <= 255 || throw(TargetAddressError("SOCKS target FQDN is too long", text))

--- a/src/Reseau.jl
+++ b/src/Reseau.jl
@@ -14,6 +14,7 @@ include("1_socket_ops.jl")
 include("2_iopoll.jl")
 include("3_tcp.jl")
 include("4_host_resolvers.jl")
+include("5_socks.jl")
 include("5_tls.jl")
 include("6_precompile_workload.jl")
 

--- a/test/host_resolvers_tests.jl
+++ b/test/host_resolvers_tests.jl
@@ -348,6 +348,17 @@ end
             @test ND._split_host_zone("%$parser_zone") == ("%$parser_zone", "")
             @test_throws ND.AddressError ND._split_host_zone("fe80::1%")
 
+            # zone-scoped literals are rejected by the raw parser on every
+            # platform; macOS inet_pton would otherwise accept them and embed
+            # the zone index into the address bytes
+            @test ND._parse_ipv6_literal("fe80::1%en0") === nothing
+            @test ND._parse_ipv6_literal("fe80::1%7") === nothing
+            @test ND._parse_ipv6_literal("::1%lo0") === nothing
+            @test ND._parse_ipv6_literal("fe80::1") == (
+                0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            )
+
             @test ND._scope_id_from_zone("") == UInt32(0)
             @test ND._scope_id_from_zone("7") == UInt32(7)
             if zone !== nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ test_files = [
     "socket_ops_tests.jl",
     "tcp_tests.jl",
     "host_resolvers_tests.jl",
+    "socks_tests.jl",
     "tls_crypto_tests.jl",
     "tls_x509_tests.jl",
     "tls_handshake_messages_tests.jl",

--- a/test/socks_tests.jl
+++ b/test/socks_tests.jl
@@ -114,7 +114,11 @@ function _socks_with_proxy(server_handler::Function, client_handler::Function)
     return nothing
 end
 
-function _socks_expect_no_proxy_bytes(target::String)::Nothing
+function _socks_expect_no_proxy_bytes(
+        target::String;
+        errtype::Type{<:Exception} = SK.TargetAddressError,
+        kwargs...,
+    )::Nothing
     IP.shutdown!()
     listener = nothing
     client = nothing
@@ -139,7 +143,7 @@ function _socks_expect_no_proxy_bytes(target::String)::Nothing
             end
         end)
         client = NC.connect(NC.loopback_addr(Int(laddr.port)))
-        @test_throws SK.TargetAddressError SK.connect!(client, target)
+        @test_throws errtype SK.connect!(client, target; kwargs...)
         _socks_wait_task!(server_task)
         @test fetch(server_task) == :no_bytes
     finally
@@ -231,6 +235,7 @@ end
 
 @testset "SOCKS5 parses bound reply addresses" begin
     cases = (
+        (UInt8(0x01), UInt8[0xc0, 0xa8, 0x01, 0x0a, 0x1f, 0x90], "192.168.1.10:8080"),
         (UInt8(0x03), UInt8[0x0b, codeunits("bound.local")..., 0x1f, 0x90], "bound.local:8080"),
         (UInt8(0x04), UInt8[
                 0x00, 0x00, 0x00, 0x00,
@@ -251,6 +256,7 @@ end
             conn -> begin
                 bound = SK.connect!(conn, "example.com:80")
                 @test string(bound) == expected
+                @test sprint(show, bound) == expected
             end,
         )
     end
@@ -294,6 +300,24 @@ end
     _socks_expect_no_proxy_bytes("example.com")
     long_host = repeat("a", 256)
     _socks_expect_no_proxy_bytes("$long_host:80")
+    # bracketed-but-invalid IPv6 literals must not be sent as FQDN targets
+    _socks_expect_no_proxy_bytes("[fe80::1%en0]:80")
+    _socks_expect_no_proxy_bytes("[1:2:3]:80")
+    _socks_expect_no_proxy_bytes(":80")
+    _socks_expect_no_proxy_bytes("example.com:")
+    _socks_expect_no_proxy_bytes("example.com:0")
+    _socks_expect_no_proxy_bytes("example.com:65536")
+    # strict decimal ports only
+    _socks_expect_no_proxy_bytes("example.com:0x50")
+    _socks_expect_no_proxy_bytes("example.com:+80")
+    _socks_expect_no_proxy_bytes("example.com: 80")
+end
+
+@testset "SOCKS5 validates credentials before proxy I/O" begin
+    _socks_expect_no_proxy_bytes("example.com:80"; errtype = SK.AuthenticationError, username = "")
+    _socks_expect_no_proxy_bytes("example.com:80"; errtype = SK.AuthenticationError, username = repeat("u", 256))
+    _socks_expect_no_proxy_bytes("example.com:80"; errtype = SK.AuthenticationError, username = "user", password = repeat("p", 256))
+    _socks_expect_no_proxy_bytes("example.com:80"; errtype = SK.AuthenticationError, password = "pass")
 end
 
 @testset "SOCKS5 handshake observes connection deadline" begin
@@ -306,4 +330,193 @@ end
             @test_throws NC.DeadlineExceededError SK.connect!(conn, "example.com:80"; deadline_ns)
         end,
     )
+end
+
+function _socks_read_auth_request!(conn::NC.Conn)::Tuple{String, String}
+    header = _socks_read_exact!(conn, 2)
+    @test header[1] == 0x01
+    username = String(_socks_read_exact!(conn, Int(header[2])))
+    plen = Int(_socks_read_exact!(conn, 1)[1])
+    password = String(_socks_read_exact!(conn, plen))
+    return username, password
+end
+
+@testset "SOCKS5 username/password rejection surfaces AuthenticationError" begin
+    # proxy rejects the credentials
+    _socks_with_proxy(
+        conn -> begin
+            @test _socks_read_greeting!(conn) == UInt8[0x00, 0x02]
+            write(conn, UInt8[0x05, 0x02])
+            _socks_read_auth_request!(conn)
+            write(conn, UInt8[0x01, 0x01])
+        end,
+        conn -> begin
+            @test_throws SK.AuthenticationError SK.connect!(conn, "example.com:80"; username = "user", password = "pass")
+        end,
+    )
+    # proxy replies with a bad subnegotiation version
+    _socks_with_proxy(
+        conn -> begin
+            @test _socks_read_greeting!(conn) == UInt8[0x00, 0x02]
+            write(conn, UInt8[0x05, 0x02])
+            _socks_read_auth_request!(conn)
+            write(conn, UInt8[0x02, 0x00])
+        end,
+        conn -> begin
+            @test_throws SK.AuthenticationError SK.connect!(conn, "example.com:80"; username = "user", password = "pass")
+        end,
+    )
+end
+
+@testset "SOCKS5 unsupported method selections surface AuthenticationError" begin
+    # proxy demands username/password when only no-auth was offered
+    _socks_with_proxy(
+        conn -> begin
+            @test _socks_read_greeting!(conn) == UInt8[0x00]
+            write(conn, UInt8[0x05, 0x02])
+        end,
+        conn -> begin
+            @test_throws SK.AuthenticationError SK.connect!(conn, "example.com:80")
+        end,
+    )
+    # proxy selects a method that was never offered
+    _socks_with_proxy(
+        conn -> begin
+            @test _socks_read_greeting!(conn) == UInt8[0x00, 0x02]
+            write(conn, UInt8[0x05, 0x01])
+        end,
+        conn -> begin
+            @test_throws SK.AuthenticationError SK.connect!(conn, "example.com:80"; username = "user", password = "pass")
+        end,
+    )
+end
+
+@testset "SOCKS5 malformed proxy responses surface ProtocolError" begin
+    # wrong version in the method selection reply
+    _socks_with_proxy(
+        conn -> begin
+            _socks_read_greeting!(conn)
+            write(conn, UInt8[0x04, 0x00])
+        end,
+        conn -> begin
+            @test_throws SK.ProtocolError SK.connect!(conn, "example.com:80")
+        end,
+    )
+    # wrong version in the connect reply
+    _socks_with_proxy(
+        conn -> begin
+            _socks_read_greeting!(conn)
+            write(conn, UInt8[0x05, 0x00])
+            _socks_read_connect_request!(conn)
+            write(conn, UInt8[0x04, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+        end,
+        conn -> begin
+            @test_throws SK.ProtocolError SK.connect!(conn, "example.com:80")
+        end,
+    )
+    # non-zero reserved byte in the connect reply
+    _socks_with_proxy(
+        conn -> begin
+            _socks_read_greeting!(conn)
+            write(conn, UInt8[0x05, 0x00])
+            _socks_read_connect_request!(conn)
+            write(conn, UInt8[0x05, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+        end,
+        conn -> begin
+            @test_throws SK.ProtocolError SK.connect!(conn, "example.com:80")
+        end,
+    )
+    # unknown bound address type in the connect reply
+    _socks_with_proxy(
+        conn -> begin
+            _socks_read_greeting!(conn)
+            write(conn, UInt8[0x05, 0x00])
+            _socks_read_connect_request!(conn)
+            write(conn, UInt8[0x05, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+        end,
+        conn -> begin
+            @test_throws SK.ProtocolError SK.connect!(conn, "example.com:80")
+        end,
+    )
+end
+
+@testset "SOCKS5 proxy EOF mid-handshake throws EOFError" begin
+    _socks_with_proxy(
+        conn -> begin
+            _socks_read_greeting!(conn)
+        end,
+        conn -> begin
+            @test_throws EOFError SK.connect!(conn, "example.com:80")
+        end,
+    )
+end
+
+@testset "SOCKS5 credentials offered but proxy selects no-auth" begin
+    _socks_with_proxy(
+        conn -> begin
+            @test _socks_read_greeting!(conn) == UInt8[0x00, 0x02]
+            write(conn, UInt8[0x05, 0x00])
+            _socks_read_connect_request!(conn)
+            _socks_write_success!(conn)
+        end,
+        conn -> begin
+            bound = SK.connect!(conn, "example.com:80"; username = "user", password = "pass")
+            @test string(bound) == "0.0.0.0:0"
+        end,
+    )
+end
+
+@testset "SOCKS5 username without password sends empty password" begin
+    _socks_with_proxy(
+        conn -> begin
+            @test _socks_read_greeting!(conn) == UInt8[0x00, 0x02]
+            write(conn, UInt8[0x05, 0x02])
+            @test _socks_read_auth_request!(conn) == ("user", "")
+            write(conn, UInt8[0x01, 0x00])
+            _socks_read_connect_request!(conn)
+            _socks_write_success!(conn)
+        end,
+        conn -> begin
+            bound = SK.connect!(conn, "example.com:80"; username = "user")
+            @test string(bound) == "0.0.0.0:0"
+        end,
+    )
+end
+
+@testset "SOCKS5 boundary length credentials and FQDN" begin
+    long_user = repeat("u", 255)
+    long_pass = repeat("p", 255)
+    _socks_with_proxy(
+        conn -> begin
+            @test _socks_read_greeting!(conn) == UInt8[0x00, 0x02]
+            write(conn, UInt8[0x05, 0x02])
+            @test _socks_read_auth_request!(conn) == (long_user, long_pass)
+            write(conn, UInt8[0x01, 0x00])
+            _socks_read_connect_request!(conn)
+            _socks_write_success!(conn)
+        end,
+        conn -> begin
+            bound = SK.connect!(conn, "example.com:80"; username = long_user, password = long_pass)
+            @test string(bound) == "0.0.0.0:0"
+        end,
+    )
+
+    long_host = repeat("a", 255)
+    seen = Channel{_SocksRequest}(1)
+    _socks_with_proxy(
+        conn -> begin
+            @test _socks_read_greeting!(conn) == UInt8[0x00]
+            write(conn, UInt8[0x05, 0x00])
+            put!(seen, _socks_read_connect_request!(conn))
+            _socks_write_success!(conn)
+        end,
+        conn -> begin
+            bound = SK.connect!(conn, "$long_host:80")
+            @test string(bound) == "0.0.0.0:0"
+        end,
+    )
+    req = take!(seen)
+    @test req.atyp == 0x03
+    @test req.host == long_host
+    @test req.port == UInt16(80)
 end

--- a/test/socks_tests.jl
+++ b/test/socks_tests.jl
@@ -1,0 +1,309 @@
+using Test
+using Reseau
+
+const SK = Reseau.SOCKS
+const NC = Reseau.TCP
+const IP = Reseau.IOPoll
+
+struct _SocksRequest
+    atyp::UInt8
+    host::String
+    port::UInt16
+end
+
+function _socks_close_quiet!(x)
+    x === nothing && return nothing
+    try
+        close(x)
+    catch
+    end
+    return nothing
+end
+
+function _socks_wait_task!(task::Task; timeout_s::Float64 = 2.0)
+    status = timedwait(() -> istaskdone(task), timeout_s; pollint = 0.001)
+    status == :timed_out && error("timed out waiting for SOCKS test task")
+    fetch(task)
+    return nothing
+end
+
+function _socks_read_exact!(conn::NC.Conn, n::Integer)::Vector{UInt8}
+    count = Int(n)
+    buf = Vector{UInt8}(undef, count)
+    got = readbytes!(conn, buf, count; all = true)
+    got == count || throw(EOFError())
+    return buf
+end
+
+function _socks_read_greeting!(conn::NC.Conn)::Vector{UInt8}
+    header = _socks_read_exact!(conn, 2)
+    @test header[1] == 0x05
+    nmethods = Int(header[2])
+    return _socks_read_exact!(conn, nmethods)
+end
+
+function _socks_read_connect_request!(conn::NC.Conn)::_SocksRequest
+    prefix = _socks_read_exact!(conn, 4)
+    @test prefix[1:3] == UInt8[0x05, 0x01, 0x00]
+    atyp = prefix[4]
+    if atyp == 0x01
+        data = _socks_read_exact!(conn, 6)
+        host = string(data[1], ".", data[2], ".", data[3], ".", data[4])
+        port = (UInt16(data[5]) << 8) | UInt16(data[6])
+        return _SocksRequest(atyp, host, port)
+    elseif atyp == 0x03
+        len = Int(_socks_read_exact!(conn, 1)[1])
+        data = _socks_read_exact!(conn, len + 2)
+        host = String(data[1:len])
+        port = (UInt16(data[len + 1]) << 8) | UInt16(data[len + 2])
+        return _SocksRequest(atyp, host, port)
+    elseif atyp == 0x04
+        data = _socks_read_exact!(conn, 18)
+        ip = (
+            data[1], data[2], data[3], data[4],
+            data[5], data[6], data[7], data[8],
+            data[9], data[10], data[11], data[12],
+            data[13], data[14], data[15], data[16],
+        )
+        port = (UInt16(data[17]) << 8) | UInt16(data[18])
+        return _SocksRequest(atyp, NC._format_ipv6(ip), port)
+    end
+    error("unexpected SOCKS address type $(Int(atyp))")
+end
+
+function _socks_write_success!(conn::NC.Conn)::Nothing
+    write(conn, UInt8[0x05, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+    return nothing
+end
+
+function _socks_write_success!(conn::NC.Conn, atyp::UInt8, bound_payload::Vector{UInt8})::Nothing
+    reply = UInt8[0x05, 0x00, 0x00, atyp]
+    append!(reply, bound_payload)
+    write(conn, reply)
+    return nothing
+end
+
+function _socks_with_proxy(server_handler::Function, client_handler::Function)
+    IP.shutdown!()
+    listener = nothing
+    client = nothing
+    server_task = nothing
+    try
+        listener = NC.listen(NC.loopback_addr(0); backlog = 8)
+        laddr = NC.addr(listener)::NC.SocketAddrV4
+        server_task = errormonitor(Threads.@spawn begin
+            conn = NC.accept(listener)
+            try
+                server_handler(conn)
+            finally
+                _socks_close_quiet!(conn)
+            end
+            return nothing
+        end)
+        client = NC.connect(NC.loopback_addr(Int(laddr.port)))
+        client_handler(client)
+        _socks_wait_task!(server_task)
+    finally
+        _socks_close_quiet!(client)
+        _socks_close_quiet!(listener)
+        if server_task !== nothing && !istaskdone(server_task)
+            _socks_wait_task!(server_task; timeout_s = 2.0)
+        end
+        IP.shutdown!()
+    end
+    return nothing
+end
+
+function _socks_expect_no_proxy_bytes(target::String)::Nothing
+    IP.shutdown!()
+    listener = nothing
+    client = nothing
+    server_task = nothing
+    try
+        listener = NC.listen(NC.loopback_addr(0); backlog = 8)
+        laddr = NC.addr(listener)::NC.SocketAddrV4
+        server_task = errormonitor(Threads.@spawn begin
+            conn = NC.accept(listener)
+            try
+                NC.set_read_deadline!(conn, Int64(time_ns()) + 50_000_000)
+                try
+                    read(conn, UInt8)
+                    return :saw_byte
+                catch err
+                    ex = err::Exception
+                    ex isa NC.DeadlineExceededError || rethrow(ex)
+                    return :no_bytes
+                end
+            finally
+                _socks_close_quiet!(conn)
+            end
+        end)
+        client = NC.connect(NC.loopback_addr(Int(laddr.port)))
+        @test_throws SK.TargetAddressError SK.connect!(client, target)
+        _socks_wait_task!(server_task)
+        @test fetch(server_task) == :no_bytes
+    finally
+        _socks_close_quiet!(client)
+        _socks_close_quiet!(listener)
+        if server_task !== nothing && !istaskdone(server_task)
+            _socks_wait_task!(server_task; timeout_s = 2.0)
+        end
+        IP.shutdown!()
+    end
+    return nothing
+end
+
+@testset "SOCKS5 no-auth FQDN connect leaves stream open" begin
+    seen = Channel{_SocksRequest}(1)
+    _socks_with_proxy(
+        conn -> begin
+            @test _socks_read_greeting!(conn) == UInt8[0x00]
+            write(conn, UInt8[0x05, 0x00])
+            req = _socks_read_connect_request!(conn)
+            put!(seen, req)
+            _socks_write_success!(conn)
+            @test String(_socks_read_exact!(conn, 4)) == "ping"
+            write(conn, codeunits("pong"))
+        end,
+        conn -> begin
+            bound = SK.connect!(conn, "example.com:443")
+            @test string(bound) == "0.0.0.0:0"
+            @test write(conn, codeunits("ping")) == 4
+            @test String(_socks_read_exact!(conn, 4)) == "pong"
+        end,
+    )
+    req = take!(seen)
+    @test req.atyp == 0x03
+    @test req.host == "example.com"
+    @test req.port == UInt16(443)
+end
+
+@testset "SOCKS5 connect encodes IP targets" begin
+    for (target, expected_atyp, expected_host, expected_port) in (
+            ("127.0.0.1:80", UInt8(0x01), "127.0.0.1", UInt16(80)),
+            ("[::1]:443", UInt8(0x04), "::1", UInt16(443)),
+        )
+        seen = Channel{_SocksRequest}(1)
+        _socks_with_proxy(
+            conn -> begin
+                @test _socks_read_greeting!(conn) == UInt8[0x00]
+                write(conn, UInt8[0x05, 0x00])
+                put!(seen, _socks_read_connect_request!(conn))
+                _socks_write_success!(conn)
+            end,
+            conn -> begin
+                bound = SK.connect!(conn, target)
+                @test string(bound) == "0.0.0.0:0"
+            end,
+        )
+        req = take!(seen)
+        @test req.atyp == expected_atyp
+        @test req.host == expected_host
+        @test req.port == expected_port
+    end
+end
+
+@testset "SOCKS5 username/password authentication" begin
+    seen = Channel{_SocksRequest}(1)
+    _socks_with_proxy(
+        conn -> begin
+            @test _socks_read_greeting!(conn) == UInt8[0x00, 0x02]
+            write(conn, UInt8[0x05, 0x02])
+            auth_header = _socks_read_exact!(conn, 2)
+            @test auth_header == UInt8[0x01, 0x04]
+            @test String(_socks_read_exact!(conn, 4)) == "user"
+            @test _socks_read_exact!(conn, 1) == UInt8[0x04]
+            @test String(_socks_read_exact!(conn, 4)) == "pass"
+            write(conn, UInt8[0x01, 0x00])
+            put!(seen, _socks_read_connect_request!(conn))
+            _socks_write_success!(conn)
+        end,
+        conn -> begin
+            bound = SK.connect!(conn, "secure.local:8443"; username = "user", password = "pass")
+            @test string(bound) == "0.0.0.0:0"
+        end,
+    )
+    req = take!(seen)
+    @test req.atyp == 0x03
+    @test req.host == "secure.local"
+    @test req.port == UInt16(8443)
+end
+
+@testset "SOCKS5 parses bound reply addresses" begin
+    cases = (
+        (UInt8(0x03), UInt8[0x0b, codeunits("bound.local")..., 0x1f, 0x90], "bound.local:8080"),
+        (UInt8(0x04), UInt8[
+                0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x01,
+                0x00, 0x35,
+            ], "[::1]:53"),
+    )
+    for (atyp, payload, expected) in cases
+        _socks_with_proxy(
+            conn -> begin
+                @test _socks_read_greeting!(conn) == UInt8[0x00]
+                write(conn, UInt8[0x05, 0x00])
+                _socks_read_connect_request!(conn)
+                _socks_write_success!(conn, atyp, payload)
+            end,
+            conn -> begin
+                bound = SK.connect!(conn, "example.com:80")
+                @test string(bound) == expected
+            end,
+        )
+    end
+end
+
+@testset "SOCKS5 authentication and reply failures surface typed errors" begin
+    _socks_with_proxy(
+        conn -> begin
+            @test _socks_read_greeting!(conn) == UInt8[0x00]
+            write(conn, UInt8[0x05, 0xff])
+        end,
+        conn -> begin
+            @test_throws SK.AuthenticationError SK.connect!(conn, "example.com:80")
+        end,
+    )
+
+    _socks_with_proxy(
+        conn -> begin
+            @test _socks_read_greeting!(conn) == UInt8[0x00]
+            write(conn, UInt8[0x05, 0x00])
+            _socks_read_connect_request!(conn)
+            write(conn, UInt8[0x05, 0x05, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+        end,
+        conn -> begin
+            err = try
+                SK.connect!(conn, "example.com:80")
+                nothing
+            catch ex
+                ex
+            end
+            @test err isa SK.ReplyError
+            if err isa SK.ReplyError
+                @test err.code == 0x05
+                @test err.message == "connection refused"
+            end
+        end,
+    )
+end
+
+@testset "SOCKS5 validates target before proxy I/O" begin
+    _socks_expect_no_proxy_bytes("example.com")
+    long_host = repeat("a", 256)
+    _socks_expect_no_proxy_bytes("$long_host:80")
+end
+
+@testset "SOCKS5 handshake observes connection deadline" begin
+    _socks_with_proxy(
+        conn -> begin
+            sleep(0.2)
+        end,
+        conn -> begin
+            deadline_ns = Int64(time_ns()) + 50_000_000
+            @test_throws NC.DeadlineExceededError SK.connect!(conn, "example.com:80"; deadline_ns)
+        end,
+    )
+end

--- a/test/socks_trim_safe.jl
+++ b/test/socks_trim_safe.jl
@@ -1,0 +1,62 @@
+using Reseau
+
+const NC = Reseau.TCP
+const SK = Reseau.SOCKS
+
+function _close_quiet!(x)
+    x === nothing && return nothing
+    try
+        close(x)
+    catch
+    end
+    return nothing
+end
+
+function run_socks_trim_sample()::Nothing
+    listener::Union{Nothing, NC.Listener} = nothing
+    client::Union{Nothing, NC.Conn} = nothing
+    server::Union{Nothing, NC.Conn} = nothing
+    try
+        listener = NC.listen(NC.loopback_addr(0); backlog = 16)
+        laddr = NC.addr(listener)::NC.SocketAddrV4
+        client = NC.connect(NC.loopback_addr(Int(laddr.port)))
+        server = NC.accept(listener)
+        # Pre-buffer the scripted proxy replies (no-auth method selection plus
+        # a successful CONNECT reply with a 0.0.0.0:0 IPv4 bound address) so
+        # the handshake completes without a second task.
+        replies = UInt8[0x05, 0x00, 0x05, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+        write(server, replies) == length(replies) || error("expected proxy reply write")
+        bound = SK.connect!(client, "example.com:443")
+        string(bound) == "0.0.0.0:0" || error("unexpected SOCKS bound address")
+        expected = UInt8[
+            0x05, 0x01, 0x00,
+            0x05, 0x01, 0x00, 0x03, UInt8(length("example.com")),
+            codeunits("example.com")...,
+            0x01, 0xbb,
+        ]
+        request = Vector{UInt8}(undef, length(expected))
+        read!(server, request)
+        request == expected || error("unexpected SOCKS handshake bytes")
+        err = try
+            SK.connect!(client, "missing-port")
+            nothing
+        catch ex
+            ex
+        end
+        err isa SK.TargetAddressError || error("expected SOCKS target validation error")
+        isempty(sprint(showerror, err::SK.TargetAddressError)) && error("expected SOCKS error message")
+    finally
+        _close_quiet!(server)
+        _close_quiet!(client)
+        _close_quiet!(listener)
+    end
+    return nothing
+end
+
+function @main(args::Vector{String})::Cint
+    _ = args
+    run_socks_trim_sample()
+    return 0
+end
+
+Base.Experimental.entrypoint(main, (Vector{String},))

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -195,6 +195,7 @@ end
             ("iopoll_runtime_trim_safe.jl", "iopoll_runtime_trim_safe"),
             ("socket_ops_trim_safe.jl", "socket_ops_trim_safe"),
             ("tcp_trim_safe.jl", "tcp_trim_safe"),
+            ("socks_trim_safe.jl", "socks_trim_safe"),
             ("host_resolvers_trim_safe.jl", "host_resolvers_trim_safe"),
             ("host_resolvers_system_trim_safe.jl", "host_resolvers_system_trim_safe"),
             ("tls_trim_safe.jl", "tls_trim_safe"),


### PR DESCRIPTION
## Summary
- add an internal `Reseau.SOCKS` support layer for SOCKS5 CONNECT handshakes over `TCP.Conn`
- support no-auth and username/password authentication, FQDN/IPv4/IPv6 targets, typed failure modes, bound reply parsing, and deadline handling
- document the internal support layer and wire focused SOCKS tests into the main test entrypoint

## Tests
- `JULIA_NUM_THREADS=1 ~/.juliaup/bin/julialauncher --project=. --startup-file=no --history-file=no test/runtests.jl`
- `~/.juliaup/bin/julialauncher --project=docs --startup-file=no --history-file=no -e 'using Documenter: doctest; using Reseau; doctest(Reseau)'`
- `~/.juliaup/bin/julialauncher --project=docs --startup-file=no --history-file=no docs/make.jl`

Co-authored by Codex