### PR TITLE
Avoid live IOCP during Windows precompilation

### DIFF
--- a/src/6_precompile_workload.jl
+++ b/src/6_precompile_workload.jl
@@ -8,8 +8,12 @@ const NC = TCP
 const ND = HostResolvers
 const TL = TLS
 
-@inline function _pc_runtime_supported()::Bool
-    return Sys.isapple() || Sys.islinux() || Sys.iswindows()
+@inline function _pc_live_io_supported()::Bool
+    # Keep package precompilation independent of live IOCP and loopback
+    # completion on Windows. The workload contains blocking network operations
+    # and repeated poller shutdowns that cannot be made safe with an atexit hook
+    # if the operation itself never reaches cleanup.
+    return Sys.isapple() || Sys.islinux()
 end
 
 const _PC_EWOULDBLOCK = @static isdefined(Base.Libc, :EWOULDBLOCK) ? Int32(getfield(Base.Libc, :EWOULDBLOCK)) : Int32(Base.Libc.EAGAIN)
@@ -151,7 +155,7 @@ function _pc_run_eventloops_workload!()
     waiter = IP.PollWaiter()
     IP.pollnotify!(waiter)
     IP.pollwait!(waiter)
-    _pc_runtime_supported() || return nothing
+    _pc_live_io_supported() || return nothing
     state = IP.Poller()
     fd0 = SO.INVALID_SOCKET
     fd1 = SO.INVALID_SOCKET
@@ -195,7 +199,7 @@ function _pc_run_eventloops_workload!()
 end
 
 function _pc_run_internal_poll_workload!()
-    _pc_runtime_supported() || return nothing
+    _pc_live_io_supported() || return nothing
     fd0, fd1 = _pc_stream_pair()
     ipfd = IP.FD(fd0)
     fd0 = SO.INVALID_SOCKET
@@ -221,7 +225,7 @@ function _pc_run_internal_poll_workload!()
 end
 
 function _pc_run_socket_ops_workload!()
-    _pc_runtime_supported() || return nothing
+    _pc_live_io_supported() || return nothing
     listener = SO.INVALID_SOCKET
     client = SO.INVALID_SOCKET
     accepted = SO.INVALID_SOCKET
@@ -257,7 +261,7 @@ function _pc_run_socket_ops_workload!()
 end
 
 function _pc_run_tcp_workload!()
-    _pc_runtime_supported() || return nothing
+    _pc_live_io_supported() || return nothing
     listener = nothing
     client = nothing
     server = nothing
@@ -290,7 +294,7 @@ function _pc_run_tcp_workload!()
 end
 
 function _pc_run_host_resolvers_workload!()
-    _pc_runtime_supported() || return nothing
+    _pc_live_io_supported() || return nothing
     listener = nothing
     client = nothing
     server = nothing
@@ -608,7 +612,7 @@ Keeping this workload source-owned means trim/precompile coverage evolves with
 the actual supported public API rather than drifting into a test-only harness.
 """
 function _pc_run_tls_workload!()
-    _pc_runtime_supported() || return nothing
+    _pc_live_io_supported() || return nothing
     paths = _pc_tls12_paths()
     paths === nothing && return nothing
     # Start with the "normal" modern config that allows both TLS 1.2 and TLS

--- a/test/iopoll_runtime_tests.jl
+++ b/test/iopoll_runtime_tests.jl
@@ -127,6 +127,12 @@ function _el_wait_connect_ready!(fd::SO.SocketFD)
 end
 
 @testset "IOPoll runtime phase 1" begin
+        @testset "precompile live I/O platform guard" begin
+            @test Reseau._pc_live_io_supported() == (Sys.isapple() || Sys.islinux())
+            @static if Sys.iswindows()
+                @test !Reseau._pc_live_io_supported()
+            end
+        end
         NP.shutdown!()
         _el_log_test_progress("START: poller-backed sleep/timedwait")
         @testset "poller-backed sleep/timedwait" begin


### PR DESCRIPTION
## Summary

- keep package precompilation independent of live loopback and IOCP completion
  on Windows
- preserve the existing live precompile workload on macOS and Linux
- add a platform guard regression to the Windows runtime test lane

Fixes #136.

## Root cause

The package-owned `@compile_workload` performs real loopback connects, accepts,
poll waits, reads, writes, TLS handshakes, and repeated poller shutdowns while
Julia is generating package output. Several of those live operations have no
wall-clock escape. On the reporter's Windows 11 / Julia 1.12.6 environment, one
does not complete, so `Pkg.add` never reaches workload cleanup.

The earlier fixes solve adjacent but different lifecycle problems:

- #130 registers `shutdown!` at exit so a poller started by a completed
  precompile workload does not strand the worker.
- #135 strictly drains IOCP completions before releasing kernel-owned buffers
  and `OVERLAPPED` storage.

An exit hook cannot interrupt a workload operation that never returns, and the
IOCP lifetime guarantees should not be weakened for an opportunistic
precompile workload. The narrow boundary is therefore to skip live workload I/O
while generating package output on Windows. Normal Windows runtime behavior and
runtime test coverage are unchanged.

## Reproduction and platform scope

The reporter's exact command hangs on Windows 11 x86_64 / Julia 1.12.6 and
completes when `src/6_precompile_workload.jl` is emptied.

I could not reproduce that machine-specific stall on the available Windows
environment:

- macOS arm64 / Julia 1.12.6: exact `Pkg.add(url=..., rev="main")` completed
- GitHub-hosted Windows Server 2025 x86_64 / Julia 1.12.6: exact `Pkg.add`
  completed for the full workload and each isolated workload

The fix removes the reporter-sensitive live I/O boundary from Windows package
precompilation by construction.

## Validation

- Julia 1.12.6 focused IOPoll suite: 1,743/1,743
- Julia 1.10.11 focused IOPoll suite: 1,743/1,743
- Julia 1.12.6 full macOS suite: 5,498/5,498
- JuliaC trim workload matrix: 42/42
- Windows Server 2025 / Julia 1.12.6 exact fixed-commit `Pkg.add`: completed in
  8 seconds and printed `REPRO_DONE`
  ([run 30299089637](https://github.com/JuliaServices/Reseau.jl/actions/runs/30299089637))

Co-authored by Codex
