### PR TITLE
Register poller shutdown during precompile output generation

### DIFF
--- a/src/iopoll/runtime.jl
+++ b/src/iopoll/runtime.jl
@@ -432,6 +432,7 @@ end
 function __init__()
     _POLLER_THREAD_ENTRY_C[] = @cfunction(_poller_thread_entry, Ptr{Cvoid}, (Ptr{Cvoid},))
     if _is_generating_output()
+        atexit(shutdown!)
         POLLER[] = Poller()
     elseif _runtime_supported()
         @static if Sys.iswindows()


### PR DESCRIPTION
## Summary

Register `shutdown!` with `atexit` from the `IOPoll.__init__` output-generation path.

This keeps normal runtime startup/exit behavior unchanged, but ensures that a downstream precompile worker tears down Reseau's detached poller thread if a `@compile_workload` lazily starts it.

## Context

PR #128 reports a real hang: a downstream `@compile_workload` can perform same-process loopback I/O, call `init!()` lazily, and start Reseau's detached poller thread while Julia is generating precompile output. Once the workload body completes, that native thread can remain blocked indefinitely in the backend wait, preventing the precompile worker process from exiting.

I reproduced the failure on `origin/main` with PR #128's regression harness. The worker timed out before printing `PRECOMPILE_DONE`, and the killed process showed it was stuck in `kevent` on macOS. The same harness passed with this one-line change.

## Reasoning

The important invariant is that output-generation processes need an automatic cleanup hook before any downstream workload can lazily start the poller. `__init__()` already has a special `jl_generating_output` branch that avoids eager poller startup by assigning an inert `Poller()` state. Registering `atexit(shutdown!)` in that branch is enough:

- If no workload starts the poller, `shutdown!` is harmless at process exit.
- If a workload does start the poller, `shutdown!` wakes the backend wait and waits for the poller thread to report shutdown before closing backend resources.
- The hook is registered once per module load in the current process, and `atexit` registrations do not survive into later processes.

That makes a separate atomic guard and lazy-registration helper unnecessary for this failure mode.

## Validation

Ran PR #128's downstream `Pkg.precompile()` regression harness against this branch:

```text
Test Summary:                              | Pass  Total   Time
Precompile loopback workload does not hang |    3      3  12.6s
```

Co-authored by Codex