### PR TITLE
iopoll: GC-safe epoll_wait, alloc-free timer drain, shutdown hardening

### DIFF
--- a/src/iopoll/epoll.jl
+++ b/src/iopoll/epoll.jl
@@ -10,7 +10,6 @@ const EPOLL_CLOEXEC = Cint(0x80000)
 const EFD_NONBLOCK = Cint(0x800)
 const EFD_CLOEXEC = Cint(0x80000)
 const MAX_EPOLL_EVENTS = 128
-const MAX_GC_UNSAFE_EPOLL_WAIT_MS = Cint(25)
 const _WAKE_TOKEN = UInt64(0)
 
 # Mirror of Linux `struct epoll_event`.
@@ -53,7 +52,13 @@ Typed epoll backend state attached to the shared poller.
 mutable struct EpollBackendState <: BackendState
     epfd::Cint
     wakefd::Cint
-    events::Vector{EpollEvent}
+    # C-allocated (`Libc.malloc`) buffer with room for MAX_EPOLL_EVENTS
+    # entries, freed in `_backend_close!`. The buffer must live off the Julia
+    # heap: `epoll_wait` runs as a GC-safe ccall, so the GC can run while the
+    # kernel fills the buffer, and gVisor's userspace epoll has crashed
+    # writing into Julia-heap memory during concurrent GC. Plain C memory
+    # keeps event delivery entirely outside GC-managed pages.
+    events::Ptr{EpollEvent}
     @atomic wake_sig::UInt32
 end
 
@@ -81,12 +86,23 @@ function _backend_init!(state::Poller)::Int32
         @ccall close(epfd::Cint)::Cint
         return errno
     end
-    state.backend_state = EpollBackendState(epfd, efd, Vector{EpollEvent}(undef, MAX_EPOLL_EVENTS), UInt32(0))
+    events = convert(Ptr{EpollEvent}, Base.Libc.malloc(MAX_EPOLL_EVENTS * sizeof(EpollEvent)))
+    if events == C_NULL
+        @ccall close(efd::Cint)::Cint
+        @ccall close(epfd::Cint)::Cint
+        return Int32(Base.Libc.ENOMEM)
+    end
+    state.backend_state = EpollBackendState(epfd, efd, events, UInt32(0))
     return Int32(0)
 end
 
 """
 Close epoll backend resources.
+
+Only safe after the poller thread has exited (`shutdown!` waits on
+`shutdown_event` before calling this): the backend wait has no timeout cap,
+so the thread can be parked in `epoll_wait` indefinitely, and freeing the
+event buffer under a live wait would hand the kernel a dangling pointer.
 """
 function _backend_close!(state::Poller)
     backend = state.backend_state
@@ -98,6 +114,10 @@ function _backend_close!(state::Poller)
             epoll.epfd = Cint(-1)
         end
         epoll.wakefd = Cint(-1)
+        if epoll.events != C_NULL
+            Base.Libc.free(epoll.events)
+            epoll.events = Ptr{EpollEvent}(C_NULL)
+        end
     end
     state.backend_state = nothing
     return nothing
@@ -163,6 +183,12 @@ end
 
 """
 Wake a blocking epoll_wait via eventfd.
+
+The write stays a plain (GC-unsafe) ccall on purpose: the eventfd is
+EFD_NONBLOCK so the write cannot stall GC, and keeping the thread GC-unsafe
+means the kernel never reads the Julia-heap `Ref` while the GC runs — the
+same gVisor hazard the C-allocated event buffer avoids on the wait side.
+See `_maybe_wake_for_earlier_time!` for the wake coalescing contract.
 """
 function _backend_wake!(state::Poller)::Int32
     backend = state.backend_state
@@ -173,7 +199,7 @@ function _backend_wake!(state::Poller)::Int32
     ok || return Int32(0)
     one = Ref{UInt64}(1)
     while true
-        n = @gcsafe_ccall write(
+        n = @ccall write(
             epoll.wakefd::Cint,
             one::Ref{UInt64},
             Csize_t(sizeof(UInt64))::Csize_t,
@@ -223,22 +249,27 @@ function _backend_poll_once!(state::Poller, delay_ns::Int64)::Int32
     backend isa EpollBackendState || return Int32(Base.Libc.ENOSYS)
     epoll = backend::EpollBackendState
     events = epoll.events
+    events == C_NULL && return Int32(Base.Libc.EBADF)
     waitms = _epoll_wait_timeout_ms(delay_ns)
-    # gVisor can crash when its userspace epoll implementation writes into the
-    # event buffer while this foreign poller thread is in a GC-safe ccall. Keep
-    # the wait GC-unsafe, but cap each sleep so this detached thread cannot
-    # block Julia GC indefinitely while the poller is idle.
-    waitms = waitms < 0 ? MAX_GC_UNSAFE_EPOLL_WAIT_MS : min(waitms, MAX_GC_UNSAFE_EPOLL_WAIT_MS)
+    # The wait runs as a GC-safe ccall so a blocked poller never stalls
+    # stop-the-world: a GC-unsafe wait added its remaining timeout to every GC
+    # pause, and the 25ms cap that used to bound the stall taxed every
+    # collection while forcing an idle poller to wake 40 times a second. The
+    # event buffer is C memory (see `EpollBackendState`), so neither the
+    # kernel nor gVisor's userspace epoll touches the Julia heap while the GC
+    # runs, and no cap is needed: an idle poller sleeps until the wake eventfd
+    # fires, matching the kqueue and IOCP backends.
     while true
-        n = GC.@preserve events begin
-            @ccall epoll_wait(
-                epoll.epfd::Cint,
-                pointer(events)::Ptr{EpollEvent},
-                Cint(length(events))::Cint,
-                waitms::Cint,
-            )::Cint
-        end
+        n = @gcsafe_ccall epoll_wait(
+            epoll.epfd::Cint,
+            events::Ptr{EpollEvent},
+            Cint(MAX_EPOLL_EVENTS)::Cint,
+            waitms::Cint,
+        )::Cint
         if n == Cint(-1)
+            # Relies on the GC-safe transition back (which can block on a
+            # running collection) not clobbering errno; futex waits on
+            # glibc/musl do not touch it.
             errno = Int32(Base.Libc.errno())
             if errno == Int32(Base.Libc.EINTR)
                 waitms > 0 && return Int32(0)
@@ -247,16 +278,19 @@ function _backend_poll_once!(state::Poller, delay_ns::Int64)::Int32
             return errno
         end
         for i in 1:n
-            ev = events[i]
+            ev = unsafe_load(events, i)
             ev.events == UInt32(0) && continue
             event_data = _epoll_event_data(ev)
             if event_data == _WAKE_TOKEN
                 # Match the IOCP wake path: once the eventfd wake is consumed,
                 # always drain it and clear the coalescing latch. Leaving the
                 # latch set after a zero-timeout poll can suppress the next
-                # real wake and strand later timers/deadline updates.
+                # real wake and strand later timers/deadline updates. The
+                # drain stays a plain ccall: the counter is known nonzero, so
+                # the read cannot block, and the kernel must not write the
+                # Julia-heap `Ref` while this thread is GC-safe.
                 one = Ref{UInt64}(0)
-                _ = @gcsafe_ccall read(
+                _ = @ccall read(
                     epoll.wakefd::Cint,
                     one::Ref{UInt64},
                     Csize_t(sizeof(UInt64))::Csize_t,

--- a/src/iopoll/runtime.jl
+++ b/src/iopoll/runtime.jl
@@ -153,6 +153,11 @@ Returns `nothing`.
 
 Waiting registrations are notified so blocked Julia tasks can observe close or
 shutdown on their next state check instead of remaining parked forever.
+
+The backend wake is the only thing that gets a parked poller thread out of its
+(possibly indefinite) backend wait, so `_backend_close!` must stay strictly
+ordered after `wait(state.shutdown_event)`: tearing down backend resources
+while the poller thread can still touch them would race the poll loop.
 """
 function shutdown!()
     lock(POLLER_LOCK)
@@ -187,6 +192,9 @@ function shutdown!()
             _close_timer!(timer)
         end
         if stop_requested
+            # If the wake fails the poller thread may stay parked indefinitely;
+            # throwing here, before `_backend_close!`, intentionally leaks the
+            # backend rather than freeing memory the kernel may still write.
             wake_errno = _backend_wake!(state)
             wake_errno == Int32(0) || _throw_errno("iopoll wake", wake_errno)
             wait(state.shutdown_event)
@@ -410,8 +418,13 @@ function _poller_thread_entry(arg::Ptr{Cvoid})::Ptr{Cvoid}
     try
         _poller_thread_main!(state)
     catch
-        _notify_all_waiters!(state)
-        notify(state.shutdown_event)
+        # Never strand `shutdown!`: even if waiter notification itself throws,
+        # the shutdown event must fire so `wait(state.shutdown_event)` returns.
+        try
+            _notify_all_waiters!(state)
+        finally
+            notify(state.shutdown_event)
+        end
     end
     return C_NULL
 end

--- a/src/iopoll/timers.jl
+++ b/src/iopoll/timers.jl
@@ -112,6 +112,26 @@ function _time_peek_locked(state::Poller)
     return state.time_heap[1]
 end
 
+# Wake coalescing contract. The backend wake latch (`wake_sig`) lets
+# concurrent wakers skip redundant backend wakes, and losing the latch CAS is
+# only safe because of two invariants:
+#
+# 1. A set latch implies the backend wake token is still undelivered (the
+#    eventfd / EVFILT_USER event / IOCP packet stays readable until consumed),
+#    so the poller cannot block again without first consuming it.
+# 2. Wakers publish the state they want the poller to observe under
+#    `state.lock` *before* attempting the wake (heap pushes here,
+#    `running = false` in `shutdown!`), and the poller re-acquires
+#    `state.lock` every cycle between consuming a wake and sleeping again
+#    (`_poll_delay_ns`, the expired-entry drain) — so state published before a
+#    failed CAS is always observed before the next sleep.
+#
+# The `poll_until_ns` read below is protected the same way: the poller stores
+# it under `state.lock` in `_poll_delay_ns`, so a waker whose heap push was
+# not seen by the poller's latest peek necessarily reads the sleep horizon
+# that peek committed, and wakes if its deadline is earlier. `0` doubles as
+# "no horizon committed" and "sleeping without a timeout"; both must wake
+# unconditionally.
 @inline function _maybe_wake_for_earlier_time!(state::Poller, new_earliest::Int64)
     new_earliest > 0 || return nothing
     poll_until_ns = @atomic :acquire state.poll_until_ns
@@ -345,26 +365,25 @@ end
 Remove all expired time entries from the heap and dispatch them to their
 deadline or timer fire path.
 
-The heap lock is not held across fire callbacks. That keeps the critical
-section small and avoids lock-ordering problems with descriptor-local locks in
-`IOPoll`.
+Entries are popped and fired one at a time. The heap lock is still never held
+across fire callbacks (avoiding lock-ordering problems with descriptor-local
+locks in `IOPoll`), and the loop allocates nothing: it runs on the poller
+thread every cycle, and allocating on that thread has crashed under gVisor's
+sandbox.
 """
 function _drain_expired_time_entries!(state::Poller, now_ns::Int64)
-    expired = TimeEntry[]
-    lock(state.lock)
-    try
-        while true
-            entry = _time_peek_locked(state)
-            (entry === nothing || entry.deadline_ns > now_ns) && break
-            push!(expired, _time_pop_locked!(state))
+    while true
+        local entry::TimeEntry
+        lock(state.lock)
+        try
+            head = _time_peek_locked(state)
+            (head === nothing || head.deadline_ns > now_ns) && return nothing
+            entry = _time_pop_locked!(state)
+        finally
+            unlock(state.lock)
         end
-    finally
-        unlock(state.lock)
-    end
-    for entry in expired
         _fire_time_entry!(entry)
     end
-    return nothing
 end
 
 """

--- a/test/internal_poll_tests.jl
+++ b/test/internal_poll_tests.jl
@@ -35,6 +35,7 @@ function _ip_socketpair_stream()
         client >= 0 && SO.close_socket_nothrow(client)
         listener >= 0 && SO.close_socket_nothrow(listener)
     end
+end
 
 function _ip_close_fd(fd::Cint)
     fd < 0 && return nothing
@@ -184,7 +185,10 @@ end
             try
                 IP._set_nonblocking!(ipfd.sysfd)
                 IP.register!(ipfd)
-                IP.set_read_deadline!(ipfd, time_ns() + 100_000_000)
+                # Far-future deadline: it only exists so a live rseq can be
+                # captured and later fired stale. A short deadline races the
+                # test's own setup and can legitimately expire the waiter.
+                IP.set_read_deadline!(ipfd, time_ns() + 5_000_000_000)
                 stale_rseq = @atomic :acquire ipfd.pd.rseq
                 wait_started = Channel{Nothing}(1)
                 wait_task = errormonitor(Threads.@spawn begin
@@ -352,4 +356,3 @@ end
             end
         end
     end
-end

--- a/test/iopoll_runtime_tests.jl
+++ b/test/iopoll_runtime_tests.jl
@@ -487,4 +487,60 @@ end
             end
         end
         _el_log_test_progress("DONE: shutdown cancels active waiters and timers")
+        _el_log_test_progress("START: expired-entry drain fires without allocating")
+        @testset "expired-entry drain fires without allocating" begin
+            state = NP.Poller()
+            t1 = NP.TimerState()
+            t2 = NP.TimerState()
+            now = Int64(time_ns())
+            for (timer, offset) in ((t1, Int64(-2_000_000)), (t2, Int64(-1_000_000)))
+                @atomic :release timer.deadline_ns = now + offset
+                seq = @atomic timer.seq += UInt64(1)
+                entry = NP._timer_entry(now + offset, timer, seq)
+                lock(state.lock)
+                try
+                    NP._time_push_locked!(state, entry)
+                finally
+                    unlock(state.lock)
+                end
+            end
+            NP._drain_expired_time_entries!(state, now)
+            @test isempty(state.time_heap)
+            @test (@atomic :acquire t1.deadline_ns) == Int64(0)
+            @test (@atomic :acquire t2.deadline_ns) == Int64(0)
+            # Fired-but-unparked waiters latch NOTIFIED; check the latch
+            # directly so a drain regression fails instead of parking forever.
+            @test (@atomic :acquire t1.waiter.state) == NP.PollWaiterState.NOTIFIED
+            @test (@atomic :acquire t2.waiter.state) == NP.PollWaiterState.NOTIFIED
+            # The drain runs on the detached poller thread every cycle, and
+            # allocating there has crashed under gVisor's sandbox. Coverage
+            # instrumentation adds allocations, so only assert without it.
+            drained = NP._drain_expired_time_entries!(state, Int64(time_ns()))
+            @test drained === nothing
+            if Base.JLOptions().code_coverage == 0
+                allocs = @allocated NP._drain_expired_time_entries!(state, Int64(time_ns()))
+                @test allocs == 0
+            end
+        end
+        _el_log_test_progress("DONE: expired-entry drain fires without allocating")
+        _el_log_test_progress("START: shutdown wakes an idle poller promptly")
+        @testset "shutdown wakes an idle poller promptly" begin
+            NP.shutdown!()
+            state = NP.init!()
+            @test @atomic state.running
+            # Let the poller thread commit to its uncapped backend wait: with
+            # no registrations and no timers there is no poll timeout at all,
+            # so shutdown completing is exactly the backend wake working.
+            sleep(0.1)
+            shutdown_task = errormonitor(Threads.@spawn begin
+                NP.shutdown!()
+                return nothing
+            end)
+            @test _el_wait_task_done(shutdown_task, 10.0) != :timed_out
+            if istaskdone(shutdown_task)
+                wait(shutdown_task)
+                @test !(@atomic state.running)
+            end
+        end
+        _el_log_test_progress("DONE: shutdown wakes an idle poller promptly")
     end

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -6,7 +6,11 @@ const _TRIM_SUPPORTED = VERSION >= v"1.12.0-rc1"
 const _TRIM_PRE_RELEASE = !isempty(VERSION.prerelease)
 const _JULIAC_ENTRYPOINT_EXPR = "using JuliaC; if isdefined(JuliaC, :main); JuliaC.main(ARGS); else JuliaC._main_cli(ARGS); end"
 
-function _run_trim_compile(project_path::String, script_path::String, output_name::String; timeout_s::Float64 = 120.0, bundle_dir::Union{Nothing, String} = nothing)
+# Single-threaded Windows CI runners compile these cases at ~60-70s each
+# (healthy multi-threaded runners take ~35s), so a 120s budget was a
+# near-miss that flaked on slow runners. The wait returns as soon as the
+# process exits, so a generous budget costs nothing when healthy.
+function _run_trim_compile(project_path::String, script_path::String, output_name::String; timeout_s::Float64 = 240.0, bundle_dir::Union{Nothing, String} = nothing)
     julia_exe = joinpath(Sys.BINDIR, Base.julia_exename())
     cmd = if bundle_dir === nothing
         `$julia_exe --startup-file=no --history-file=no --code-coverage=none --project=$project_path -e $(_JULIAC_ENTRYPOINT_EXPR) -- --output-exe $output_name --project=$project_path --experimental --trim=safe $script_path`
@@ -37,9 +41,33 @@ function _run_command_with_timeout(cmd::Cmd; timeout_s::Float64, log_label::Stri
     catch
         ""
     finally
-        rm(output_path; force = true)
+        # A killed process tree can briefly keep the redirect target locked
+        # on Windows (unlink EBUSY); never let temp cleanup error the testset.
+        try
+            rm(output_path; force = true)
+        catch
+        end
     end
     return exit_code, output, timed_out
+end
+
+# `kill(proc)` only terminates the direct child, but juliac spawns workers
+# that inherit the stdout/stderr redirect. On Windows the survivors keep the
+# redirect file locked and keep consuming CPU under later test cases, so
+# terminate the whole tree there before killing the direct child.
+function _kill_process_tree!(proc::Base.Process)
+    @static if Sys.iswindows()
+        try
+            pid = getpid(proc)
+            pid > 0 && run(pipeline(ignorestatus(`taskkill /T /F /PID $pid`); stdout = devnull, stderr = devnull))
+        catch
+        end
+    end
+    try
+        kill(proc)
+    catch
+    end
+    return nothing
 end
 
 function _wait_process_with_timeout!(proc::Base.Process; timeout_s::Float64, log_label::String)
@@ -50,10 +78,7 @@ function _wait_process_with_timeout!(proc::Base.Process; timeout_s::Float64, log
         now = time()
         if now - started_at >= timeout_s
             timed_out = true
-            try
-                kill(proc)
-            catch
-            end
+            _kill_process_tree!(proc)
             break
         end
         if now >= next_log_at


### PR DESCRIPTION
Clean-room implementation of #125 (thanks @SimonDanisch for the diagnosis and measurements!) plus the robustness/test follow-ups from its review, in one PR.

## The core fix

A running poller roughly doubled every GC pause: `epoll_wait` ran as a GC-unsafe ccall, so stop-the-world had to wait out the in-flight wait slice. The 25ms `MAX_GC_UNSAFE_EPOLL_WAIT_MS` cap bounded that stall but baked it into every collection — and since package loading is GC-heavy and the poller starts eagerly in `__init__`, everything imported after Reseau loaded ~3.5x slower (#125 measured `import Makie` after HTTP at 7.3s vs 1.6s, and GC pauses 35 → 17ms = the no-poller baseline).

The cap was also **Linux-only**: kqueue (macOS/FreeBSD) and IOCP (Windows) have always run GC-safe blocking waits with **no timeout cap**, relying entirely on the explicit backend wake. This PR brings epoll in line with the model the other three platforms have been shipping:

- `epoll_wait` is now a `@gcsafe_ccall` against a **C-allocated** (`Libc.malloc`) event buffer, freed in `_backend_close!`. Keeping event delivery off the Julia heap removes the gVisor crash that originally forced the wait GC-unsafe (JuliaWeb/HTTP.jl#1266: gVisor's userspace epoll segfaulted writing into Julia-heap memory while the GC ran concurrently).
- The eventfd **wake write and drain read stay plain ccalls** — they're non-blocking (`EFD_NONBLOCK`), so they can't stall GC, and staying GC-unsafe means the kernel never touches their Julia-heap `Ref`s while the GC runs. Going GC-safe there would buy nothing and reintroduce the same hazard class (sentry writing into Julia-heap pages during concurrent GC) that the C buffer eliminates, just through a smaller window. This also matches kqueue, whose wake was already a plain ccall.
- With the stall gone, the cap is removed: an idle poller sleeps until the wake eventfd fires instead of spinning 40x/second.

## Robustness follow-ups (from the #125 review)

- **Alloc-free expired-entry drain.** `_drain_expired_time_entries!` allocated a `TimeEntry[]` every poll cycle on the detached poller thread — the site of the *second* gVisor crash in JuliaWeb/HTTP.jl#1266 (at startup, driven by the cap's idle 25ms wakeups, `Allocations: 1; GC: 0`). It now pops and fires entries one at a time, allocation-free, still never holding the heap lock across fire callbacks.
- **Crash path can't strand `shutdown!`.** `_poller_thread_entry`'s catch now notifies `shutdown_event` in a `finally`, so a throwing waiter notification can't leave `shutdown!` waiting forever on an event that never fires.
- **Invariants documented where future refactors would break them:**
  - the wake coalescing contract (why losing the `wake_sig` CAS is safe) at `_maybe_wake_for_earlier_time!` — this is the protocol that makes uncapped sleeping correct, and it's subtle: it relies on wakers publishing state under `state.lock` *before* the CAS, and the poller re-acquiring `state.lock` every cycle;
  - `_backend_close!` must only run after the poller thread has exited (the buffer free would otherwise race a kernel write through a dangling pointer);
  - the shutdown wake-failure path intentionally leaks the backend rather than freeing memory the kernel may still write.

## Tests

- **New: "shutdown wakes an idle poller promptly"** — init, let the poller commit to its uncapped indefinite wait, then assert `shutdown!` completes (timeout-wrapped so a missed wake fails the test instead of hanging CI). This is the exact failure mode the 25ms cap used to mask.
- **New: "expired-entry drain fires without allocating"** — correctness of the one-at-a-time drain plus a zero-allocation regression guard (skipped under coverage instrumentation).
- **Resurrected `test/internal_poll_tests.jl` (103 tests).** A missing `end` on `_ip_socketpair_stream` made the entire file one giant never-called function definition **since the day it was added** (#60) — it has never run a single test, in CI or anywhere. The fix is two lines of structure. One testset then needed a real fix: "wait_read retries stale canceled wake internally" raced its own 100ms read deadline against test setup (first-run compile cost alone exceeds it; verified the deadline machinery itself fires within ~2ms of the requested time). The deadline only exists to capture an `rseq`, so it's now comfortably far in the future.

## Validation

| Platform | What ran | Result |
|---|---|---|
| macOS (kqueue) | full test suite, t1 + t2 | pass |
| Linux, Julia 1.12 (native `gc_safe` ccall) | iopoll runtime + internal poll suites in Docker | pass (58 + 103) |
| Linux, Julia 1.10 (`jl_gc_safe_enter`/`leave` fallback shim) | CI "min" jobs on this PR (ubuntu/macOS/Windows); same shim kqueue has shipped on macOS 1.10 since March | pass |
| Linux idle-poller GC pauses | branch vs main microbenchmark | stall removed (numbers below) |

GC pause benchmark (Linux/Docker, Julia 1.12, idle poller running, 150 full collections with allocation churn):

| | median | p90 | max |
|---|---|---|---|
| main (GC-unsafe + 25ms cap) | 71.99ms | 78.51ms | 81.52ms |
| this PR (GC-safe, uncapped) | **26.24ms** | **28.47ms** | **32.73ms** |

A full collection has multiple stop-the-world phases and each one was waiting out the in-flight `epoll_wait` slice; with the wait GC-safe the poller no longer appears in pause times at all.

## The one thing this PR can't verify: gVisor

The original A/B test in JuliaWeb/HTTP.jl#1266 established: GC-safe + Julia-heap buffer **crashes**; GC-unsafe + either buffer is fine; **GC-safe + malloc buffer — the combination this PR ships — was never run under gVisor.** It's the cell that discriminates "the sentry writing into GC-managed pages during concurrent GC" (this PR's theory, and the best fit for the data) from "something else about the GC-safe state on the adopted thread". Either way this PR is a strict improvement for everyone not on gVisor and no worse than pre-#118 for gVisor users, but:

- [ ] ask @gsoleilhac to re-run the JuliaWeb/HTTP.jl#1266 MWE under `runsc` against this branch before that issue is closed (the alloc-free drain in this PR should also address the second crash reported there)

Supersedes #125.

