### PR TITLE
Support GC-unsafe epoll waits for embedded runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ artifacts and JLLs so runtime libraries like OpenSSL are available next to the
 built executable. The trim-compile tests in `test/trim_compile_tests.jl`
 exercise that path directly.
 
+## Embedded Runtime Poller Note
+
+On Linux, the dedicated epoll thread uses a GC-safe wait by default. An
+embedded or trim-compiled runtime whose foreign-thread callbacks cannot safely
+return from a GC-safe call can set `RESEAU_EPOLL_WAIT_GCSAFE=0`. Reseau then
+uses GC-unsafe waits capped at 25 ms, which avoids that transition while
+bounding the longest GC delay caused by an idle poller.
+
 ## Development Note
 
 This rewrite made significant use of AI assistance for the initial Go-to-Julia

--- a/src/iopoll/epoll.jl
+++ b/src/iopoll/epoll.jl
@@ -10,6 +10,7 @@ const EPOLL_CLOEXEC = Cint(0x80000)
 const EFD_NONBLOCK = Cint(0x800)
 const EFD_CLOEXEC = Cint(0x80000)
 const MAX_EPOLL_EVENTS = 128
+const MAX_GC_UNSAFE_EPOLL_WAIT_MS = Cint(25)
 const _WAKE_TOKEN = UInt64(0)
 
 # Mirror of Linux `struct epoll_event`.
@@ -59,7 +60,13 @@ mutable struct EpollBackendState <: BackendState
     # writing into Julia-heap memory during concurrent GC. Plain C memory
     # keeps event delivery entirely outside GC-managed pages.
     events::Ptr{EpollEvent}
+    wait_gc_safe::Bool
     @atomic wake_sig::UInt32
+end
+
+@inline function _epoll_wait_gc_safe_enabled()::Bool
+    value = strip(lowercase(get(ENV, "RESEAU_EPOLL_WAIT_GCSAFE", "1")))
+    return !(isempty(value) || value == "0" || value == "false" || value == "no" || value == "off")
 end
 
 """
@@ -92,7 +99,7 @@ function _backend_init!(state::Poller)::Int32
         @ccall close(epfd::Cint)::Cint
         return Int32(Base.Libc.ENOMEM)
     end
-    state.backend_state = EpollBackendState(epfd, efd, events, UInt32(0))
+    state.backend_state = EpollBackendState(epfd, efd, events, _epoll_wait_gc_safe_enabled(), UInt32(0))
     return Int32(0)
 end
 
@@ -100,8 +107,8 @@ end
 Close epoll backend resources.
 
 Only safe after the poller thread has exited (`shutdown!` waits on
-`shutdown_event` before calling this): the backend wait has no timeout cap,
-so the thread can be parked in `epoll_wait` indefinitely, and freeing the
+`shutdown_event` before calling this): the default backend wait has no timeout
+cap, so the thread can be parked in `epoll_wait` indefinitely, and freeing the
 event buffer under a live wait would hand the kernel a dangling pointer.
 """
 function _backend_close!(state::Poller)
@@ -233,6 +240,32 @@ end
     return Cint(1_000_000_000)
 end
 
+@inline function _epoll_effective_wait_timeout_ms(waitms::Cint, wait_gc_safe::Bool)::Cint
+    wait_gc_safe && return waitms
+    return waitms < 0 ? MAX_GC_UNSAFE_EPOLL_WAIT_MS : min(waitms, MAX_GC_UNSAFE_EPOLL_WAIT_MS)
+end
+
+@inline function _epoll_wait!(
+        epoll::EpollBackendState,
+        events::Ptr{EpollEvent},
+        waitms::Cint,
+    )::Cint
+    if epoll.wait_gc_safe
+        return @gcsafe_ccall epoll_wait(
+            epoll.epfd::Cint,
+            events::Ptr{EpollEvent},
+            Cint(MAX_EPOLL_EVENTS)::Cint,
+            waitms::Cint,
+        )::Cint
+    end
+    return @ccall epoll_wait(
+        epoll.epfd::Cint,
+        events::Ptr{EpollEvent},
+        Cint(MAX_EPOLL_EVENTS)::Cint,
+        waitms::Cint,
+    )::Cint
+end
+
 @inline function _decode_epoll_mode(events::UInt32)
     mode = UInt8(0x00)
     (events & (EPOLLIN | EPOLLRDHUP | EPOLLHUP | EPOLLERR)) != UInt32(0) && (mode |= UInt8(PollMode.READ))
@@ -250,26 +283,20 @@ function _backend_poll_once!(state::Poller, delay_ns::Int64)::Int32
     epoll = backend::EpollBackendState
     events = epoll.events
     events == C_NULL && return Int32(Base.Libc.EBADF)
-    waitms = _epoll_wait_timeout_ms(delay_ns)
-    # The wait runs as a GC-safe ccall so a blocked poller never stalls
-    # stop-the-world: a GC-unsafe wait added its remaining timeout to every GC
-    # pause, and the 25ms cap that used to bound the stall taxed every
-    # collection while forcing an idle poller to wake 40 times a second. The
-    # event buffer is C memory (see `EpollBackendState`), so neither the
-    # kernel nor gVisor's userspace epoll touches the Julia heap while the GC
-    # runs, and no cap is needed: an idle poller sleeps until the wake eventfd
-    # fires, matching the kqueue and IOCP backends.
+    waitms = _epoll_effective_wait_timeout_ms(
+        _epoll_wait_timeout_ms(delay_ns),
+        epoll.wait_gc_safe,
+    )
+    # GC-safe waiting is the default and lets an idle poller sleep until its
+    # eventfd wakes. Trimmed or embedded runtimes that cannot safely return
+    # from a GC-safe call on this foreign pthread can set
+    # RESEAU_EPOLL_WAIT_GCSAFE=0. That path stays GC-unsafe and caps each wait
+    # so the poller can delay a collection by at most 25ms.
     while true
-        n = @gcsafe_ccall epoll_wait(
-            epoll.epfd::Cint,
-            events::Ptr{EpollEvent},
-            Cint(MAX_EPOLL_EVENTS)::Cint,
-            waitms::Cint,
-        )::Cint
+        n = _epoll_wait!(epoll, events, waitms)
         if n == Cint(-1)
-            # Relies on the GC-safe transition back (which can block on a
-            # running collection) not clobbering errno; futex waits on
-            # glibc/musl do not touch it.
+            # The GC-safe path can wait for a running collection before it
+            # returns here. Its glibc/musl futex wait does not clobber errno.
             errno = Int32(Base.Libc.errno())
             if errno == Int32(Base.Libc.EINTR)
                 waitms > 0 && return Int32(0)

--- a/test/internal_poll_tests.jl
+++ b/test/internal_poll_tests.jl
@@ -100,6 +100,34 @@ end
             @test err isa ErrorException
             @test occursin("got 5 from a write of 4", sprint(showerror, err))
         end
+        @static if Sys.islinux()
+            @testset "epoll GC-safe wait configuration" begin
+                @test IP._epoll_wait_gc_safe_enabled()
+                withenv("RESEAU_EPOLL_WAIT_GCSAFE" => "0") do
+                    @test !IP._epoll_wait_gc_safe_enabled()
+                end
+                withenv("RESEAU_EPOLL_WAIT_GCSAFE" => "false") do
+                    @test !IP._epoll_wait_gc_safe_enabled()
+                end
+                @test IP._epoll_effective_wait_timeout_ms(Cint(-1), true) == Cint(-1)
+                @test IP._epoll_effective_wait_timeout_ms(Cint(-1), false) == Cint(25)
+                @test IP._epoll_effective_wait_timeout_ms(Cint(10), false) == Cint(10)
+                @test IP._epoll_effective_wait_timeout_ms(Cint(100), false) == Cint(25)
+                withenv("RESEAU_EPOLL_WAIT_GCSAFE" => "0") do
+                    state = IP.init!()
+                    try
+                        backend = state.backend_state
+                        @test backend isa IP.EpollBackendState
+                        @test !(backend::IP.EpollBackendState).wait_gc_safe
+                        for _ in 1:4
+                            GC.gc()
+                        end
+                    finally
+                        IP.shutdown!()
+                    end
+                end
+            end
+        end
         @testset "read waits then wakes on readability" begin
             fd0, fd1 = _ip_socketpair_stream()
             ipfd = IP.FD(fd0)


### PR DESCRIPTION
## Summary
- add `RESEAU_EPOLL_WAIT_GCSAFE=0` for embedded and trim-compiled runtimes that cannot safely return from a GC-safe call on the foreign poller thread
- cap fallback epoll waits at 25 ms so an idle poller cannot block garbage collection indefinitely
- cover configuration, timeout bounds, and repeated full collections on Linux

## Motivation
A trim-compiled LeagueEasy process on Fly.io reliably crashed during PostgreSQL reconnect allocation. A two-signal GDB trace showed the first SIGSEGV was Julia's expected GC safepoint and the fatal second SIGSEGV occurred on the Reseau poller immediately after returning from `@gcsafe_ccall epoll_wait`. The fallback preserves the existing fast path by default and gives affected embedded runtimes an explicit bounded alternative.

## Validation
- Linux full test suite with 2 Julia threads: pass
- Linux fallback poller test with repeated `GC.gc()`: pass
- macOS focused poller suite: pass
- LeagueEasy trim/Fly validation will pin this exact commit

Co-authored by Codex