### PR TITLE
Fix IOCP buffer and OVERLAPPED lifetime races

### DIFF
--- a/src/3_tcp.jl
+++ b/src/3_tcp.jl
@@ -853,8 +853,8 @@ end
     return IOPoll.read!(conn.fd.pfd, buf)
 end
 
-@inline function _read_some!(conn::Conn, ptr::Ptr{UInt8}, nbytes::Int)::Int
-    return IOPoll._read_ptr_some!(conn.fd.pfd, ptr, nbytes)
+@inline function _read_some!(conn::Conn, ptr::Ptr{UInt8}, nbytes::Int, root=nothing)::Int
+    return IOPoll._read_ptr_some!(conn.fd.pfd, ptr, nbytes, root)
 end
 
 function _grow_readbytes_target!(buf::Vector{UInt8}, current::Int, nb::Int)::Int
@@ -937,7 +937,7 @@ function _readbytes_all!(conn::Conn, buf::Vector{UInt8}, requested::Int)::Int
         end
         chunk_capacity = min(current_len - bytes_read, requested - bytes_read)
         n = try
-            GC.@preserve buf _read_some!(conn, pointer(buf, bytes_read + 1), chunk_capacity)
+            GC.@preserve buf _read_some!(conn, pointer(buf, bytes_read + 1), chunk_capacity, buf)
         catch err
             ex = err::Exception
             ex isa EOFError || rethrow(ex)
@@ -955,7 +955,7 @@ function _readbytes_some!(conn::Conn, buf::Vector{UInt8}, requested::Int)::Int
     original_len = length(buf)
     requested > original_len && resize!(buf, requested)
     bytes_read = try
-        GC.@preserve buf _read_some!(conn, pointer(buf), requested)
+        GC.@preserve buf _read_some!(conn, pointer(buf), requested, buf)
     catch err
         ex = err::Exception
         ex isa EOFError || rethrow(ex)
@@ -973,7 +973,7 @@ function _readbytes_all!(conn::Conn, buf::MutableByteBuffer, requested::Int)::In
     bytes_read = 0
     while bytes_read < requested
         n = try
-            GC.@preserve buf _read_some!(conn, pointer(buf, bytes_read + 1), requested - bytes_read)
+            GC.@preserve buf _read_some!(conn, pointer(buf, bytes_read + 1), requested - bytes_read, buf)
         catch err
             ex = err::Exception
             ex isa EOFError || rethrow(ex)
@@ -987,7 +987,7 @@ end
 function _readbytes_some!(conn::Conn, buf::MutableByteBuffer, requested::Int)::Int
     requested <= length(buf) || throw(ArgumentError("nb exceeds fixed-size buffer length"))
     return try
-        GC.@preserve buf _read_some!(conn, pointer(buf), requested)
+        GC.@preserve buf _read_some!(conn, pointer(buf), requested, buf)
     catch err
         ex = err::Exception
         ex isa EOFError || rethrow(ex)
@@ -1100,6 +1100,10 @@ function Base.flush(::Conn)
     return nothing
 end
 
+@inline function _write_rooted!(conn::Conn, ptr::Ptr{UInt8}, nbytes::Int, root)::Int
+    return IOPoll._write_ptr!(conn.fd.pfd, ptr, nbytes, root)
+end
+
 """
     write(conn, byte::UInt8) -> Int
 
@@ -1108,7 +1112,7 @@ Write one byte to the connection and return `1`.
 function Base.write(conn::Conn, byte::UInt8)::Int
     ref = Ref{UInt8}(byte)
     GC.@preserve ref begin
-        return Int(Base.unsafe_write(conn, Base.unsafe_convert(Ptr{UInt8}, ref), UInt(1)))
+        return _write_rooted!(conn, Base.unsafe_convert(Ptr{UInt8}, ref), 1, ref)
     end
 end
 
@@ -1134,28 +1138,28 @@ Base.write(conn::Conn, buf::AbstractVector{UInt8})
 
 function Base.write(conn::Conn, buf::Vector{UInt8})::Int
     GC.@preserve buf begin
-        return Int(Base.unsafe_write(conn, pointer(buf), UInt(length(buf))))
+        return _write_rooted!(conn, pointer(buf), length(buf), buf)
     end
 end
 
 function Base.write(conn::Conn, buf::StridedVector{UInt8})::Int
     if stride(buf, 1) == 1
-        return GC.@preserve buf Int(Base.unsafe_write(conn, pointer(buf), UInt(length(buf))))
+        return GC.@preserve buf _write_rooted!(conn, pointer(buf), length(buf), buf)
     end
     data = Vector{UInt8}(buf)
     GC.@preserve data begin
-        return Int(Base.unsafe_write(conn, pointer(data), UInt(length(data))))
+        return _write_rooted!(conn, pointer(data), length(data), data)
     end
 end
 
 function Base.write(conn::Conn, buf::Base.CodeUnits{UInt8,<:AbstractString})::Int
-    return write(conn, buf.s)
+    return GC.@preserve buf _write_rooted!(conn, pointer(buf), length(buf), buf)
 end
 
 function Base.write(conn::Conn, buf::AbstractVector{UInt8})::Int
     data = Vector{UInt8}(buf)
     GC.@preserve data begin
-        return Int(Base.unsafe_write(conn, pointer(data), UInt(length(data))))
+        return _write_rooted!(conn, pointer(data), length(data), data)
     end
 end
 
@@ -1174,7 +1178,7 @@ function Base.write(conn::Conn, buf::ByteMemory, nbytes::Integer)::Int
     n < 0 && throw(ArgumentError("nbytes must be >= 0"))
     n <= length(buf) || throw(ArgumentError("nbytes exceeds buffer length"))
     GC.@preserve buf begin
-        return Int(Base.unsafe_write(conn, pointer(buf), UInt(n)))
+        return _write_rooted!(conn, pointer(buf), n, buf)
     end
 end
 

--- a/src/iopoll/fd.jl
+++ b/src/iopoll/fd.jl
@@ -45,6 +45,12 @@ const _MAX_RW = 1 << 30
 
 @inline _max_rw_chunk(nbytes::Int)::Int = min(nbytes, _MAX_RW)
 
+# A raw pointer does not identify the Julia object that owns its memory. On
+# Windows, copy pointer-only I/O through a bounded, op-rooted buffer so an
+# exceptional cancellation/shutdown path can never leave the kernel accessing
+# caller memory after the unsafe_read/unsafe_write call has unwound.
+const _MAX_IOCP_RAW_BUFFER = 64 * 1024
+
 @inline function _checked_write_advance(total::Int, wrote::Int, requested::Int)::Int
     wrote > requested && throw(ErrorException("invalid return from write: got $wrote from a write of $requested"))
     return total + wrote
@@ -444,37 +450,38 @@ function _wait_iocp_completion!(registration::Registration, pd::PollState, mode:
     while true
         reason = pollwait!(waiter)
         err = _check_error(pd, mode)
+        # READY dominates a latched CANCELED token in PollWaiter. Honor a
+        # concurrently published deadline/close error before consulting the
+        # operation fence, otherwise that only error wake can be consumed as
+        # stale readiness and the task may park forever.
+        err == _POLL_NO_ERROR || _convert_poll_error!(err, is_file)
         if reason == PollWakeReason.READY
             _iocp_mode_active(registration, mode) && continue
-            _convert_poll_error!(err, is_file)
             return nothing
         end
-        err == _POLL_NO_ERROR && continue
-        _convert_poll_error!(err, is_file)
+        continue
     end
 end
 
 """
-Drain a deadline/close-interrupted Windows overlapped operation until the
-kernel no longer owns it.
+Retire a deadline/close-interrupted Windows overlapped operation.
 
-After `CancelIoEx` the kernel may keep writing through the submitted
-WSARecv/WSASend buffer until the operation's completion packet is delivered;
-the zombie machinery pins the OVERLAPPED but not the caller's data buffer, so
-returning (and leaving the caller's `GC.@preserve`) before that completion
-arrives could let the kernel scribble on reclaimed memory. Mirroring Go's
-`fd_windows.go` `execIO`, this waits for the completion unconditionally,
-looping until a finish call reports the operation is no longer in flight
-(anything other than `EAGAIN`, the mapping of `ERROR_IO_INCOMPLETE`).
+After `CancelIoEx` the operation remains in flight until its completion packet
+is consumed. Mirroring Go's `fd_windows.go` `execIO`, this waits while the
+runtime is available, looping until finish reports anything other than
+`EAGAIN`. If global shutdown has already made lookup unavailable, the op-rooted
+buffer and OVERLAPPED remain owned by the backend until its synchronous drain.
 
 Wake reasons are ignored on purpose: a concurrent close's `evict!` fires
 CANCELED wakes at every waiter before the completion is delivered, and the
-drain must keep waiting through those. That is safe because the caller holds
-the fd read/write lock, so `_destroy!` (and therefore `deregister!`) cannot
-tear down the registration until the drain returns, and the running poller
-thread always dispatches a wake when it processes the completion packet. If
-the poller has shut down instead, the finish call fails its registration
-lookup (`EBADF`) and the loop exits rather than parking forever.
+drain must keep waiting through those. The caller holds the fd read/write lock,
+so `_destroy!` (and therefore `deregister!`) cannot tear down the registration
+until the drain returns.
+
+Every READ/WRITE operation independently roots its submitted buffer. For
+pointer-only APIs that buffer is a bounded copy, so an unavailable runtime may
+return `EBADF` here while global shutdown finishes draining without exposing
+caller-owned memory to the kernel.
 """
 function _drain_canceled_iocp_op!(registration::Registration, mode::PollMode.T)
     canceled = _iocp_cancel_mode!(registration, mode)
@@ -483,9 +490,8 @@ function _drain_canceled_iocp_op!(registration::Registration, mode::PollMode.T)
         canceled && pollwait!(waiter)
         _, errno = mode == PollMode.WRITE ? _iocp_finish_write!(registration) : _iocp_finish_read!(registration)
         errno == Int32(Base.Libc.EAGAIN) || return nothing
-        # Still ERROR_IO_INCOMPLETE: the operation remains in flight, so keep
-        # waiting for its completion wake (tolerating eviction CANCELED wakes
-        # consumed along the way).
+        # The completion packet has not been consumed yet. Keep waiting through
+        # stale deadline/close wakes until the poller dispatches it.
         canceled = true
     end
 end
@@ -771,8 +777,8 @@ end
 
 # `root` (when given) is the object backing `p`; on Windows it is rooted in the
 # overlapped op so the kernel-owned WSARecv buffer stays reachable for the op's
-# full lifetime. Raw-pointer callers (e.g. tcp `unsafe` reads) pass nothing and
-# rely on their own `GC.@preserve` plus the cancel/drain path.
+# full lifetime. Pointer-only callers are copied through an op-rooted bounce
+# buffer because a pointer alone cannot keep its Julia owner alive.
 function _read_ptr_some!(fd::FD, p::Ptr{UInt8}, nbytes::Int, root=nothing)::Int
     _fd_read_lock!(fd)
     try
@@ -780,28 +786,36 @@ function _read_ptr_some!(fd::FD, p::Ptr{UInt8}, nbytes::Int, root=nothing)::Int
         @static if Sys.iswindows()
             prepareread(fd.pd, fd.is_file)
             registration = _poll_registration(fd.pd)
-            n = UInt32(_max_rw_chunk(nbytes))
-            while true
-                errno = _iocp_submit_read!(registration, p, n, root)
-                errno == Int32(0) && break
-                if errno == Int32(Base.Libc.EALREADY)
-                    waitread(fd.pd, fd.is_file)
-                    continue
+            raw_pointer = root === nothing
+            n = raw_pointer ?
+                UInt32(min(_max_rw_chunk(nbytes), _MAX_IOCP_RAW_BUFFER)) :
+                UInt32(_max_rw_chunk(nbytes))
+            io_root = raw_pointer ? Vector{UInt8}(undef, Int(n)) : root
+            io_ptr = raw_pointer ? pointer(io_root::Vector{UInt8}) : p
+            return GC.@preserve io_root begin
+                while true
+                    errno = _iocp_submit_read!(registration, io_ptr, n, io_root)
+                    errno == Int32(0) && break
+                    if errno == Int32(Base.Libc.EALREADY)
+                        waitread(fd.pd, fd.is_file)
+                        continue
+                    end
+                    throw(SystemError("read", Int(errno)))
                 end
-                throw(SystemError("read", Int(errno)))
+                try
+                    _wait_iocp_completion!(registration, fd.pd, PollMode.READ, fd.is_file)
+                catch err
+                    _drain_canceled_iocp_op!(registration, PollMode.READ)
+                    rethrow(err)
+                end
+                bytes, result = _iocp_finish_read!(registration)
+                result == Int32(0) || throw(SystemError("read", Int(result)))
+                if bytes == UInt32(0) && fd.zero_read_is_eof
+                    throw(EOFError())
+                end
+                raw_pointer && unsafe_copyto!(p, io_ptr, Int(bytes))
+                return Int(bytes)
             end
-            try
-                _wait_iocp_completion!(registration, fd.pd, PollMode.READ, fd.is_file)
-            catch err
-                _drain_canceled_iocp_op!(registration, PollMode.READ)
-                rethrow(err)
-            end
-            bytes, result = _iocp_finish_read!(registration)
-            result == Int32(0) || throw(SystemError("read", Int(result)))
-            if bytes == UInt32(0) && fd.zero_read_is_eof
-                throw(EOFError())
-            end
-            return Int(bytes)
         end
         # Avoid taking the global poller lock before every successful read.
         # If the read would block, `waitread` refreshes backend event state
@@ -864,32 +878,50 @@ function write!(fd::FD, p::ByteMemory, nbytes::Integer)::Int
 end
 
 # See `_read_ptr_some!`: `root`, when supplied, keeps the WSASend source buffer
-# reachable for the overlapped op's full lifetime on Windows.
+# reachable for the overlapped op's full lifetime on Windows. Pointer-only
+# callers use the same bounded bounce-buffer fallback.
 function _write_ptr!(fd::FD, p::Ptr{UInt8}, nbytes::Int, root=nothing)::Int
     _fd_write_lock!(fd)
     nn = 0
     try
         @static if Sys.iswindows()
+            raw_pointer = root === nothing
+            bounce = raw_pointer ?
+                Vector{UInt8}(undef, min(nbytes, _MAX_IOCP_RAW_BUFFER)) :
+                nothing
             while nn < nbytes
                 preparewrite(fd.pd, fd.is_file)
                 registration = _poll_registration(fd.pd)
-                chunk = UInt32(_max_rw_chunk(nbytes - nn))
-                while true
-                    errno = _iocp_submit_write!(registration, p + nn, chunk, root)
-                    errno == Int32(0) && break
-                    if errno == Int32(Base.Libc.EALREADY)
-                        waitwrite(fd.pd, fd.is_file)
-                        continue
+                chunk_int = raw_pointer ?
+                    min(nbytes - nn, _MAX_IOCP_RAW_BUFFER) :
+                    _max_rw_chunk(nbytes - nn)
+                chunk = UInt32(chunk_int)
+                io_root = raw_pointer ? bounce::Vector{UInt8} : root
+                io_ptr = p + nn
+                if raw_pointer
+                    GC.@preserve io_root unsafe_copyto!(pointer(io_root), io_ptr, chunk_int)
+                    io_ptr = pointer(io_root)
+                end
+                bytes = UInt32(0)
+                result = Int32(0)
+                GC.@preserve io_root begin
+                    while true
+                        errno = _iocp_submit_write!(registration, io_ptr, chunk, io_root)
+                        errno == Int32(0) && break
+                        if errno == Int32(Base.Libc.EALREADY)
+                            waitwrite(fd.pd, fd.is_file)
+                            continue
+                        end
+                        throw(SystemError("write", Int(errno)))
                     end
-                    throw(SystemError("write", Int(errno)))
+                    try
+                        _wait_iocp_completion!(registration, fd.pd, PollMode.WRITE, fd.is_file)
+                    catch err
+                        _drain_canceled_iocp_op!(registration, PollMode.WRITE)
+                        rethrow(err)
+                    end
+                    bytes, result = _iocp_finish_write!(registration)
                 end
-                try
-                    _wait_iocp_completion!(registration, fd.pd, PollMode.WRITE, fd.is_file)
-                catch err
-                    _drain_canceled_iocp_op!(registration, PollMode.WRITE)
-                    rethrow(err)
-                end
-                bytes, result = _iocp_finish_write!(registration)
                 result == Int32(0) || throw(SystemError("write", Int(result)))
                 bytes == UInt32(0) && throw(EOFError())
                 nn = _checked_write_advance(nn, Int(bytes), Int(chunk))

--- a/src/iopoll/iocp.jl
+++ b/src/iopoll/iocp.jl
@@ -115,12 +115,12 @@ mutable struct IocpOp
     token::UInt64
     kind::IocpOpKind.T
     request::IocpRequest
-    # Strong reference to the caller's data buffer for the full lifetime of a
+    # Strong reference to the submitted data buffer for the full lifetime of a
     # READ/WRITE overlapped op, mirroring how CONNECT/ACCEPT root their address
-    # buffer via `request`. The kernel keeps writing through the submitted
-    # WSARecv/WSASend buffer until the completion packet is delivered, so the op
-    # must keep the backing object reachable even if it ever outlives the
-    # caller's `GC.@preserve` scope. Cleared on terminal (non-EAGAIN) finish.
+    # buffer via `request`. This is either the caller's backing object or the
+    # bounded bounce buffer used by pointer-only APIs. The kernel retains the
+    # WSARecv/WSASend pointer until the completion packet is delivered, so the
+    # op must keep that object reachable until terminal finish.
     buffer::Any
     @atomic active::Bool
 end
@@ -137,6 +137,7 @@ end
 mutable struct IocpBackendState <: BackendState
     port::Ptr{Cvoid}
     entries::Vector{OverlappedEntry}
+    ready_events::Vector{PollEvent}
     by_fd::Dict{SysFD, IocpRegistration}
     by_ptr::Dict{Ptr{Cvoid}, IocpRegistration}
     zombies::Vector{IocpRegistration}
@@ -317,6 +318,16 @@ function _cleanup_registration_if_done!(backend::IocpBackendState, reg::IocpRegi
     return nothing
 end
 
+"""
+Request cancellation of an active overlapped operation.
+
+The return value says whether a completion packet is still owed and must be
+drained, not whether `CancelIoEx` itself found and canceled the request.
+`ERROR_NOT_FOUND` can mean that the operation has completed and its packet is
+already queued (or dequeued by the poller while it waits for `state.lock`).
+Only the completion consumer may clear `active`; until then the OVERLAPPED and
+its buffer roots must remain live and the storage must not be reused.
+"""
 function _cancel_iocp_op!(reg::IocpRegistration, op::IocpOp; strict::Bool = false)::Bool
     (@atomic :acquire op.active) || return false
     ok = @gcsafe_ccall _KERNEL32.CancelIoEx(
@@ -326,8 +337,10 @@ function _cancel_iocp_op!(reg::IocpRegistration, op::IocpOp; strict::Bool = fals
     if ok == 0
         err = _win_get_last_error()
         if err == _ERROR_NOT_FOUND
-            @atomic :release op.active = false
-            return false
+            # No request remains cancellable, but the completion packet is
+            # still the lifetime/reuse fence. In particular, GQCSEx may already
+            # have dequeued it while the poller is blocked on `state.lock`.
+            return true
         end
         # Ordinary deadline/close cancellation keeps waiting for terminal
         # completion even if cancellation itself failed. During global backend
@@ -352,6 +365,14 @@ function _submit_iocp_op!(
     )::Int32
     _, ok = @atomicreplace(op.active, false => true)
     ok || return Int32(Base.Libc.EALREADY)
+    if (kind == IocpOpKind.READ || kind == IocpOpKind.WRITE) && buffer === nothing
+        # An existing operation must win with EALREADY before validating the
+        # next request. The read/write wrappers clear a newly failed
+        # submission, so returning EINVAL for an already-active op would reset
+        # live OVERLAPPED storage before its completion packet is consumed.
+        _clear_iocp_op!(op)
+        return Int32(Base.Libc.EINVAL)
+    end
     if kind !== nothing
         op.kind = kind::IocpOpKind.T
         op.request = request
@@ -515,10 +536,16 @@ function _iocp_op_for_mode(reg::IocpRegistration, mode::PollMode.T)::IocpOp
     throw(ArgumentError("invalid IOCP mode"))
 end
 
-function _lookup_iocp_registration(registration::Registration)::Union{Nothing, IocpRegistration}
-    isassigned(POLLER) || return nothing
-    state = POLLER[]
+function _lookup_iocp_registration(
+        state::Poller,
+        registration::Registration,
+    )::Union{Nothing, IocpRegistration}
     (@atomic :acquire state.running) || return nothing
+    # Validate object identity, not only fd/token. Poller generations restart
+    # their token counter, so an old waiter must never alias a new registration
+    # after shutdown/re-init happens to reuse both values.
+    get(state.registrations_by_token, registration.token, nothing) === registration || return nothing
+    get(state.registrations, registration.fd, nothing) === registration || return nothing
     backend = _iocp_backend(state)
     backend === nothing && return nothing
     reg = get(backend.by_fd, registration.fd, nothing)
@@ -533,37 +560,41 @@ function _finish_iocp_mode!(registration::Registration, mode::PollMode.T)::Int32
 end
 
 function _finish_iocp_mode_with_bytes!(registration::Registration, mode::PollMode.T)::Tuple{UInt32, Int32}
+    isassigned(POLLER) || return UInt32(0), Int32(Base.Libc.EBADF)
     state = POLLER[]
-    reg = nothing
-    op = nothing
     lock(state.lock)
     try
-        reg = _lookup_iocp_registration(registration)
+        reg = _lookup_iocp_registration(state, registration)
         reg === nothing && return UInt32(0), Int32(Base.Libc.EBADF)
         op = _iocp_op_for_mode(reg, mode)
-    finally
-        unlock(state.lock)
-    end
-    bytes, result = _wsagetoverlappedresult_bytes(registration.fd, op::IocpOp)
-    lock(state.lock)
-    try
+        # `active` is the completion-packet fence. Even if
+        # WSAGetOverlappedResult could already report a terminal result, the
+        # OVERLAPPED cannot be reset or reused until GQCS[Ex] has consumed its
+        # packet and published active=false.
+        (@atomic :acquire op.active) &&
+            return UInt32(0), Int32(Base.Libc.EAGAIN)
+        bytes, result = _wsagetoverlappedresult_bytes(registration.fd, op)
         if result != Int32(Base.Libc.EAGAIN)
             _clear_iocp_op!(op)
         end
+        return bytes, result
     finally
         unlock(state.lock)
     end
-    return bytes, result
 end
 
 function _iocp_mode_active(registration::Registration, mode::PollMode.T)::Bool
-    isassigned(POLLER) || return false
+    # An unavailable registration is not evidence of terminal I/O: shutdown
+    # publishes running=false and clears the runtime maps before its synchronous
+    # IOCP drain. Be conservative so raw-pointer callers remain parked until
+    # shutdown marks their PollState closing after backend teardown.
+    isassigned(POLLER) || return true
     state = POLLER[]
-    (@atomic :acquire state.running) || return false
+    (@atomic :acquire state.running) || return true
     lock(state.lock)
     try
-        reg = _lookup_iocp_registration(registration)
-        reg === nothing && return false
+        reg = _lookup_iocp_registration(state, registration)
+        reg === nothing && return true
         op = _iocp_op_for_mode(reg, mode)
         return @atomic :acquire op.active
     finally
@@ -578,7 +609,7 @@ function _iocp_cancel_mode!(registration::Registration, mode::PollMode.T)::Bool
     canceled = false
     lock(state.lock)
     try
-        reg = _lookup_iocp_registration(registration)
+        reg = _lookup_iocp_registration(state, registration)
         reg === nothing && return false
         canceled = _cancel_iocp_op!(reg, _iocp_op_for_mode(reg, mode))
     finally
@@ -594,7 +625,7 @@ function _iocp_submit_read!(registration::Registration, ptr::Ptr{UInt8}, nbytes:
     errno = Int32(0)
     lock(state.lock)
     try
-        reg = _lookup_iocp_registration(registration)
+        reg = _lookup_iocp_registration(state, registration)
         reg === nothing && return Int32(Base.Libc.EBADF)
         op = reg.read_op
         errno = _submit_iocp_op!(registration, reg, op; ptr, nbytes, kind=IocpOpKind.READ, buffer=root)
@@ -618,7 +649,7 @@ function _iocp_submit_write!(registration::Registration, ptr::Ptr{UInt8}, nbytes
     errno = Int32(0)
     lock(state.lock)
     try
-        reg = _lookup_iocp_registration(registration)
+        reg = _lookup_iocp_registration(state, registration)
         reg === nothing && return Int32(Base.Libc.EBADF)
         op = reg.write_op
         errno = _submit_iocp_op!(registration, reg, op; ptr, nbytes, kind=IocpOpKind.WRITE, buffer=root)
@@ -642,7 +673,7 @@ function _iocp_submit_connect!(registration::Registration, addrbuf::Vector{UInt8
     errno = Int32(0)
     lock(state.lock)
     try
-        reg = _lookup_iocp_registration(registration)
+        reg = _lookup_iocp_registration(state, registration)
         reg === nothing && return Int32(Base.Libc.EBADF)
         op = reg.write_op
         request = IocpConnectRequest(addrbuf, addrlen)
@@ -667,7 +698,7 @@ function _iocp_submit_accept!(registration::Registration, acceptfd::SysFD, addrb
     errno = Int32(0)
     lock(state.lock)
     try
-        reg = _lookup_iocp_registration(registration)
+        reg = _lookup_iocp_registration(state, registration)
         reg === nothing && return Int32(Base.Libc.EBADF)
         op = reg.read_op
         request = IocpAcceptRequest(acceptfd, addrbuf)
@@ -682,11 +713,12 @@ function _iocp_submit_accept!(registration::Registration, acceptfd::SysFD, addrb
 end
 
 function _iocp_finish_accept!(registration::Registration)::Tuple{SysFD, Vector{UInt8}, Int32}
+    isassigned(POLLER) || return INVALID_FD, UInt8[], Int32(Base.Libc.EBADF)
     state = POLLER[]
     request = nothing
     lock(state.lock)
     try
-        reg = _lookup_iocp_registration(registration)
+        reg = _lookup_iocp_registration(state, registration)
         reg === nothing && return INVALID_FD, UInt8[], Int32(Base.Libc.EBADF)
         request = reg.read_op.request
     finally
@@ -708,6 +740,7 @@ function _backend_init!(state::Poller)::Int32
     state.backend_state = IocpBackendState(
         port,
         Vector{OverlappedEntry}(undef, _MAX_IOCP_EVENTS),
+        Vector{PollEvent}(undef, _MAX_IOCP_EVENTS),
         Dict{SysFD, IocpRegistration}(),
         Dict{Ptr{Cvoid}, IocpRegistration}(),
         IocpRegistration[],
@@ -930,6 +963,8 @@ function _backend_poll_once!(state::Poller, delay_ns::Int64)::Int32
         return _map_win_errno(err)
     end
     n = Int(removed[])
+    ready_events = backend.ready_events
+    ready_count = 0
     for i in 1:n
         entry = entries[i]
         if entry.key == _WAKE_KEY && entry.overlapped == C_NULL
@@ -982,7 +1017,20 @@ function _backend_poll_once!(state::Poller, delay_ns::Int64)::Int32
         end
         dispatch || continue
         status = UInt32(entry.internal & UInt(typemax(UInt32)))
-        _dispatch_ready_event!(state, PollEvent(INVALID_FD, token, mode, is_probe && status != UInt32(0)))
+        ready_count += 1
+        ready_events[ready_count] = PollEvent(
+            INVALID_FD,
+            token,
+            mode,
+            is_probe && status != UInt32(0),
+        )
+    end
+    # GQCSEx dequeues the whole batch atomically. Retire every corresponding
+    # operation above before any waiter dispatch can throw; otherwise a later
+    # entry could remain active even though its only completion packet was
+    # already removed, causing shutdown's synchronous drain to wait forever.
+    for i in 1:ready_count
+        _dispatch_ready_event!(state, ready_events[i])
     end
     return Int32(0)
 end

--- a/src/iopoll/runtime.jl
+++ b/src/iopoll/runtime.jl
@@ -119,6 +119,12 @@ function init!()::Poller
         if isassigned(POLLER)
             state = POLLER[]
             (@atomic state.running) && return state
+            # A stopped poller may still own a live backend (for example after
+            # its thread exited on an error). Fully retire that generation
+            # before replacing the only references to its registrations,
+            # OVERLAPPED storage, and data-buffer roots. POLLER_LOCK is
+            # reentrant, so shutdown! safely shares the canonical teardown path.
+            shutdown!()
         end
         _runtime_supported() || throw(ArgumentError("iopoll backend is currently supported on macOS, Linux, and Windows"))
         new_state = Poller()
@@ -160,10 +166,9 @@ ordered after `wait(state.shutdown_event)`: tearing down backend resources
 while the poller thread can still touch them would race the poll loop.
 
 Registrations remain parked until backend teardown is complete. On Windows,
-their `GC.@preserve` scopes may be the last roots for raw buffers owned by an
-outstanding overlapped operation; waking those tasks before IOCP has delivered
-every terminal completion would let them return while the kernel still holds a
-pointer into Julia memory.
+each outstanding operation independently roots its submitted buffer, while the
+synchronous IOCP drain keeps both that buffer and its OVERLAPPED alive until the
+terminal completion packet has been consumed.
 """
 function shutdown!()
     lock(POLLER_LOCK)
@@ -200,11 +205,18 @@ function shutdown!()
             # backend rather than freeing memory the kernel may still write.
             wake_errno = _backend_wake!(state)
             wake_errno == Int32(0) || _throw_errno("iopoll wake", wake_errno)
+        end
+        if state.backend_state !== nothing
+            # `running=false` only requests/announces termination; the poller
+            # may still be unwinding an error path and touching backend state.
+            # Every published state with a live backend has successfully
+            # started its poller thread, so wait for its definitive exit even
+            # when this shutdown call did not perform the true→false change.
             wait(state.shutdown_event)
         end
         _backend_close!(state)
-        # Backend teardown has relinquished all kernel ownership, so blocked
-        # descriptor tasks may now leave their GC.@preserve scopes safely.
+        # Backend teardown has relinquished all kernel ownership; blocked
+        # descriptor tasks can now observe the final closing state.
         for registration in registrations
             pd = registration.pollstate
             lock(pd.lock)
@@ -424,8 +436,13 @@ function _poller_thread_main!(state::Poller)
         if errno == Int32(Base.Libc.EINTR)
             continue
         end
-        _notify_all_waiters!(state)
+        # Publish terminal poller failure before waking descriptor tasks. An
+        # interrupted raw IOCP caller must observe the stopped state instead of
+        # canceling and re-parking after the only poller has exited. Its IOCP
+        # storage remains rooted by the backend until shutdown or re-init drains
+        # the queued completion.
         @atomic :release state.running = false
+        _notify_all_waiters!(state)
     end
     notify(state.shutdown_event)
     return nothing

--- a/src/tls/record_common.jl
+++ b/src/tls/record_common.jl
@@ -152,11 +152,12 @@ function _tls_read_record_bytes!(
         ptr::Ptr{UInt8},
         nbytes::Int,
         allow_boundary_eof::Bool,
+        root=nothing,
     )::Nothing
     offset = 0
     while offset < nbytes
         n = try
-            TCP._read_some!(tcp, ptr + offset, nbytes - offset)
+            TCP._read_some!(tcp, ptr + offset, nbytes - offset, root)
         catch err
             err isa IOPoll.DeadlineExceededError &&
                 throw(_TLSTransportDeadlineError(_TLS_IO_READ, err))
@@ -214,13 +215,25 @@ function _tls_read_wire_record!(
         negotiated_version::UInt16,
     )::Int
     resize!(record_buffer, 5)
-    GC.@preserve record_buffer _tls_read_record_bytes!(tcp, pointer(record_buffer), 5, true)
+    GC.@preserve record_buffer _tls_read_record_bytes!(
+        tcp,
+        pointer(record_buffer),
+        5,
+        true,
+        record_buffer,
+    )
     _tls_validate_record_header!(record_buffer, negotiated_version)
     payload_len = (Int(record_buffer[4]) << 8) | Int(record_buffer[5])
     payload_len <= max_ciphertext || _tls_fail(_TLS_ALERT_RECORD_OVERFLOW, "tls: received oversized TLS record")
     resize!(record_buffer, 5 + payload_len)
     if payload_len != 0
-        GC.@preserve record_buffer _tls_read_record_bytes!(tcp, pointer(record_buffer, 6), payload_len, false)
+        GC.@preserve record_buffer _tls_read_record_bytes!(
+            tcp,
+            pointer(record_buffer, 6),
+            payload_len,
+            false,
+            record_buffer,
+        )
     end
     return payload_len
 end

--- a/test/internal_poll_tests.jl
+++ b/test/internal_poll_tests.jl
@@ -57,6 +57,22 @@ function _ip_write_byte(fd::SO.SocketFD, b::UInt8)
     throw(ArgumentError("timed out writing byte"))
 end
 
+function _ip_read_byte(fd::SO.SocketFD)::UInt8
+    buf = Ref{UInt8}(0)
+    deadline = Int64(time_ns()) + Int64(2_000_000_000)
+    while Int64(time_ns()) < deadline
+        n = GC.@preserve buf SO.read_once!(fd, Base.unsafe_convert(Ptr{UInt8}, buf), Csize_t(1))
+        n == Cssize_t(1) && return buf[]
+        n == Cssize_t(0) && throw(EOFError())
+        errno = SO.last_error()
+        errno == Int32(Base.Libc.EAGAIN) && (yield(); continue)
+        errno == _IP_EWOULDBLOCK && (yield(); continue)
+        errno == Int32(Base.Libc.EINTR) && continue
+        throw(SystemError("read", Int(errno)))
+    end
+    throw(ArgumentError("timed out reading byte"))
+end
+
 function _ip_accept_with_retry(listener::SO.SocketFD)::Tuple{SO.SocketFD, SO.AcceptPeer}
     for _ in 1:5000
         accepted, peer, errno = SO.try_accept_socket(listener)
@@ -373,20 +389,67 @@ end
             end
         end
         @static if Sys.iswindows()
-            @testset "shutdown drains pending IOCP before releasing raw buffers" begin
+            @testset "pointer-only IOCP uses rooted bounce buffers" begin
                 IP.shutdown!()
                 fd0, fd1 = _ip_socketpair_stream()
                 ipfd = IP.FD(fd0)
                 read_task = nothing
                 shutdown_task = nothing
+                raw_ptr = Channel{Ptr{UInt8}}(1)
                 fd0 = SO.INVALID_SOCKET
                 try
                     IP._set_nonblocking!(ipfd.sysfd)
                     IP.register!(ipfd)
-                    # Exercise the raw-pointer path used by TCP/TLS: the IOCP op
-                    # has no object in its buffer root slot, so the task's
-                    # GC.@preserve scope must remain parked until shutdown has
-                    # observed the terminal completion.
+                    # A pointer-only operation must target an op-rooted bounce
+                    # buffer rather than the caller's unowned pointer.
+                    read_task = errormonitor(Threads.@spawn begin
+                        buf = Vector{UInt8}(undef, 1)
+                        return GC.@preserve buf begin
+                            put!(raw_ptr, pointer(buf))
+                            try
+                                n = IP._read_ptr_some!(ipfd, pointer(buf), 1)
+                                (n, buf[1])
+                            catch err
+                                err
+                            end
+                        end
+                    end)
+                    caller_ptr = take!(raw_ptr)
+                    state = IP.POLLER[]
+                    active = IP.timedwait(2.0; pollint = 0.001) do
+                        lock(state.lock)
+                        try
+                            backend = IP._iocp_backend(state)
+                            backend === nothing && return false
+                            reg = get(backend.by_fd, ipfd.sysfd, nothing)
+                            reg === nothing && return false
+                            op_buffer = reg.read_op.buffer
+                            return (@atomic :acquire reg.read_op.active) &&
+                                op_buffer isa Vector{UInt8} &&
+                                pointer(op_buffer::Vector{UInt8}) != caller_ptr
+                        finally
+                            unlock(state.lock)
+                        end
+                    end
+                    @test active != :timed_out
+                    @test !istaskdone(read_task)
+
+                    _ip_write_byte(fd1, 0x6a)
+                    @test IP.timedwait(() -> istaskdone(read_task), 2.0; pollint = 0.001) != :timed_out
+                    @test fetch(read_task) == (1, 0x6a)
+
+                    source = Ref{UInt8}(0x6c)
+                    written = GC.@preserve source IP._write_ptr!(
+                        ipfd,
+                        Base.unsafe_convert(Ptr{UInt8}, source),
+                        1,
+                    )
+                    @test written == 1
+                    @test _ip_read_byte(fd1) == 0x6c
+
+                    # Leave another raw read pending and verify normal runtime
+                    # shutdown retires the rooted bounce buffer before waking
+                    # the caller out of its preserve scope.
                     read_task = errormonitor(Threads.@spawn begin
                         buf = Vector{UInt8}(undef, 1)
                         return GC.@preserve buf begin
@@ -398,28 +461,39 @@ end
                             end
                         end
                     end)
-                    state = IP.POLLER[]
-                    active = IP.timedwait(2.0; pollint = 0.001) do
+                    pending = IP.timedwait(2.0; pollint = 0.001) do
                         lock(state.lock)
                         try
                             backend = IP._iocp_backend(state)
                             backend === nothing && return false
                             reg = get(backend.by_fd, ipfd.sysfd, nothing)
                             reg === nothing && return false
-                            return (@atomic :acquire reg.read_op.active) && reg.read_op.buffer === nothing
+                            return (@atomic :acquire reg.read_op.active) &&
+                                reg.read_op.buffer isa Vector{UInt8}
                         finally
                             unlock(state.lock)
                         end
                     end
-                    @test active != :timed_out
-                    @test !istaskdone(read_task)
+                    @test pending != :timed_out
 
-                    shutdown_task = errormonitor(Threads.@spawn IP.shutdown!())
-                    @test IP.timedwait(() -> istaskdone(shutdown_task), 5.0; pollint = 0.001) != :timed_out
+                    shutdown_started = Channel{Nothing}(1)
+                    shutdown_task = errormonitor(Threads.@spawn begin
+                        put!(shutdown_started, nothing)
+                        IP.shutdown!()
+                    end)
+                    take!(shutdown_started)
+                    @test IP.timedwait(
+                        () -> istaskdone(shutdown_task),
+                        5.0;
+                        pollint = 0.001,
+                    ) != :timed_out
                     wait(shutdown_task)
-                    @test IP.timedwait(() -> istaskdone(read_task), 2.0; pollint = 0.001) != :timed_out
-                    result = fetch(read_task)
-                    @test result isa IP.NetClosingError
+                    @test IP.timedwait(
+                        () -> istaskdone(read_task),
+                        2.0;
+                        pollint = 0.001,
+                    ) != :timed_out
+                    @test fetch(read_task) isa IP.NetClosingError
                     @test (@atomic :acquire ipfd.pd.closing)
                     @test !(@atomic :acquire ipfd.pd.pollable)
                 finally
@@ -429,6 +503,297 @@ end
                     if shutdown_task isa Task && istaskdone(shutdown_task)
                         wait(shutdown_task)
                     end
+                    IP._is_valid_fd(ipfd.sysfd) && close(ipfd)
+                    _ip_close_fd(fd1)
+                    IP.shutdown!()
+                end
+            end
+            @testset "CancelIoEx ERROR_NOT_FOUND preserves the queued-completion fence" begin
+                IP.shutdown!()
+                fd0, fd1 = _ip_socketpair_stream()
+                state = IP.Poller()
+                op = nothing
+                packet_posted = false
+                try
+                    @test IP._backend_init!(state) == Int32(0)
+                    backend = IP._iocp_backend(state)
+                    @test backend !== nothing
+                    token = UInt64(0x51)
+                    @test IP._backend_open_fd!(state, fd0, IP.PollMode.READWRITE, token) == Int32(0)
+                    reg = (backend::IP.IocpBackendState).by_fd[fd0]
+                    op = reg.read_op
+                    registration = IP.Registration(
+                        fd0,
+                        token,
+                        IP.PollMode.READ,
+                        IP.PollWaiter(),
+                        IP.PollWaiter(),
+                        false,
+                    )
+                    @test IP._submit_iocp_op!(
+                        registration,
+                        reg,
+                        op;
+                        ptr = Ptr{UInt8}(C_NULL),
+                        nbytes = UInt32(1),
+                        kind = IP.IocpOpKind.READ,
+                    ) == Int32(Base.Libc.EINVAL)
+                    @test !(@atomic :acquire op.active)
+                    @atomic :release op.active = true
+                    impostor = IP.Registration(
+                        fd0,
+                        token,
+                        IP.PollMode.READ,
+                        IP.PollWaiter(),
+                        IP.PollWaiter(),
+                        false,
+                    )
+                    lock(state.lock)
+                    try
+                        state.registrations[fd0] = registration
+                        state.registrations_by_token[token] = registration
+                        @atomic :release state.running = true
+                        @test IP._lookup_iocp_registration(state, registration) === reg
+                        @test IP._lookup_iocp_registration(state, impostor) === nothing
+                    finally
+                        unlock(state.lock)
+                    end
+
+                    posted = ccall(
+                        (:PostQueuedCompletionStatus, "Kernel32"),
+                        Int32,
+                        (Ptr{Cvoid}, UInt32, UInt, Ptr{Cvoid}),
+                        backend.port,
+                        UInt32(0),
+                        UInt(token),
+                        IP._op_ptr(op),
+                    )
+                    posted != 0 || error(
+                        "PostQueuedCompletionStatus failed: $(IP._win_get_last_error())",
+                    )
+                    packet_posted = posted != 0
+
+                    # There is deliberately no matching OS request, so
+                    # CancelIoEx returns ERROR_NOT_FOUND even though a packet
+                    # for this OVERLAPPED is queued.
+                    raw_cancel = ccall(
+                        (:CancelIoEx, "Kernel32"),
+                        Int32,
+                        (Ptr{Cvoid}, Ptr{Cvoid}),
+                        IP._socket_handle(fd0),
+                        IP._op_ptr(op),
+                    )
+                    raw_cancel_error = raw_cancel == 0 ? IP._win_get_last_error() : UInt32(0)
+                    @test raw_cancel == 0
+                    @test raw_cancel_error == IP._ERROR_NOT_FOUND
+                    @test IP._cancel_iocp_op!(reg, op)
+                    @test (@atomic :acquire op.active)
+
+                    @test IP._submit_iocp_op!(
+                        registration,
+                        reg,
+                        op;
+                        kind = IP.IocpOpKind.PROBE_READ,
+                    ) == Int32(Base.Libc.EALREADY)
+
+                    IP._drain_pending_ops_on_close!(backend)
+                    @test !(@atomic :acquire op.active)
+
+                    bytes_ref = Ref{UInt32}(UInt32(0))
+                    key_ref = Ref{UInt}(UInt(0))
+                    ov_ref = Ref{Ptr{Cvoid}}(C_NULL)
+                    empty_result = GC.@preserve bytes_ref key_ref ov_ref begin
+                        ccall(
+                            (:GetQueuedCompletionStatus, "Kernel32"),
+                            Int32,
+                            (Ptr{Cvoid}, Ref{UInt32}, Ref{UInt}, Ref{Ptr{Cvoid}}, UInt32),
+                            backend.port,
+                            bytes_ref,
+                            key_ref,
+                            ov_ref,
+                            UInt32(0),
+                        )
+                    end
+                    empty_error = empty_result == 0 ? IP._win_get_last_error() : UInt32(0)
+                    @test empty_result == 0
+                    @test ov_ref[] == C_NULL
+                    @test empty_error == IP._WAIT_TIMEOUT
+                finally
+                    @atomic :release state.running = false
+                    if op isa IP.IocpOp && !packet_posted
+                        active_op = op::IP.IocpOp
+                        @atomic :release active_op.active = false
+                    end
+                    state.backend_state === nothing || IP._backend_close!(state)
+                    _ip_close_fd(fd0)
+                    _ip_close_fd(fd1)
+                    IP.shutdown!()
+                end
+            end
+            @testset "active IOCP storage cannot be finished or reused before dispatch" begin
+                IP.shutdown!()
+                fd0, fd1 = _ip_socketpair_stream()
+                ipfd = IP.FD(fd0)
+                read_task = nothing
+                fd0 = SO.INVALID_SOCKET
+                try
+                    IP._set_nonblocking!(ipfd.sysfd)
+                    IP.register!(ipfd)
+                    read_task = errormonitor(Threads.@spawn begin
+                        buf = Vector{UInt8}(undef, 1)
+                        try
+                            n = IP.read!(ipfd, buf)
+                            return n, buf[1]
+                        catch err
+                            return err
+                        end
+                    end)
+                    state = IP.POLLER[]
+                    active = IP.timedwait(2.0; pollint = 0.001) do
+                        lock(state.lock)
+                        try
+                            backend = IP._iocp_backend(state)
+                            backend === nothing && return false
+                            reg = get(backend.by_fd, ipfd.sysfd, nothing)
+                            reg === nothing && return false
+                            return @atomic :acquire reg.read_op.active
+                        finally
+                            unlock(state.lock)
+                        end
+                    end
+                    @test active != :timed_out
+
+                    lock(state.lock)
+                    try
+                        backend = IP._iocp_backend(state)::IP.IocpBackendState
+                        reg = backend.by_fd[ipfd.sysfd]
+                        op = reg.read_op
+                        registration = state.registrations[ipfd.sysfd]
+                        _ip_write_byte(fd1, 0x6b)
+
+                        # For IOCP-associated handles, WSAGetOverlappedResult
+                        # becomes terminal after GQCSEx dequeues the packet. The
+                        # poller cannot publish active=false yet because this
+                        # task deliberately holds state.lock.
+                        observed = Ref((UInt32(0), Int32(Base.Libc.EAGAIN)))
+                        dequeued = false
+                        dequeue_deadline = Int64(time_ns()) + Int64(2_000_000_000)
+                        while Int64(time_ns()) < dequeue_deadline
+                            observed[] = IP._wsagetoverlappedresult_bytes(ipfd.sysfd, op)
+                            if observed[][2] != Int32(Base.Libc.EAGAIN)
+                                dequeued = true
+                                break
+                            end
+                            yield()
+                        end
+                        @test dequeued
+                        @test observed[][2] == Int32(0)
+
+                        @test IP._cancel_iocp_op!(reg, op)
+                        still_active = @atomic :acquire op.active
+                        @test still_active
+                        if still_active
+                            @test IP._iocp_finish_read!(registration) ==
+                                (UInt32(0), Int32(Base.Libc.EAGAIN))
+                            second = Vector{UInt8}(undef, 1)
+                            rootless_errno = GC.@preserve second begin
+                                IP._iocp_submit_read!(
+                                    registration,
+                                    pointer(second),
+                                    UInt32(1),
+                                )
+                            end
+                            @test rootless_errno == Int32(Base.Libc.EALREADY)
+                            @test (@atomic :acquire op.active)
+                            rooted_errno = GC.@preserve second begin
+                                IP._iocp_submit_read!(
+                                    registration,
+                                    pointer(second),
+                                    UInt32(1),
+                                    second,
+                                )
+                            end
+                            @test rooted_errno == Int32(Base.Libc.EALREADY)
+                        end
+                    finally
+                        unlock(state.lock)
+                    end
+
+                    @test IP.timedwait(() -> istaskdone(read_task), 2.0; pollint = 0.001) != :timed_out
+                    @test fetch(read_task) == (1, 0x6b)
+                finally
+                    IP._is_valid_fd(ipfd.sysfd) && close(ipfd)
+                    _ip_close_fd(fd1)
+                    IP.shutdown!()
+                end
+            end
+            @testset "re-init retires a stopped IOCP generation after a raw read unwinds" begin
+                IP.shutdown!()
+                fd0, fd1 = _ip_socketpair_stream()
+                ipfd = IP.FD(fd0)
+                read_task = nothing
+                fd0 = SO.INVALID_SOCKET
+                try
+                    IP._set_nonblocking!(ipfd.sysfd)
+                    IP.register!(ipfd)
+                    read_task = errormonitor(Threads.@spawn begin
+                        buf = Vector{UInt8}(undef, 1)
+                        return GC.@preserve buf begin
+                            try
+                                IP._read_ptr_some!(ipfd, pointer(buf), 1)
+                                :ok
+                            catch err
+                                err
+                            end
+                        end
+                    end)
+                    old_state = IP.POLLER[]
+                    old_op = Ref{Any}(nothing)
+                    active = IP.timedwait(2.0; pollint = 0.001) do
+                        lock(old_state.lock)
+                        try
+                            backend = IP._iocp_backend(old_state)
+                            backend === nothing && return false
+                            reg = get(backend.by_fd, ipfd.sysfd, nothing)
+                            reg === nothing && return false
+                            old_op[] = reg.read_op
+                            return @atomic :acquire reg.read_op.active
+                        finally
+                            unlock(old_state.lock)
+                        end
+                    end
+                    @test active != :timed_out
+
+                    lock(old_state.lock)
+                    try
+                        @atomic :release old_state.running = false
+                    finally
+                        unlock(old_state.lock)
+                    end
+                    wake_errno = IP._backend_wake!(old_state)
+                    if wake_errno != Int32(0)
+                        # Restore a serviceable poll loop before failing the
+                        # test so cleanup cannot strand the native thread.
+                        @atomic :release old_state.running = true
+                        _ip_write_byte(fd1, 0x7e)
+                        error("IOCP backend wake failed: $(wake_errno)")
+                    end
+                    IP.set_read_deadline!(ipfd, Int64(time_ns()) - Int64(1))
+
+                    @test IP.timedwait(() -> istaskdone(read_task), 5.0; pollint = 0.001) != :timed_out
+                    @test fetch(read_task) isa IP.DeadlineExceededError
+                    op = old_op[]::IP.IocpOp
+                    @test old_state.backend_state !== nothing
+                    @test (@atomic :acquire op.active)
+                    @test op.buffer isa Vector{UInt8}
+
+                    new_state = IP.init!()
+                    @test new_state !== old_state
+                    @test (@atomic :acquire new_state.running)
+                    @test old_state.backend_state === nothing
+                    @test !(@atomic :acquire op.active)
+                    @test !(@atomic :acquire ipfd.pd.pollable)
+                finally
                     IP._is_valid_fd(ipfd.sysfd) && close(ipfd)
                     _ip_close_fd(fd1)
                     IP.shutdown!()


### PR DESCRIPTION
## Summary

- root object-backed read and write buffers for the complete overlapped-operation lifetime
- copy raw-pointer I/O through bounded, operation-rooted bounce buffers
- keep `OVERLAPPED` storage active until its completion packet is consumed, including `CancelIoEx(ERROR_NOT_FOUND)` races
- synchronously cancel and drain pending operations before shutdown or poller re-init drops backend roots
- add Windows regressions for queued/dequeued completions, raw-buffer ownership, premature storage reuse, and stopped-poller retirement

## Root cause

Canceled pointer-based reads and writes could unwind their caller's `GC.@preserve` scope while Windows still owned the submitted buffer. Separately, cancellation and shutdown paths could clear, reuse, or unroot an `OVERLAPPED` before its queued completion packet had been consumed.

That left either caller memory or Julia-owned `OVERLAPPED` storage reachable by the kernel after the corresponding Julia lifetime had ended.

## Impact

Pending IOCP operations now retain every buffer and `OVERLAPPED` until kernel ownership is conclusively retired. Object-backed APIs remain direct, while pointer-only APIs use a bounded copy to avoid exposing unowned caller memory after exceptional unwind.

## Validation

- full Linux suite on Julia 1.14-dev: 5,979/5,979 assertions passed
- focused internal suite on Julia 1.10: 136/136 assertions passed
- `git diff --check` passed
- Windows-specific regression coverage added; native Windows execution was not available in the local environment