### PR TITLE
Shut down host resolver workers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Reseau"
 uuid = "802f3686-a58f-41ce-bb0c-3c43c75bba36"
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 NetworkOptions = "ca575930-c2e3-43a9-ace4-1e988b2c1908"

--- a/src/4_host_resolvers.jl
+++ b/src/4_host_resolvers.jl
@@ -400,6 +400,8 @@ const _ADDRINFO_POOL_CAPACITY = 64
 const _ADDRINFO_THREAD_ENTRY_C = Ref{Ptr{Cvoid}}(C_NULL)
 const _ADDRINFO_POOL_LOCK = ReentrantLock()
 const _ADDRINFO_STARTED_THREADS = Ref{Int}(0)
+const _ADDRINFO_EXIT_COND = Threads.Condition()
+const _ADDRINFO_LIVE_THREADS = Ref{Int}(0)
 
 mutable struct _AddrInfoFuture
     notify::Threads.Condition
@@ -482,6 +484,36 @@ function _run_addrinfo_future!(future::_AddrInfoFuture)::Nothing
     return nothing
 end
 
+function _addrinfo_worker_started!()::Nothing
+    lock(_ADDRINFO_EXIT_COND)
+    try
+        _ADDRINFO_LIVE_THREADS[] += 1
+    finally
+        unlock(_ADDRINFO_EXIT_COND)
+    end
+    return nothing
+end
+
+function _addrinfo_worker_stopped!()::Nothing
+    lock(_ADDRINFO_EXIT_COND)
+    try
+        _ADDRINFO_LIVE_THREADS[] = max(_ADDRINFO_LIVE_THREADS[] - 1, 0)
+        notify(_ADDRINFO_EXIT_COND)
+    finally
+        unlock(_ADDRINFO_EXIT_COND)
+    end
+    return nothing
+end
+
+function _addrinfo_live_threads()::Int
+    lock(_ADDRINFO_EXIT_COND)
+    try
+        return _ADDRINFO_LIVE_THREADS[]
+    finally
+        unlock(_ADDRINFO_EXIT_COND)
+    end
+end
+
 function _addrinfo_worker_entry(arg::Ptr{Cvoid})::Ptr{Cvoid}
     work_queue = unsafe_pointer_to_objref(arg)::Channel{_AddrInfoFuture}
     try
@@ -489,6 +521,8 @@ function _addrinfo_worker_entry(arg::Ptr{Cvoid})::Ptr{Cvoid}
             _run_addrinfo_future!(future)
         end
     catch
+    finally
+        _addrinfo_worker_stopped!()
     end
     return C_NULL
 end
@@ -503,13 +537,39 @@ function _ensure_addrinfo_pool!()::Channel{_AddrInfoFuture}
         work_queue = _ADDRINFO_WORK_QUEUE[]
         while _ADDRINFO_STARTED_THREADS[] < _ADDRINFO_POOL_SIZE
             next_idx = _ADDRINFO_STARTED_THREADS[] + 1
-            IOPoll._spawn_detached_thread("reseau-getaddrinfo-$next_idx", _ADDRINFO_THREAD_ENTRY_C, work_queue)
+            _addrinfo_worker_started!()
+            try
+                IOPoll._spawn_detached_thread("reseau-getaddrinfo-$next_idx", _ADDRINFO_THREAD_ENTRY_C, work_queue)
+            catch
+                _addrinfo_worker_stopped!()
+                rethrow()
+            end
             _ADDRINFO_STARTED_THREADS[] = next_idx
         end
         return work_queue
     finally
         unlock(_ADDRINFO_POOL_LOCK)
     end
+end
+
+function shutdown!(timeout::Real = 5.0)::Nothing
+    lock(_ADDRINFO_POOL_LOCK)
+    try
+        if isassigned(_ADDRINFO_WORK_QUEUE)
+            work_queue = _ADDRINFO_WORK_QUEUE[]
+            isopen(work_queue) && close(work_queue)
+        end
+        _ADDRINFO_WORK_QUEUE[] = Channel{_AddrInfoFuture}(_ADDRINFO_POOL_CAPACITY)
+        _ADDRINFO_STARTED_THREADS[] = 0
+    finally
+        unlock(_ADDRINFO_POOL_LOCK)
+    end
+    Base.timedwait(
+        () -> _addrinfo_live_threads() == 0,
+        Float64(timeout);
+        pollint=0.01,
+    )
+    return nothing
 end
 
 function _wait_addrinfo_future!(future::_AddrInfoFuture)::Cint
@@ -529,6 +589,7 @@ function __init__()
     _ADDRINFO_THREAD_ENTRY_C[] = @cfunction(_addrinfo_worker_entry, Ptr{Cvoid}, (Ptr{Cvoid},))
     _ADDRINFO_WORK_QUEUE[] = Channel{_AddrInfoFuture}(_ADDRINFO_POOL_CAPACITY)
     _ADDRINFO_STARTED_THREADS[] = 0
+    _ADDRINFO_LIVE_THREADS[] = 0
 end
 
 @static if Sys.iswindows()

--- a/src/6_precompile_workload.jl
+++ b/src/6_precompile_workload.jl
@@ -317,6 +317,10 @@ function _pc_run_host_resolvers_workload!()
             listener === nothing || close(listener)
         catch
         end
+        try
+            ND.shutdown!()
+        catch
+        end
         IP.shutdown!()
     end
     return nothing

--- a/test/host_resolvers_tests.jl
+++ b/test/host_resolvers_tests.jl
@@ -507,6 +507,22 @@ end
                 @test occursin("lookup failed", bad_host_err.err)
             end
         end
+        @testset "system resolver worker shutdown and restart" begin
+            ND.shutdown!()
+            @test ND._addrinfo_live_threads() == 0
+            try
+                @test !isempty(ND.resolve_tcp_addrs("tcp", "localhost:0"))
+                @test ND._addrinfo_live_threads() > 0
+                ND.shutdown!()
+                @test ND._addrinfo_live_threads() == 0
+
+                @test !isempty(ND.resolve_tcp_addrs("tcp", "localhost:0"))
+                @test ND._addrinfo_live_threads() > 0
+            finally
+                ND.shutdown!()
+            end
+            @test ND._addrinfo_live_threads() == 0
+        end
         @testset "connect/listen by address strings (ipv4)" begin
             IP.shutdown!()
             listener = nothing


### PR DESCRIPTION
## Summary

- add explicit lifecycle tracking and shutdown for the HostResolvers `getaddrinfo` worker pool
- shut down host resolver workers during the host resolver precompile workload
- add a focused shutdown/restart test for the system resolver worker pool
- bump Reseau to 1.2.1 so HTTP can depend on the new cleanup API

## RCA context

HTTP's package precompile hang was not fixed by disabling workloads or platform-skipping anything. The repro showed Reseau resolver worker threads could remain alive after precompile work, and HTTP's precompile path needed a concrete cleanup API for those workers. This PR gives the worker pool an explicit shutdown path so downstream precompile workloads can drain it before package-output teardown.

## Validation

- `julia --project=. -e 'using Reseau, Test; ...'` lifecycle smoke on the Azure repro VM: workers start, `HostResolvers.shutdown!()` drains to zero, workers restart, and drain again.
- `test/host_resolvers_tests.jl` on the Azure repro VM: the new `system resolver worker shutdown and restart` test passed 7/7; the file has one pre-existing environment-specific failure where `localhost` did not return IPv6 despite the VM supporting IPv6 sockets.
- Exact patched cold HTTP+Reseau source precompile on the Azure repro VM, with no trace flags and no workload disabling: Reseau ~38.6s, HTTP ~67.1s, total ~106s, exit 0.

Co-authored by Codex
