### PR TITLE
Complete classical TLS curve support

### DIFF
--- a/src/5_tls.jl
+++ b/src/5_tls.jl
@@ -60,6 +60,7 @@ include("tls/handshake_server_tls12.jl")
 const X25519 = _TLS_GROUP_X25519
 const P256 = _TLS_GROUP_SECP256R1
 const P384 = _TLS_GROUP_SECP384R1
+const P521 = _TLS_GROUP_SECP521R1
 
 """
     ClientAuthMode
@@ -294,9 +295,8 @@ Keyword arguments:
   certificates. This is required for server configs that verify presented client certs.
 - `alpn_protocols`: ordered ALPN protocol preference list.
 - `curve_preferences`: ordered native ECDHE group preferences for TLS 1.2/1.3.
-  When empty, native TLS 1.3 and mixed-mode handshakes default to
-  `[TLS.X25519, TLS.P256, TLS.P384]`, while exact native TLS 1.2 defaults to
-  `[TLS.P256, TLS.P384]`.
+  When empty, native handshakes default to
+  `[TLS.X25519, TLS.P256, TLS.P384, TLS.P521]`.
 - `handshake_timeout_ns`: optional cap, in monotonic nanoseconds, applied only while the
   handshake is running. Existing transport deadlines still win if they are earlier.
 - `min_version` / `max_version`: TLS protocol version bounds. Only TLS 1.2 and TLS 1.3
@@ -440,6 +440,7 @@ const _NATIVE_DEFAULT_CURVE_PREFERENCES = (
     _TLS_GROUP_X25519,
     _TLS_GROUP_SECP256R1,
     _TLS_GROUP_SECP384R1,
+    _TLS_GROUP_SECP521R1,
 )
 
 @inline _supported_tls_version(version::UInt16)::Bool = version == TLS1_2_VERSION || version == TLS1_3_VERSION
@@ -451,9 +452,7 @@ function _require_supported_tls_version!(field_name::AbstractString, version::UI
 end
 
 @inline function _native_curve_supported(group::UInt16)::Bool
-    return group == _TLS_GROUP_X25519 ||
-        group == _TLS_GROUP_SECP256R1 ||
-        group == _TLS_GROUP_SECP384R1
+    return group == _TLS_GROUP_X25519 || _tls_nist_curve_supported(group)
 end
 
 @inline _curve_preference_name(group::UInt16) = "0x" * string(group, base = 16, pad = 4)
@@ -471,7 +470,7 @@ function _native_curve_preferences(config::Config)::Vector{UInt16}
 end
 
 function _tls12_curve_preferences(config::Config)::Vector{UInt16}
-    isempty(config.curve_preferences) && return UInt16[_TLS_GROUP_SECP256R1, _TLS_GROUP_SECP384R1]
+    isempty(config.curve_preferences) && return UInt16[_NATIVE_DEFAULT_CURVE_PREFERENCES...]
     return _native_curve_preferences(config)
 end
 
@@ -2587,6 +2586,7 @@ end
     group == _TLS_GROUP_X25519 && return "X25519"
     group == _TLS_GROUP_SECP256R1 && return "P-256"
     group == _TLS_GROUP_SECP384R1 && return "P-384"
+    group == _TLS_GROUP_SECP521R1 && return "P-521"
     return nothing
 end
 

--- a/src/5_tls.jl
+++ b/src/5_tls.jl
@@ -59,6 +59,7 @@ include("tls/handshake_server_tls12.jl")
 
 const X25519 = _TLS_GROUP_X25519
 const P256 = _TLS_GROUP_SECP256R1
+const P384 = _TLS_GROUP_SECP384R1
 
 """
     ClientAuthMode
@@ -293,8 +294,9 @@ Keyword arguments:
   certificates. This is required for server configs that verify presented client certs.
 - `alpn_protocols`: ordered ALPN protocol preference list.
 - `curve_preferences`: ordered native ECDHE group preferences for TLS 1.2/1.3.
-  When empty, native TLS 1.3 and mixed-mode handshakes default to `[TLS.X25519, TLS.P256]`,
-  while exact native TLS 1.2 defaults to `[TLS.P256]`.
+  When empty, native TLS 1.3 and mixed-mode handshakes default to
+  `[TLS.X25519, TLS.P256, TLS.P384]`, while exact native TLS 1.2 defaults to
+  `[TLS.P256, TLS.P384]`.
 - `handshake_timeout_ns`: optional cap, in monotonic nanoseconds, applied only while the
   handshake is running. Existing transport deadlines still win if they are earlier.
 - `min_version` / `max_version`: TLS protocol version bounds. Only TLS 1.2 and TLS 1.3
@@ -434,7 +436,11 @@ function Config(;
     )
 end
 
-const _NATIVE_DEFAULT_CURVE_PREFERENCES = (_TLS_GROUP_X25519, _TLS_GROUP_SECP256R1)
+const _NATIVE_DEFAULT_CURVE_PREFERENCES = (
+    _TLS_GROUP_X25519,
+    _TLS_GROUP_SECP256R1,
+    _TLS_GROUP_SECP384R1,
+)
 
 @inline _supported_tls_version(version::UInt16)::Bool = version == TLS1_2_VERSION || version == TLS1_3_VERSION
 @inline _tls_version_hex(version::UInt16)::String = "0x" * string(version, base = 16, pad = 4)
@@ -445,7 +451,9 @@ function _require_supported_tls_version!(field_name::AbstractString, version::UI
 end
 
 @inline function _native_curve_supported(group::UInt16)::Bool
-    return group == _TLS_GROUP_X25519 || group == _TLS_GROUP_SECP256R1
+    return group == _TLS_GROUP_X25519 ||
+        group == _TLS_GROUP_SECP256R1 ||
+        group == _TLS_GROUP_SECP384R1
 end
 
 @inline _curve_preference_name(group::UInt16) = "0x" * string(group, base = 16, pad = 4)
@@ -463,7 +471,7 @@ function _native_curve_preferences(config::Config)::Vector{UInt16}
 end
 
 function _tls12_curve_preferences(config::Config)::Vector{UInt16}
-    isempty(config.curve_preferences) && return UInt16[_TLS_GROUP_SECP256R1]
+    isempty(config.curve_preferences) && return UInt16[_TLS_GROUP_SECP256R1, _TLS_GROUP_SECP384R1]
     return _native_curve_preferences(config)
 end
 
@@ -2578,6 +2586,7 @@ end
 @inline function _tls_group_name(group::UInt16)::Union{Nothing, String}
     group == _TLS_GROUP_X25519 && return "X25519"
     group == _TLS_GROUP_SECP256R1 && return "P-256"
+    group == _TLS_GROUP_SECP384R1 && return "P-384"
     return nothing
 end
 

--- a/src/tls/handshake_client_tls12.jl
+++ b/src/tls/handshake_client_tls12.jl
@@ -409,17 +409,13 @@ function _tls12_generate_client_key_exchange(
 )::_TLS12ClientKeyExchangeResult
     in(group, advertised_curves) ||
         _tls_fail(_TLS_ALERT_ILLEGAL_PARAMETER, "tls: server selected an unadvertised TLS 1.2 ECDHE curve")
-    if group != _TLS_GROUP_X25519 &&
-       group != _TLS_GROUP_SECP256R1 &&
-       group != _TLS_GROUP_SECP384R1
+    if group != _TLS_GROUP_X25519 && !_tls_nist_curve_supported(group)
         _tls_fail(_TLS_ALERT_HANDSHAKE_FAILURE, "tls: native TLS 1.2 client does not support ECDHE group $(string(group, base = 16))")
     end
     private_key = if group == _TLS_GROUP_X25519
         _tls13_x25519_generate_private_key()
-    elseif group == _TLS_GROUP_SECP256R1
-        _tls13_p256_generate_private_key()
     else
-        _tls13_p384_generate_private_key()
+        _tls_ec_generate_private_key(group)
     end
     client_public_key = UInt8[]
     shared_secret = UInt8[]
@@ -427,12 +423,9 @@ function _tls12_generate_client_key_exchange(
         if group == _TLS_GROUP_X25519
             client_public_key = _tls13_x25519_public_key(private_key)
             shared_secret = _tls13_x25519_shared_secret(private_key, server_public_key)
-        elseif group == _TLS_GROUP_SECP256R1
-            client_public_key = _tls13_p256_public_key(private_key)
-            shared_secret = _tls13_p256_shared_secret(private_key, server_public_key)
         else
-            client_public_key = _tls13_p384_public_key(private_key)
-            shared_secret = _tls13_p384_shared_secret(private_key, server_public_key)
+            client_public_key = _tls_ec_public_key(group, private_key)
+            shared_secret = _tls_ec_shared_secret(group, private_key, server_public_key)
         end
         body = UInt8[UInt8(length(client_public_key))]
         append!(body, client_public_key)

--- a/src/tls/handshake_client_tls12.jl
+++ b/src/tls/handshake_client_tls12.jl
@@ -409,19 +409,30 @@ function _tls12_generate_client_key_exchange(
 )::_TLS12ClientKeyExchangeResult
     in(group, advertised_curves) ||
         _tls_fail(_TLS_ALERT_ILLEGAL_PARAMETER, "tls: server selected an unadvertised TLS 1.2 ECDHE curve")
-    if group != _TLS_GROUP_X25519 && group != _TLS_GROUP_SECP256R1
+    if group != _TLS_GROUP_X25519 &&
+       group != _TLS_GROUP_SECP256R1 &&
+       group != _TLS_GROUP_SECP384R1
         _tls_fail(_TLS_ALERT_HANDSHAKE_FAILURE, "tls: native TLS 1.2 client does not support ECDHE group $(string(group, base = 16))")
     end
-    private_key = group == _TLS_GROUP_X25519 ? _tls13_x25519_generate_private_key() : _tls13_p256_generate_private_key()
+    private_key = if group == _TLS_GROUP_X25519
+        _tls13_x25519_generate_private_key()
+    elseif group == _TLS_GROUP_SECP256R1
+        _tls13_p256_generate_private_key()
+    else
+        _tls13_p384_generate_private_key()
+    end
     client_public_key = UInt8[]
     shared_secret = UInt8[]
     try
         if group == _TLS_GROUP_X25519
             client_public_key = _tls13_x25519_public_key(private_key)
             shared_secret = _tls13_x25519_shared_secret(private_key, server_public_key)
-        else
+        elseif group == _TLS_GROUP_SECP256R1
             client_public_key = _tls13_p256_public_key(private_key)
             shared_secret = _tls13_p256_shared_secret(private_key, server_public_key)
+        else
+            client_public_key = _tls13_p384_public_key(private_key)
+            shared_secret = _tls13_p384_shared_secret(private_key, server_public_key)
         end
         body = UInt8[UInt8(length(client_public_key))]
         append!(body, client_public_key)

--- a/src/tls/handshake_client_tls13.jl
+++ b/src/tls/handshake_client_tls13.jl
@@ -160,9 +160,7 @@ function _TLS13OpenSSLCertificateVerifier(;
 end
 
 @inline function _tls13_supports_key_share_group(group::UInt16)::Bool
-    return group == _TLS_GROUP_X25519 ||
-        group == _TLS_GROUP_SECP256R1 ||
-        group == _TLS_GROUP_SECP384R1
+    return group == _TLS_GROUP_X25519 || _tls_nist_curve_supported(group)
 end
 
 function _tls13_generate_key_share!(provider::_TLS13OpenSSLKeyShareProvider, group::UInt16)::_TLSKeyShare
@@ -176,17 +174,13 @@ function _tls13_generate_key_share!(provider::_TLS13OpenSSLKeyShareProvider, gro
         provider.private_key_group = group
         return _TLSKeyShare(group, _tls13_x25519_public_key(provider.private_key))
     end
-    if group == _TLS_GROUP_SECP256R1
-        provider.private_key = provider.has_fixed_p256_private_key ?
-            _tls13_p256_private_key_from_bytes(provider.fixed_p256_private_key) :
-            _tls13_p256_generate_private_key()
+    if _tls_nist_curve_supported(group)
+        provider.private_key =
+            group == _TLS_GROUP_SECP256R1 && provider.has_fixed_p256_private_key ?
+            _tls_ec_private_key_from_bytes(group, provider.fixed_p256_private_key) :
+            _tls_ec_generate_private_key(group)
         provider.private_key_group = group
-        return _TLSKeyShare(group, _tls13_p256_public_key(provider.private_key))
-    end
-    if group == _TLS_GROUP_SECP384R1
-        provider.private_key = _tls13_p384_generate_private_key()
-        provider.private_key_group = group
-        return _TLSKeyShare(group, _tls13_p384_public_key(provider.private_key))
+        return _TLSKeyShare(group, _tls_ec_public_key(group, provider.private_key))
     end
     throw(ArgumentError("tls13 client handshake OpenSSL key share provider does not support group $(string(group, base = 16))"))
 end
@@ -208,11 +202,8 @@ function _tls13_resolve_server_shared_secret(provider::_TLS13OpenSSLKeyShareProv
         if server_share.group == _TLS_GROUP_X25519
             return _tls13_x25519_shared_secret(provider.private_key, server_share.data)
         end
-        if server_share.group == _TLS_GROUP_SECP256R1
-            return _tls13_p256_shared_secret(provider.private_key, server_share.data)
-        end
-        if server_share.group == _TLS_GROUP_SECP384R1
-            return _tls13_p384_shared_secret(provider.private_key, server_share.data)
+        if _tls_nist_curve_supported(server_share.group)
+            return _tls_ec_shared_secret(server_share.group, provider.private_key, server_share.data)
         end
     catch err
         ex = _as_exception(err)

--- a/src/tls/handshake_client_tls13.jl
+++ b/src/tls/handshake_client_tls13.jl
@@ -160,7 +160,9 @@ function _TLS13OpenSSLCertificateVerifier(;
 end
 
 @inline function _tls13_supports_key_share_group(group::UInt16)::Bool
-    return group == _TLS_GROUP_X25519 || group == _TLS_GROUP_SECP256R1
+    return group == _TLS_GROUP_X25519 ||
+        group == _TLS_GROUP_SECP256R1 ||
+        group == _TLS_GROUP_SECP384R1
 end
 
 function _tls13_generate_key_share!(provider::_TLS13OpenSSLKeyShareProvider, group::UInt16)::_TLSKeyShare
@@ -180,6 +182,11 @@ function _tls13_generate_key_share!(provider::_TLS13OpenSSLKeyShareProvider, gro
             _tls13_p256_generate_private_key()
         provider.private_key_group = group
         return _TLSKeyShare(group, _tls13_p256_public_key(provider.private_key))
+    end
+    if group == _TLS_GROUP_SECP384R1
+        provider.private_key = _tls13_p384_generate_private_key()
+        provider.private_key_group = group
+        return _TLSKeyShare(group, _tls13_p384_public_key(provider.private_key))
     end
     throw(ArgumentError("tls13 client handshake OpenSSL key share provider does not support group $(string(group, base = 16))"))
 end
@@ -203,6 +210,9 @@ function _tls13_resolve_server_shared_secret(provider::_TLS13OpenSSLKeyShareProv
         end
         if server_share.group == _TLS_GROUP_SECP256R1
             return _tls13_p256_shared_secret(provider.private_key, server_share.data)
+        end
+        if server_share.group == _TLS_GROUP_SECP384R1
+            return _tls13_p384_shared_secret(provider.private_key, server_share.data)
         end
     catch err
         ex = _as_exception(err)

--- a/src/tls/handshake_common.jl
+++ b/src/tls/handshake_common.jl
@@ -39,7 +39,7 @@ end
         curve_id = (public_key::_TLSECPublicKey).curve_id
         return (curve_id == _TLS_GROUP_SECP256R1 && signature_algorithm == _TLS_SIGNATURE_ECDSA_SECP256R1_SHA256) ||
             (curve_id == _TLS_GROUP_SECP384R1 && signature_algorithm == _TLS_SIGNATURE_ECDSA_SECP384R1_SHA384) ||
-            (curve_id == UInt16(0x0019) && signature_algorithm == _TLS_SIGNATURE_ECDSA_SECP521R1_SHA512)
+            (curve_id == _TLS_GROUP_SECP521R1 && signature_algorithm == _TLS_SIGNATURE_ECDSA_SECP521R1_SHA512)
     end
     return public_key isa _TLSEd25519PublicKey && signature_algorithm == _TLS_SIGNATURE_ED25519
 end

--- a/src/tls/handshake_common.jl
+++ b/src/tls/handshake_common.jl
@@ -38,7 +38,7 @@ end
     if public_key isa _TLSECPublicKey
         curve_id = (public_key::_TLSECPublicKey).curve_id
         return (curve_id == _TLS_GROUP_SECP256R1 && signature_algorithm == _TLS_SIGNATURE_ECDSA_SECP256R1_SHA256) ||
-            (curve_id == UInt16(0x0018) && signature_algorithm == _TLS_SIGNATURE_ECDSA_SECP384R1_SHA384) ||
+            (curve_id == _TLS_GROUP_SECP384R1 && signature_algorithm == _TLS_SIGNATURE_ECDSA_SECP384R1_SHA384) ||
             (curve_id == UInt16(0x0019) && signature_algorithm == _TLS_SIGNATURE_ECDSA_SECP521R1_SHA512)
     end
     return public_key isa _TLSEd25519PublicKey && signature_algorithm == _TLS_SIGNATURE_ED25519

--- a/src/tls/handshake_server_tls12.jl
+++ b/src/tls/handshake_server_tls12.jl
@@ -287,22 +287,27 @@ end
     return in(UInt8(0x00), client_hello.supported_points)
 end
 
+function _tls12_has_nist_curve_overlap(
+    preferred_curves::AbstractVector{UInt16},
+    client_curves::AbstractVector{UInt16},
+)::Bool
+    for group in preferred_curves
+        _tls_nist_curve_supported(group) && in(group, client_curves) && return true
+    end
+    return false
+end
+
 function _tls12_select_server_curve(client_hello::_ClientHelloMsg, config)::UInt16
     preferred_curves = _tls12_curve_preferences(config)
     for group in preferred_curves
         in(group, client_hello.supported_curves) || continue
-        if (group == _TLS_GROUP_SECP256R1 || group == _TLS_GROUP_SECP384R1) &&
+        if _tls_nist_curve_supported(group) &&
            !_tls12_client_supports_uncompressed_points(client_hello)
             continue
         end
         return group
     end
-    has_uncompressed_ec_overlap =
-        (in(_TLS_GROUP_SECP256R1, preferred_curves) &&
-         in(_TLS_GROUP_SECP256R1, client_hello.supported_curves)) ||
-        (in(_TLS_GROUP_SECP384R1, preferred_curves) &&
-         in(_TLS_GROUP_SECP384R1, client_hello.supported_curves))
-    if has_uncompressed_ec_overlap &&
+    if _tls12_has_nist_curve_overlap(preferred_curves, client_hello.supported_curves) &&
        !_tls12_client_supports_uncompressed_points(client_hello)
         _tls_fail(_TLS_ALERT_HANDSHAKE_FAILURE, "tls: client did not offer uncompressed TLS 1.2 EC points")
     end
@@ -455,7 +460,7 @@ function _tls12_send_server_hello!(
     server_hello.secure_renegotiation_supported = state.client_hello.secure_renegotiation_supported
     server_hello.server_name_ack = !isempty(state.client_hello.server_name)
     server_hello.alpn_protocol = state.selected_alpn
-    if (state.curve_id == _TLS_GROUP_SECP256R1 || state.curve_id == _TLS_GROUP_SECP384R1) &&
+    if _tls_nist_curve_supported(state.curve_id) &&
        !isempty(state.client_hello.supported_points)
         server_hello.supported_points = UInt8[0x00]
     end
@@ -483,12 +488,9 @@ function _tls12_server_key_exchange_params(state::_TLS12ServerHandshakeState)::V
     if state.curve_id == _TLS_GROUP_X25519
         state.ecdhe_private_key = _tls13_x25519_generate_private_key()
         public_key = _tls13_x25519_public_key(state.ecdhe_private_key)
-    elseif state.curve_id == _TLS_GROUP_SECP256R1
-        state.ecdhe_private_key = _tls13_p256_generate_private_key()
-        public_key = _tls13_p256_public_key(state.ecdhe_private_key)
-    elseif state.curve_id == _TLS_GROUP_SECP384R1
-        state.ecdhe_private_key = _tls13_p384_generate_private_key()
-        public_key = _tls13_p384_public_key(state.ecdhe_private_key)
+    elseif _tls_nist_curve_supported(state.curve_id)
+        state.ecdhe_private_key = _tls_ec_generate_private_key(state.curve_id)
+        public_key = _tls_ec_public_key(state.curve_id, state.ecdhe_private_key)
     else
         _tls_fail(_TLS_ALERT_HANDSHAKE_FAILURE, "tls: unsupported native TLS 1.2 ECDHE group")
     end
@@ -597,13 +599,8 @@ function _tls12_read_client_key_exchange!(
     if state.curve_id == _TLS_GROUP_X25519
         length(ciphertext) == 33 ||
             _tls_fail(_TLS_ALERT_ILLEGAL_PARAMETER, "tls: malformed TLS 1.2 ClientKeyExchange")
-    elseif state.curve_id == _TLS_GROUP_SECP256R1
-        length(ciphertext) == 66 ||
-            _tls_fail(_TLS_ALERT_ILLEGAL_PARAMETER, "tls: malformed TLS 1.2 ClientKeyExchange")
-        ciphertext[2] == 0x04 ||
-            _tls_fail(_TLS_ALERT_ILLEGAL_PARAMETER, "tls: malformed TLS 1.2 ClientKeyExchange")
-    elseif state.curve_id == _TLS_GROUP_SECP384R1
-        length(ciphertext) == 98 ||
+    elseif _tls_nist_curve_supported(state.curve_id)
+        length(ciphertext) == 1 + _tls_nist_curve_public_key_length(state.curve_id) ||
             _tls_fail(_TLS_ALERT_ILLEGAL_PARAMETER, "tls: malformed TLS 1.2 ClientKeyExchange")
         ciphertext[2] == 0x04 ||
             _tls_fail(_TLS_ALERT_ILLEGAL_PARAMETER, "tls: malformed TLS 1.2 ClientKeyExchange")
@@ -619,11 +616,8 @@ function _tls12_server_shared_secret(state::_TLS12ServerHandshakeState, client_k
     if state.curve_id == _TLS_GROUP_X25519
         return _tls13_x25519_shared_secret(state.ecdhe_private_key, @view(client_key_exchange[2:end]))
     end
-    if state.curve_id == _TLS_GROUP_SECP256R1
-        return _tls13_p256_shared_secret(state.ecdhe_private_key, @view(client_key_exchange[2:end]))
-    end
-    if state.curve_id == _TLS_GROUP_SECP384R1
-        return _tls13_p384_shared_secret(state.ecdhe_private_key, @view(client_key_exchange[2:end]))
+    if _tls_nist_curve_supported(state.curve_id)
+        return _tls_ec_shared_secret(state.curve_id, state.ecdhe_private_key, @view(client_key_exchange[2:end]))
     end
     _tls_fail(_TLS_ALERT_HANDSHAKE_FAILURE, "tls: unsupported native TLS 1.2 ECDHE group")
 end

--- a/src/tls/handshake_server_tls12.jl
+++ b/src/tls/handshake_server_tls12.jl
@@ -291,13 +291,18 @@ function _tls12_select_server_curve(client_hello::_ClientHelloMsg, config)::UInt
     preferred_curves = _tls12_curve_preferences(config)
     for group in preferred_curves
         in(group, client_hello.supported_curves) || continue
-        if group == _TLS_GROUP_SECP256R1 && !_tls12_client_supports_uncompressed_points(client_hello)
+        if (group == _TLS_GROUP_SECP256R1 || group == _TLS_GROUP_SECP384R1) &&
+           !_tls12_client_supports_uncompressed_points(client_hello)
             continue
         end
         return group
     end
-    if in(_TLS_GROUP_SECP256R1, preferred_curves) &&
-       in(_TLS_GROUP_SECP256R1, client_hello.supported_curves) &&
+    has_uncompressed_ec_overlap =
+        (in(_TLS_GROUP_SECP256R1, preferred_curves) &&
+         in(_TLS_GROUP_SECP256R1, client_hello.supported_curves)) ||
+        (in(_TLS_GROUP_SECP384R1, preferred_curves) &&
+         in(_TLS_GROUP_SECP384R1, client_hello.supported_curves))
+    if has_uncompressed_ec_overlap &&
        !_tls12_client_supports_uncompressed_points(client_hello)
         _tls_fail(_TLS_ALERT_HANDSHAKE_FAILURE, "tls: client did not offer uncompressed TLS 1.2 EC points")
     end
@@ -450,7 +455,8 @@ function _tls12_send_server_hello!(
     server_hello.secure_renegotiation_supported = state.client_hello.secure_renegotiation_supported
     server_hello.server_name_ack = !isempty(state.client_hello.server_name)
     server_hello.alpn_protocol = state.selected_alpn
-    if state.curve_id == _TLS_GROUP_SECP256R1 && !isempty(state.client_hello.supported_points)
+    if (state.curve_id == _TLS_GROUP_SECP256R1 || state.curve_id == _TLS_GROUP_SECP384R1) &&
+       !isempty(state.client_hello.supported_points)
         server_hello.supported_points = UInt8[0x00]
     end
     state.server_hello = server_hello
@@ -480,6 +486,9 @@ function _tls12_server_key_exchange_params(state::_TLS12ServerHandshakeState)::V
     elseif state.curve_id == _TLS_GROUP_SECP256R1
         state.ecdhe_private_key = _tls13_p256_generate_private_key()
         public_key = _tls13_p256_public_key(state.ecdhe_private_key)
+    elseif state.curve_id == _TLS_GROUP_SECP384R1
+        state.ecdhe_private_key = _tls13_p384_generate_private_key()
+        public_key = _tls13_p384_public_key(state.ecdhe_private_key)
     else
         _tls_fail(_TLS_ALERT_HANDSHAKE_FAILURE, "tls: unsupported native TLS 1.2 ECDHE group")
     end
@@ -593,6 +602,11 @@ function _tls12_read_client_key_exchange!(
             _tls_fail(_TLS_ALERT_ILLEGAL_PARAMETER, "tls: malformed TLS 1.2 ClientKeyExchange")
         ciphertext[2] == 0x04 ||
             _tls_fail(_TLS_ALERT_ILLEGAL_PARAMETER, "tls: malformed TLS 1.2 ClientKeyExchange")
+    elseif state.curve_id == _TLS_GROUP_SECP384R1
+        length(ciphertext) == 98 ||
+            _tls_fail(_TLS_ALERT_ILLEGAL_PARAMETER, "tls: malformed TLS 1.2 ClientKeyExchange")
+        ciphertext[2] == 0x04 ||
+            _tls_fail(_TLS_ALERT_ILLEGAL_PARAMETER, "tls: malformed TLS 1.2 ClientKeyExchange")
     else
         _tls_fail(_TLS_ALERT_HANDSHAKE_FAILURE, "tls: unsupported native TLS 1.2 ECDHE group")
     end
@@ -607,6 +621,9 @@ function _tls12_server_shared_secret(state::_TLS12ServerHandshakeState, client_k
     end
     if state.curve_id == _TLS_GROUP_SECP256R1
         return _tls13_p256_shared_secret(state.ecdhe_private_key, @view(client_key_exchange[2:end]))
+    end
+    if state.curve_id == _TLS_GROUP_SECP384R1
+        return _tls13_p384_shared_secret(state.ecdhe_private_key, @view(client_key_exchange[2:end]))
     end
     _tls_fail(_TLS_ALERT_HANDSHAKE_FAILURE, "tls: unsupported native TLS 1.2 ECDHE group")
 end

--- a/src/tls/openssl_crypto.jl
+++ b/src/tls/openssl_crypto.jl
@@ -13,6 +13,7 @@ const _TLS_SIGNATURE_RSA_PSS_PSS_SHA384 = UInt16(0x080a)
 const _TLS_SIGNATURE_RSA_PSS_PSS_SHA512 = UInt16(0x080b)
 
 const _TLS_GROUP_SECP256R1 = UInt16(0x0017)
+const _TLS_GROUP_SECP384R1 = UInt16(0x0018)
 const _TLS_GROUP_X25519 = UInt16(0x001d)
 
 const _X25519_PKEY_ID = Ref{Cint}(0)
@@ -265,7 +266,7 @@ end
 
 @inline function _tls_ec_curve_group_nid(curve_id::UInt16)::Cint
     curve_id == _TLS_GROUP_SECP256R1 && return _init_p256_group_nid!()
-    curve_id == UInt16(0x0018) && return _init_p384_group_nid!()
+    curve_id == _TLS_GROUP_SECP384R1 && return _init_p384_group_nid!()
     curve_id == UInt16(0x0019) && return _init_p521_group_nid!()
     throw(ArgumentError("unsupported TLS EC curve: $(string(curve_id, base = 16))"))
 end
@@ -753,6 +754,136 @@ function _tls13_p256_shared_secret(private_key::Ptr{Cvoid}, peer_public_key::Abs
         if iszero(all_zero)
             _securezero!(out)
             _tls_fail(_TLS_ALERT_ILLEGAL_PARAMETER, "tls: invalid P-256 shared secret")
+        end
+        return out
+    finally
+        _free_evp_pkey_ctx!(ctx)
+        _free_evp_pkey!(peer_pkey)
+    end
+end
+
+function _tls13_p384_generate_private_key()::Ptr{Cvoid}
+    ec_key = Ptr{Cvoid}(C_NULL)
+    pkey = Ptr{Cvoid}(C_NULL)
+    try
+        ec_key = ccall((:EC_KEY_new_by_curve_name, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Cint,), _init_p384_group_nid!())
+        _openssl_require_nonnull(ec_key, "EC_KEY_new_by_curve_name(P-384)")
+        _openssl_require_ok(ccall((:EC_KEY_generate_key, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid},), ec_key), "EC_KEY_generate_key(P-384)")
+        pkey = ccall((:EVP_PKEY_new, _LIBCRYPTO_PATH), Ptr{Cvoid}, ())
+        _openssl_require_nonnull(pkey, "EVP_PKEY_new")
+        _openssl_require_ok(ccall((:EVP_PKEY_set1_EC_KEY, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), pkey, ec_key), "EVP_PKEY_set1_EC_KEY(P-384)")
+        out = pkey
+        pkey = C_NULL
+        return out
+    finally
+        _free_evp_pkey!(pkey)
+        _free_ec_key!(ec_key)
+    end
+end
+
+function _tls13_p384_public_key(pkey::Ptr{Cvoid})::Vector{UInt8}
+    ec_key = Ptr{Cvoid}(C_NULL)
+    try
+        ec_key = ccall((:EVP_PKEY_get1_EC_KEY, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid},), pkey)
+        _openssl_require_nonnull(ec_key, "EVP_PKEY_get1_EC_KEY")
+        group = ccall((:EC_KEY_get0_group, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid},), ec_key)
+        _openssl_require_nonnull(group, "EC_KEY_get0_group(P-384)")
+        point = ccall((:EC_KEY_get0_public_key, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid},), ec_key)
+        _openssl_require_nonnull(point, "EC_KEY_get0_public_key(P-384)")
+        out_len = ccall(
+            (:EC_POINT_point2oct, _LIBCRYPTO_PATH),
+            Csize_t,
+            (Ptr{Cvoid}, Ptr{Cvoid}, Cint, Ptr{UInt8}, Csize_t, Ptr{Cvoid}),
+            group,
+            point,
+            Cint(4),
+            Ptr{UInt8}(C_NULL),
+            Csize_t(0),
+            C_NULL,
+        )
+        out_len > 0 || throw(_make_tls_error("EC_POINT_point2oct(P-384)", Int32(out_len)))
+        out = Vector{UInt8}(undef, Int(out_len))
+        GC.@preserve out begin
+            wrote = ccall(
+                (:EC_POINT_point2oct, _LIBCRYPTO_PATH),
+                Csize_t,
+                (Ptr{Cvoid}, Ptr{Cvoid}, Cint, Ptr{UInt8}, Csize_t, Ptr{Cvoid}),
+                group,
+                point,
+                Cint(4),
+                pointer(out),
+                Csize_t(length(out)),
+                C_NULL,
+            )
+            Int(wrote) == length(out) || throw(_make_tls_error("EC_POINT_point2oct(P-384)", Int32(wrote)))
+        end
+        return out
+    finally
+        _free_ec_key!(ec_key)
+    end
+end
+
+function _tls13_p384_peer_public_key(peer_public_key::AbstractVector{UInt8})::Ptr{Cvoid}
+    length(peer_public_key) == 97 || throw(ArgumentError("tls13 P-384 public key must be 97 bytes in uncompressed form"))
+    peer_public_key[1] == 0x04 || throw(ArgumentError("tls13 P-384 public key must use the uncompressed point format"))
+    peer_bytes = Vector{UInt8}(peer_public_key)
+    ec_key = Ptr{Cvoid}(C_NULL)
+    point = Ptr{Cvoid}(C_NULL)
+    pkey = Ptr{Cvoid}(C_NULL)
+    try
+        ec_key = ccall((:EC_KEY_new_by_curve_name, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Cint,), _init_p384_group_nid!())
+        _openssl_require_nonnull(ec_key, "EC_KEY_new_by_curve_name(P-384)")
+        group = ccall((:EC_KEY_get0_group, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid},), ec_key)
+        _openssl_require_nonnull(group, "EC_KEY_get0_group(P-384)")
+        point = ccall((:EC_POINT_new, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid},), group)
+        _openssl_require_nonnull(point, "EC_POINT_new(P-384)")
+        ok = GC.@preserve peer_bytes ccall(
+            (:EC_POINT_oct2point, _LIBCRYPTO_PATH),
+            Cint,
+            (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{UInt8}, Csize_t, Ptr{Cvoid}),
+            group,
+            point,
+            pointer(peer_bytes),
+            Csize_t(length(peer_bytes)),
+            C_NULL,
+        )
+        _openssl_require_ok(ok, "EC_POINT_oct2point(P-384)")
+        _openssl_require_ok(ccall((:EC_KEY_set_public_key, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), ec_key, point), "EC_KEY_set_public_key(P-384)")
+        pkey = ccall((:EVP_PKEY_new, _LIBCRYPTO_PATH), Ptr{Cvoid}, ())
+        _openssl_require_nonnull(pkey, "EVP_PKEY_new")
+        _openssl_require_ok(ccall((:EVP_PKEY_set1_EC_KEY, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), pkey, ec_key), "EVP_PKEY_set1_EC_KEY(P-384)")
+        out = pkey
+        pkey = C_NULL
+        return out
+    finally
+        _free_evp_pkey!(pkey)
+        _free_ec_point!(point)
+        _free_ec_key!(ec_key)
+    end
+end
+
+function _tls13_p384_shared_secret(private_key::Ptr{Cvoid}, peer_public_key::AbstractVector{UInt8})::Vector{UInt8}
+    peer_pkey = _tls13_p384_peer_public_key(peer_public_key)
+    ctx = Ptr{Cvoid}(C_NULL)
+    try
+        ctx = ccall((:EVP_PKEY_CTX_new, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cvoid}), private_key, C_NULL)
+        _openssl_require_nonnull(ctx, "EVP_PKEY_CTX_new(P-384)")
+        _openssl_require_ok(ccall((:EVP_PKEY_derive_init, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid},), ctx), "EVP_PKEY_derive_init(P-384)")
+        _openssl_require_ok(ccall((:EVP_PKEY_derive_set_peer, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), ctx, peer_pkey), "EVP_PKEY_derive_set_peer(P-384)")
+        out_len = Ref{Csize_t}(0)
+        _openssl_require_ok(ccall((:EVP_PKEY_derive, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{UInt8}, Ref{Csize_t}), ctx, Ptr{UInt8}(C_NULL), out_len), "EVP_PKEY_derive(P-384)")
+        out = Vector{UInt8}(undef, Int(out_len[]))
+        GC.@preserve out begin
+            _openssl_require_ok(ccall((:EVP_PKEY_derive, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{UInt8}, Ref{Csize_t}), ctx, pointer(out), out_len), "EVP_PKEY_derive(P-384)")
+        end
+        resize!(out, Int(out_len[]))
+        all_zero = UInt8(0)
+        @inbounds for byte in out
+            all_zero |= byte
+        end
+        if iszero(all_zero)
+            _securezero!(out)
+            _tls_fail(_TLS_ALERT_ILLEGAL_PARAMETER, "tls: invalid P-384 shared secret")
         end
         return out
     finally

--- a/src/tls/openssl_crypto.jl
+++ b/src/tls/openssl_crypto.jl
@@ -14,6 +14,7 @@ const _TLS_SIGNATURE_RSA_PSS_PSS_SHA512 = UInt16(0x080b)
 
 const _TLS_GROUP_SECP256R1 = UInt16(0x0017)
 const _TLS_GROUP_SECP384R1 = UInt16(0x0018)
+const _TLS_GROUP_SECP521R1 = UInt16(0x0019)
 const _TLS_GROUP_X25519 = UInt16(0x001d)
 
 const _X25519_PKEY_ID = Ref{Cint}(0)
@@ -267,8 +268,32 @@ end
 @inline function _tls_ec_curve_group_nid(curve_id::UInt16)::Cint
     curve_id == _TLS_GROUP_SECP256R1 && return _init_p256_group_nid!()
     curve_id == _TLS_GROUP_SECP384R1 && return _init_p384_group_nid!()
-    curve_id == UInt16(0x0019) && return _init_p521_group_nid!()
+    curve_id == _TLS_GROUP_SECP521R1 && return _init_p521_group_nid!()
     throw(ArgumentError("unsupported TLS EC curve: $(string(curve_id, base = 16))"))
+end
+
+@inline function _tls_nist_curve_supported(group::UInt16)::Bool
+    return group == _TLS_GROUP_SECP256R1 ||
+        group == _TLS_GROUP_SECP384R1 ||
+        group == _TLS_GROUP_SECP521R1
+end
+
+@inline function _tls_nist_curve_name(group::UInt16)::String
+    group == _TLS_GROUP_SECP256R1 && return "P-256"
+    group == _TLS_GROUP_SECP384R1 && return "P-384"
+    group == _TLS_GROUP_SECP521R1 && return "P-521"
+    throw(ArgumentError("unsupported TLS NIST curve: $(string(group, base = 16))"))
+end
+
+@inline function _tls_nist_curve_scalar_length(group::UInt16)::Int
+    group == _TLS_GROUP_SECP256R1 && return 32
+    group == _TLS_GROUP_SECP384R1 && return 48
+    group == _TLS_GROUP_SECP521R1 && return 66
+    throw(ArgumentError("unsupported TLS NIST curve: $(string(group, base = 16))"))
+end
+
+@inline function _tls_nist_curve_public_key_length(group::UInt16)::Int
+    return 1 + 2 * _tls_nist_curve_scalar_length(group)
 end
 
 function _openssl_bn_from_bytes(bytes::AbstractVector{UInt8}, op::AbstractString)::Ptr{Cvoid}
@@ -587,8 +612,11 @@ function _tls13_openssl_x25519_server_share_and_secret(client_share::AbstractVec
     end
 end
 
-function _tls13_p256_private_key_from_bytes(private_key::AbstractVector{UInt8})::Ptr{Cvoid}
-    length(private_key) == 32 || throw(ArgumentError("tls13 P-256 private key must be 32 bytes"))
+function _tls_ec_private_key_from_bytes(group_id::UInt16, private_key::AbstractVector{UInt8})::Ptr{Cvoid}
+    curve_name = _tls_nist_curve_name(group_id)
+    private_key_length = _tls_nist_curve_scalar_length(group_id)
+    length(private_key) == private_key_length ||
+        throw(ArgumentError("TLS $curve_name private key must be $private_key_length bytes"))
     private_bytes = Vector{UInt8}(private_key)
     ec_key = Ptr{Cvoid}(C_NULL)
     private_bn = Ptr{Cvoid}(C_NULL)
@@ -596,8 +624,8 @@ function _tls13_p256_private_key_from_bytes(private_key::AbstractVector{UInt8}):
     bn_ctx = Ptr{Cvoid}(C_NULL)
     pkey = Ptr{Cvoid}(C_NULL)
     try
-        ec_key = ccall((:EC_KEY_new_by_curve_name, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Cint,), _init_p256_group_nid!())
-        _openssl_require_nonnull(ec_key, "EC_KEY_new_by_curve_name(P-256)")
+        ec_key = ccall((:EC_KEY_new_by_curve_name, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Cint,), _tls_ec_curve_group_nid(group_id))
+        _openssl_require_nonnull(ec_key, "EC_KEY_new_by_curve_name($curve_name)")
         private_bn = GC.@preserve private_bytes ccall(
             (:BN_bin2bn, _LIBCRYPTO_PATH),
             Ptr{Cvoid},
@@ -607,18 +635,18 @@ function _tls13_p256_private_key_from_bytes(private_key::AbstractVector{UInt8}):
             C_NULL,
         )
         _openssl_require_nonnull(private_bn, "BN_bin2bn")
-        _openssl_require_ok(ccall((:EC_KEY_set_private_key, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), ec_key, private_bn), "EC_KEY_set_private_key(P-256)")
+        _openssl_require_ok(ccall((:EC_KEY_set_private_key, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), ec_key, private_bn), "EC_KEY_set_private_key($curve_name)")
         group = ccall((:EC_KEY_get0_group, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid},), ec_key)
-        _openssl_require_nonnull(group, "EC_KEY_get0_group(P-256)")
+        _openssl_require_nonnull(group, "EC_KEY_get0_group($curve_name)")
         point = ccall((:EC_POINT_new, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid},), group)
-        _openssl_require_nonnull(point, "EC_POINT_new(P-256)")
+        _openssl_require_nonnull(point, "EC_POINT_new($curve_name)")
         bn_ctx = ccall((:BN_CTX_new, _LIBCRYPTO_PATH), Ptr{Cvoid}, ())
         _openssl_require_nonnull(bn_ctx, "BN_CTX_new")
-        _openssl_require_ok(ccall((:EC_POINT_mul, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), group, point, private_bn, C_NULL, C_NULL, bn_ctx), "EC_POINT_mul(P-256)")
-        _openssl_require_ok(ccall((:EC_KEY_set_public_key, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), ec_key, point), "EC_KEY_set_public_key(P-256)")
+        _openssl_require_ok(ccall((:EC_POINT_mul, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), group, point, private_bn, C_NULL, C_NULL, bn_ctx), "EC_POINT_mul($curve_name)")
+        _openssl_require_ok(ccall((:EC_KEY_set_public_key, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), ec_key, point), "EC_KEY_set_public_key($curve_name)")
         pkey = ccall((:EVP_PKEY_new, _LIBCRYPTO_PATH), Ptr{Cvoid}, ())
         _openssl_require_nonnull(pkey, "EVP_PKEY_new")
-        _openssl_require_ok(ccall((:EVP_PKEY_set1_EC_KEY, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), pkey, ec_key), "EVP_PKEY_set1_EC_KEY(P-256)")
+        _openssl_require_ok(ccall((:EVP_PKEY_set1_EC_KEY, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), pkey, ec_key), "EVP_PKEY_set1_EC_KEY($curve_name)")
         out = pkey
         pkey = C_NULL
         return out
@@ -632,16 +660,17 @@ function _tls13_p256_private_key_from_bytes(private_key::AbstractVector{UInt8}):
     end
 end
 
-function _tls13_p256_generate_private_key()::Ptr{Cvoid}
+function _tls_ec_generate_private_key(group_id::UInt16)::Ptr{Cvoid}
+    curve_name = _tls_nist_curve_name(group_id)
     ec_key = Ptr{Cvoid}(C_NULL)
     pkey = Ptr{Cvoid}(C_NULL)
     try
-        ec_key = ccall((:EC_KEY_new_by_curve_name, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Cint,), _init_p256_group_nid!())
-        _openssl_require_nonnull(ec_key, "EC_KEY_new_by_curve_name(P-256)")
-        _openssl_require_ok(ccall((:EC_KEY_generate_key, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid},), ec_key), "EC_KEY_generate_key(P-256)")
+        ec_key = ccall((:EC_KEY_new_by_curve_name, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Cint,), _tls_ec_curve_group_nid(group_id))
+        _openssl_require_nonnull(ec_key, "EC_KEY_new_by_curve_name($curve_name)")
+        _openssl_require_ok(ccall((:EC_KEY_generate_key, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid},), ec_key), "EC_KEY_generate_key($curve_name)")
         pkey = ccall((:EVP_PKEY_new, _LIBCRYPTO_PATH), Ptr{Cvoid}, ())
         _openssl_require_nonnull(pkey, "EVP_PKEY_new")
-        _openssl_require_ok(ccall((:EVP_PKEY_set1_EC_KEY, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), pkey, ec_key), "EVP_PKEY_set1_EC_KEY(P-256)")
+        _openssl_require_ok(ccall((:EVP_PKEY_set1_EC_KEY, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), pkey, ec_key), "EVP_PKEY_set1_EC_KEY($curve_name)")
         out = pkey
         pkey = C_NULL
         return out
@@ -651,15 +680,17 @@ function _tls13_p256_generate_private_key()::Ptr{Cvoid}
     end
 end
 
-function _tls13_p256_public_key(pkey::Ptr{Cvoid})::Vector{UInt8}
+function _tls_ec_public_key(group_id::UInt16, pkey::Ptr{Cvoid})::Vector{UInt8}
+    curve_name = _tls_nist_curve_name(group_id)
+    expected_length = _tls_nist_curve_public_key_length(group_id)
     ec_key = Ptr{Cvoid}(C_NULL)
     try
         ec_key = ccall((:EVP_PKEY_get1_EC_KEY, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid},), pkey)
         _openssl_require_nonnull(ec_key, "EVP_PKEY_get1_EC_KEY")
         group = ccall((:EC_KEY_get0_group, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid},), ec_key)
-        _openssl_require_nonnull(group, "EC_KEY_get0_group(P-256)")
+        _openssl_require_nonnull(group, "EC_KEY_get0_group($curve_name)")
         point = ccall((:EC_KEY_get0_public_key, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid},), ec_key)
-        _openssl_require_nonnull(point, "EC_KEY_get0_public_key(P-256)")
+        _openssl_require_nonnull(point, "EC_KEY_get0_public_key($curve_name)")
         out_len = ccall(
             (:EC_POINT_point2oct, _LIBCRYPTO_PATH),
             Csize_t,
@@ -671,7 +702,8 @@ function _tls13_p256_public_key(pkey::Ptr{Cvoid})::Vector{UInt8}
             Csize_t(0),
             C_NULL,
         )
-        out_len > 0 || throw(_make_tls_error("EC_POINT_point2oct(P-256)", Int32(out_len)))
+        Int(out_len) == expected_length ||
+            throw(_make_tls_error("EC_POINT_point2oct($curve_name)", Int32(out_len)))
         out = Vector{UInt8}(undef, Int(out_len))
         GC.@preserve out begin
             wrote = ccall(
@@ -685,7 +717,8 @@ function _tls13_p256_public_key(pkey::Ptr{Cvoid})::Vector{UInt8}
                 Csize_t(length(out)),
                 C_NULL,
             )
-            Int(wrote) == length(out) || throw(_make_tls_error("EC_POINT_point2oct(P-256)", Int32(wrote)))
+            Int(wrote) == length(out) ||
+                throw(_make_tls_error("EC_POINT_point2oct($curve_name)", Int32(wrote)))
         end
         return out
     finally
@@ -693,20 +726,24 @@ function _tls13_p256_public_key(pkey::Ptr{Cvoid})::Vector{UInt8}
     end
 end
 
-function _tls13_p256_peer_public_key(peer_public_key::AbstractVector{UInt8})::Ptr{Cvoid}
-    length(peer_public_key) == 65 || throw(ArgumentError("tls13 P-256 public key must be 65 bytes in uncompressed form"))
-    peer_public_key[1] == 0x04 || throw(ArgumentError("tls13 P-256 public key must use the uncompressed point format"))
+function _tls_ec_peer_public_key(group_id::UInt16, peer_public_key::AbstractVector{UInt8})::Ptr{Cvoid}
+    curve_name = _tls_nist_curve_name(group_id)
+    expected_length = _tls_nist_curve_public_key_length(group_id)
+    length(peer_public_key) == expected_length ||
+        throw(ArgumentError("TLS $curve_name public key must be $expected_length bytes in uncompressed form"))
+    peer_public_key[1] == 0x04 ||
+        throw(ArgumentError("TLS $curve_name public key must use the uncompressed point format"))
     peer_bytes = Vector{UInt8}(peer_public_key)
     ec_key = Ptr{Cvoid}(C_NULL)
     point = Ptr{Cvoid}(C_NULL)
     pkey = Ptr{Cvoid}(C_NULL)
     try
-        ec_key = ccall((:EC_KEY_new_by_curve_name, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Cint,), _init_p256_group_nid!())
-        _openssl_require_nonnull(ec_key, "EC_KEY_new_by_curve_name(P-256)")
+        ec_key = ccall((:EC_KEY_new_by_curve_name, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Cint,), _tls_ec_curve_group_nid(group_id))
+        _openssl_require_nonnull(ec_key, "EC_KEY_new_by_curve_name($curve_name)")
         group = ccall((:EC_KEY_get0_group, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid},), ec_key)
-        _openssl_require_nonnull(group, "EC_KEY_get0_group(P-256)")
+        _openssl_require_nonnull(group, "EC_KEY_get0_group($curve_name)")
         point = ccall((:EC_POINT_new, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid},), group)
-        _openssl_require_nonnull(point, "EC_POINT_new(P-256)")
+        _openssl_require_nonnull(point, "EC_POINT_new($curve_name)")
         ok = GC.@preserve peer_bytes ccall(
             (:EC_POINT_oct2point, _LIBCRYPTO_PATH),
             Cint,
@@ -717,11 +754,11 @@ function _tls13_p256_peer_public_key(peer_public_key::AbstractVector{UInt8})::Pt
             Csize_t(length(peer_bytes)),
             C_NULL,
         )
-        _openssl_require_ok(ok, "EC_POINT_oct2point(P-256)")
-        _openssl_require_ok(ccall((:EC_KEY_set_public_key, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), ec_key, point), "EC_KEY_set_public_key(P-256)")
+        _openssl_require_ok(ok, "EC_POINT_oct2point($curve_name)")
+        _openssl_require_ok(ccall((:EC_KEY_set_public_key, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), ec_key, point), "EC_KEY_set_public_key($curve_name)")
         pkey = ccall((:EVP_PKEY_new, _LIBCRYPTO_PATH), Ptr{Cvoid}, ())
         _openssl_require_nonnull(pkey, "EVP_PKEY_new")
-        _openssl_require_ok(ccall((:EVP_PKEY_set1_EC_KEY, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), pkey, ec_key), "EVP_PKEY_set1_EC_KEY(P-256)")
+        _openssl_require_ok(ccall((:EVP_PKEY_set1_EC_KEY, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), pkey, ec_key), "EVP_PKEY_set1_EC_KEY($curve_name)")
         out = pkey
         pkey = C_NULL
         return out
@@ -732,19 +769,24 @@ function _tls13_p256_peer_public_key(peer_public_key::AbstractVector{UInt8})::Pt
     end
 end
 
-function _tls13_p256_shared_secret(private_key::Ptr{Cvoid}, peer_public_key::AbstractVector{UInt8})::Vector{UInt8}
-    peer_pkey = _tls13_p256_peer_public_key(peer_public_key)
+function _tls_ec_shared_secret(
+    group_id::UInt16,
+    private_key::Ptr{Cvoid},
+    peer_public_key::AbstractVector{UInt8},
+)::Vector{UInt8}
+    curve_name = _tls_nist_curve_name(group_id)
+    peer_pkey = _tls_ec_peer_public_key(group_id, peer_public_key)
     ctx = Ptr{Cvoid}(C_NULL)
     try
         ctx = ccall((:EVP_PKEY_CTX_new, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cvoid}), private_key, C_NULL)
-        _openssl_require_nonnull(ctx, "EVP_PKEY_CTX_new(P-256)")
-        _openssl_require_ok(ccall((:EVP_PKEY_derive_init, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid},), ctx), "EVP_PKEY_derive_init(P-256)")
-        _openssl_require_ok(ccall((:EVP_PKEY_derive_set_peer, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), ctx, peer_pkey), "EVP_PKEY_derive_set_peer(P-256)")
+        _openssl_require_nonnull(ctx, "EVP_PKEY_CTX_new($curve_name)")
+        _openssl_require_ok(ccall((:EVP_PKEY_derive_init, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid},), ctx), "EVP_PKEY_derive_init($curve_name)")
+        _openssl_require_ok(ccall((:EVP_PKEY_derive_set_peer, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), ctx, peer_pkey), "EVP_PKEY_derive_set_peer($curve_name)")
         out_len = Ref{Csize_t}(0)
-        _openssl_require_ok(ccall((:EVP_PKEY_derive, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{UInt8}, Ref{Csize_t}), ctx, Ptr{UInt8}(C_NULL), out_len), "EVP_PKEY_derive(P-256)")
+        _openssl_require_ok(ccall((:EVP_PKEY_derive, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{UInt8}, Ref{Csize_t}), ctx, Ptr{UInt8}(C_NULL), out_len), "EVP_PKEY_derive($curve_name)")
         out = Vector{UInt8}(undef, Int(out_len[]))
         GC.@preserve out begin
-            _openssl_require_ok(ccall((:EVP_PKEY_derive, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{UInt8}, Ref{Csize_t}), ctx, pointer(out), out_len), "EVP_PKEY_derive(P-256)")
+            _openssl_require_ok(ccall((:EVP_PKEY_derive, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{UInt8}, Ref{Csize_t}), ctx, pointer(out), out_len), "EVP_PKEY_derive($curve_name)")
         end
         resize!(out, Int(out_len[]))
         all_zero = UInt8(0)
@@ -753,7 +795,7 @@ function _tls13_p256_shared_secret(private_key::Ptr{Cvoid}, peer_public_key::Abs
         end
         if iszero(all_zero)
             _securezero!(out)
-            _tls_fail(_TLS_ALERT_ILLEGAL_PARAMETER, "tls: invalid P-256 shared secret")
+            _tls_fail(_TLS_ALERT_ILLEGAL_PARAMETER, "tls: invalid $curve_name shared secret")
         end
         return out
     finally
@@ -762,142 +804,16 @@ function _tls13_p256_shared_secret(private_key::Ptr{Cvoid}, peer_public_key::Abs
     end
 end
 
-function _tls13_p384_generate_private_key()::Ptr{Cvoid}
-    ec_key = Ptr{Cvoid}(C_NULL)
-    pkey = Ptr{Cvoid}(C_NULL)
+function _tls_openssl_ec_server_share_and_secret(
+    group_id::UInt16,
+    client_share::AbstractVector{UInt8},
+    server_private_key::AbstractVector{UInt8},
+)::_TLSKeyShareSecret
+    pkey = _tls_ec_private_key_from_bytes(group_id, server_private_key)
     try
-        ec_key = ccall((:EC_KEY_new_by_curve_name, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Cint,), _init_p384_group_nid!())
-        _openssl_require_nonnull(ec_key, "EC_KEY_new_by_curve_name(P-384)")
-        _openssl_require_ok(ccall((:EC_KEY_generate_key, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid},), ec_key), "EC_KEY_generate_key(P-384)")
-        pkey = ccall((:EVP_PKEY_new, _LIBCRYPTO_PATH), Ptr{Cvoid}, ())
-        _openssl_require_nonnull(pkey, "EVP_PKEY_new")
-        _openssl_require_ok(ccall((:EVP_PKEY_set1_EC_KEY, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), pkey, ec_key), "EVP_PKEY_set1_EC_KEY(P-384)")
-        out = pkey
-        pkey = C_NULL
-        return out
-    finally
-        _free_evp_pkey!(pkey)
-        _free_ec_key!(ec_key)
-    end
-end
-
-function _tls13_p384_public_key(pkey::Ptr{Cvoid})::Vector{UInt8}
-    ec_key = Ptr{Cvoid}(C_NULL)
-    try
-        ec_key = ccall((:EVP_PKEY_get1_EC_KEY, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid},), pkey)
-        _openssl_require_nonnull(ec_key, "EVP_PKEY_get1_EC_KEY")
-        group = ccall((:EC_KEY_get0_group, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid},), ec_key)
-        _openssl_require_nonnull(group, "EC_KEY_get0_group(P-384)")
-        point = ccall((:EC_KEY_get0_public_key, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid},), ec_key)
-        _openssl_require_nonnull(point, "EC_KEY_get0_public_key(P-384)")
-        out_len = ccall(
-            (:EC_POINT_point2oct, _LIBCRYPTO_PATH),
-            Csize_t,
-            (Ptr{Cvoid}, Ptr{Cvoid}, Cint, Ptr{UInt8}, Csize_t, Ptr{Cvoid}),
-            group,
-            point,
-            Cint(4),
-            Ptr{UInt8}(C_NULL),
-            Csize_t(0),
-            C_NULL,
-        )
-        out_len > 0 || throw(_make_tls_error("EC_POINT_point2oct(P-384)", Int32(out_len)))
-        out = Vector{UInt8}(undef, Int(out_len))
-        GC.@preserve out begin
-            wrote = ccall(
-                (:EC_POINT_point2oct, _LIBCRYPTO_PATH),
-                Csize_t,
-                (Ptr{Cvoid}, Ptr{Cvoid}, Cint, Ptr{UInt8}, Csize_t, Ptr{Cvoid}),
-                group,
-                point,
-                Cint(4),
-                pointer(out),
-                Csize_t(length(out)),
-                C_NULL,
-            )
-            Int(wrote) == length(out) || throw(_make_tls_error("EC_POINT_point2oct(P-384)", Int32(wrote)))
-        end
-        return out
-    finally
-        _free_ec_key!(ec_key)
-    end
-end
-
-function _tls13_p384_peer_public_key(peer_public_key::AbstractVector{UInt8})::Ptr{Cvoid}
-    length(peer_public_key) == 97 || throw(ArgumentError("tls13 P-384 public key must be 97 bytes in uncompressed form"))
-    peer_public_key[1] == 0x04 || throw(ArgumentError("tls13 P-384 public key must use the uncompressed point format"))
-    peer_bytes = Vector{UInt8}(peer_public_key)
-    ec_key = Ptr{Cvoid}(C_NULL)
-    point = Ptr{Cvoid}(C_NULL)
-    pkey = Ptr{Cvoid}(C_NULL)
-    try
-        ec_key = ccall((:EC_KEY_new_by_curve_name, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Cint,), _init_p384_group_nid!())
-        _openssl_require_nonnull(ec_key, "EC_KEY_new_by_curve_name(P-384)")
-        group = ccall((:EC_KEY_get0_group, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid},), ec_key)
-        _openssl_require_nonnull(group, "EC_KEY_get0_group(P-384)")
-        point = ccall((:EC_POINT_new, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid},), group)
-        _openssl_require_nonnull(point, "EC_POINT_new(P-384)")
-        ok = GC.@preserve peer_bytes ccall(
-            (:EC_POINT_oct2point, _LIBCRYPTO_PATH),
-            Cint,
-            (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{UInt8}, Csize_t, Ptr{Cvoid}),
-            group,
-            point,
-            pointer(peer_bytes),
-            Csize_t(length(peer_bytes)),
-            C_NULL,
-        )
-        _openssl_require_ok(ok, "EC_POINT_oct2point(P-384)")
-        _openssl_require_ok(ccall((:EC_KEY_set_public_key, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), ec_key, point), "EC_KEY_set_public_key(P-384)")
-        pkey = ccall((:EVP_PKEY_new, _LIBCRYPTO_PATH), Ptr{Cvoid}, ())
-        _openssl_require_nonnull(pkey, "EVP_PKEY_new")
-        _openssl_require_ok(ccall((:EVP_PKEY_set1_EC_KEY, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), pkey, ec_key), "EVP_PKEY_set1_EC_KEY(P-384)")
-        out = pkey
-        pkey = C_NULL
-        return out
-    finally
-        _free_evp_pkey!(pkey)
-        _free_ec_point!(point)
-        _free_ec_key!(ec_key)
-    end
-end
-
-function _tls13_p384_shared_secret(private_key::Ptr{Cvoid}, peer_public_key::AbstractVector{UInt8})::Vector{UInt8}
-    peer_pkey = _tls13_p384_peer_public_key(peer_public_key)
-    ctx = Ptr{Cvoid}(C_NULL)
-    try
-        ctx = ccall((:EVP_PKEY_CTX_new, _LIBCRYPTO_PATH), Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cvoid}), private_key, C_NULL)
-        _openssl_require_nonnull(ctx, "EVP_PKEY_CTX_new(P-384)")
-        _openssl_require_ok(ccall((:EVP_PKEY_derive_init, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid},), ctx), "EVP_PKEY_derive_init(P-384)")
-        _openssl_require_ok(ccall((:EVP_PKEY_derive_set_peer, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), ctx, peer_pkey), "EVP_PKEY_derive_set_peer(P-384)")
-        out_len = Ref{Csize_t}(0)
-        _openssl_require_ok(ccall((:EVP_PKEY_derive, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{UInt8}, Ref{Csize_t}), ctx, Ptr{UInt8}(C_NULL), out_len), "EVP_PKEY_derive(P-384)")
-        out = Vector{UInt8}(undef, Int(out_len[]))
-        GC.@preserve out begin
-            _openssl_require_ok(ccall((:EVP_PKEY_derive, _LIBCRYPTO_PATH), Cint, (Ptr{Cvoid}, Ptr{UInt8}, Ref{Csize_t}), ctx, pointer(out), out_len), "EVP_PKEY_derive(P-384)")
-        end
-        resize!(out, Int(out_len[]))
-        all_zero = UInt8(0)
-        @inbounds for byte in out
-            all_zero |= byte
-        end
-        if iszero(all_zero)
-            _securezero!(out)
-            _tls_fail(_TLS_ALERT_ILLEGAL_PARAMETER, "tls: invalid P-384 shared secret")
-        end
-        return out
-    finally
-        _free_evp_pkey_ctx!(ctx)
-        _free_evp_pkey!(peer_pkey)
-    end
-end
-
-function _tls13_openssl_p256_server_share_and_secret(client_share::AbstractVector{UInt8}, server_private_key::AbstractVector{UInt8})::_TLSKeyShareSecret
-    pkey = _tls13_p256_private_key_from_bytes(server_private_key)
-    try
-        share_data = _tls13_p256_public_key(pkey)
-        secret = _tls13_p256_shared_secret(pkey, client_share)
-        return _TLSKeyShareSecret(_TLS_GROUP_SECP256R1, share_data, secret)
+        share_data = _tls_ec_public_key(group_id, pkey)
+        secret = _tls_ec_shared_secret(group_id, pkey, client_share)
+        return _TLSKeyShareSecret(group_id, share_data, secret)
     finally
         _free_evp_pkey!(pkey)
     end

--- a/src/tls/x509.jl
+++ b/src/tls/x509.jl
@@ -604,7 +604,7 @@ function _tls_parse_subject_public_key_info(bytes::AbstractVector{UInt8}, value_
         elseif _asn1_oid_equals(bytes, curve_oid_start, curve_oid_end, _ASN1_OID_CURVE_P384)
             _TLS_GROUP_SECP384R1
         elseif _asn1_oid_equals(bytes, curve_oid_start, curve_oid_end, _ASN1_OID_CURVE_P521)
-            UInt16(0x0019)
+            _TLS_GROUP_SECP521R1
         else
             throw(ArgumentError("tls: unsupported X.509 EC named curve"))
         end

--- a/src/tls/x509.jl
+++ b/src/tls/x509.jl
@@ -602,7 +602,7 @@ function _tls_parse_subject_public_key_info(bytes::AbstractVector{UInt8}, value_
         curve_id = if _asn1_oid_equals(bytes, curve_oid_start, curve_oid_end, _ASN1_OID_CURVE_P256)
             _TLS_GROUP_SECP256R1
         elseif _asn1_oid_equals(bytes, curve_oid_start, curve_oid_end, _ASN1_OID_CURVE_P384)
-            UInt16(0x0018)
+            _TLS_GROUP_SECP384R1
         elseif _asn1_oid_equals(bytes, curve_oid_start, curve_oid_end, _ASN1_OID_CURVE_P521)
             UInt16(0x0019)
         else

--- a/test/tls_config_tests.jl
+++ b/test/tls_config_tests.jl
@@ -42,13 +42,13 @@ end
         @test cfg_default.verify_hostname
         @test !isdefined(TL, :TLS1_0_VERSION)
         @test !isdefined(TL, :TLS1_1_VERSION)
-        @test TL._native_curve_preferences(cfg_default) == UInt16[TL.X25519, TL.P256, TL.P384]
-        @test TL._tls12_curve_preferences(cfg_default) == UInt16[TL.P256, TL.P384]
+        @test TL._native_curve_preferences(cfg_default) == UInt16[TL.X25519, TL.P256, TL.P384, TL.P521]
+        @test TL._tls12_curve_preferences(cfg_default) == UInt16[TL.X25519, TL.P256, TL.P384, TL.P521]
         @test TL._native_curve_preferences(TL.Config(
             min_version = TL.TLS1_3_VERSION,
             max_version = TL.TLS1_3_VERSION,
-            curve_preferences = UInt16[TL.P384, TL.P256, TL.X25519],
-        )) == UInt16[TL.P384, TL.P256, TL.X25519]
+            curve_preferences = UInt16[TL.P521, TL.P384, TL.P256, TL.X25519],
+        )) == UInt16[TL.P521, TL.P384, TL.P256, TL.X25519]
         alpn = ["h2"]
         curves = UInt16[TL.P256]
         positional_cfg = TL.Config(
@@ -192,6 +192,7 @@ end
         @test_throws TL.ConfigError TL._validate_config(TL.Config(verify_peer = false, curve_preferences = UInt16[0x9999]); is_server = false)
         @test TL._validate_config(TL.Config(verify_peer = false, curve_preferences = UInt16[TL.P256]); is_server = false) === nothing
         @test TL._validate_config(TL.Config(verify_peer = false, curve_preferences = UInt16[TL.P384]); is_server = false) === nothing
+        @test TL._validate_config(TL.Config(verify_peer = false, curve_preferences = UInt16[TL.P521]); is_server = false) === nothing
         @test TL._validate_config(TL.Config(
             verify_peer = false,
             min_version = TL.TLS1_2_VERSION,

--- a/test/tls_config_tests.jl
+++ b/test/tls_config_tests.jl
@@ -42,13 +42,13 @@ end
         @test cfg_default.verify_hostname
         @test !isdefined(TL, :TLS1_0_VERSION)
         @test !isdefined(TL, :TLS1_1_VERSION)
-        @test TL._native_curve_preferences(cfg_default) == UInt16[TL.X25519, TL.P256]
-        @test TL._tls12_curve_preferences(cfg_default) == UInt16[TL.P256]
+        @test TL._native_curve_preferences(cfg_default) == UInt16[TL.X25519, TL.P256, TL.P384]
+        @test TL._tls12_curve_preferences(cfg_default) == UInt16[TL.P256, TL.P384]
         @test TL._native_curve_preferences(TL.Config(
             min_version = TL.TLS1_3_VERSION,
             max_version = TL.TLS1_3_VERSION,
-            curve_preferences = UInt16[TL.P256, TL.X25519],
-        )) == UInt16[TL.P256, TL.X25519]
+            curve_preferences = UInt16[TL.P384, TL.P256, TL.X25519],
+        )) == UInt16[TL.P384, TL.P256, TL.X25519]
         alpn = ["h2"]
         curves = UInt16[TL.P256]
         positional_cfg = TL.Config(
@@ -191,6 +191,7 @@ end
         @test_throws TL.ConfigError TL.Config(server_name = "localhost", verify_peer = false, max_version = UInt16(0x0302))
         @test_throws TL.ConfigError TL._validate_config(TL.Config(verify_peer = false, curve_preferences = UInt16[0x9999]); is_server = false)
         @test TL._validate_config(TL.Config(verify_peer = false, curve_preferences = UInt16[TL.P256]); is_server = false) === nothing
+        @test TL._validate_config(TL.Config(verify_peer = false, curve_preferences = UInt16[TL.P384]); is_server = false) === nothing
         @test TL._validate_config(TL.Config(
             verify_peer = false,
             min_version = TL.TLS1_2_VERSION,

--- a/test/tls_handshake_client_tls12_tests.jl
+++ b/test/tls_handshake_client_tls12_tests.jl
@@ -73,7 +73,7 @@ end
             TL12H._TLS12_ECDHE_RSA_WITH_AES_128_GCM_SHA256_ID,
             TL12H._TLS12_ECDHE_RSA_WITH_AES_256_GCM_SHA384_ID,
         ]
-        @test hello.supported_curves == UInt16[TL12H.P256]
+        @test hello.supported_curves == UInt16[TL12H.P256, TL12H.P384]
         @test hello.supported_points == UInt8[0x00]
         @test hello.extended_master_secret
         @test !hello.ocsp_stapling

--- a/test/tls_handshake_client_tls12_tests.jl
+++ b/test/tls_handshake_client_tls12_tests.jl
@@ -40,9 +40,9 @@ function _tls12_generate_test_ed25519_pkey()::Ptr{Cvoid}
 end
 
 function _tls12_make_server_key_exchange(client_random::Vector{UInt8}, server_random::Vector{UInt8})
-    pkey = TL12H._tls13_p256_private_key_from_bytes(_TLS12_SERVER_P256_PRIVATE_KEY)
+    pkey = TL12H._tls_ec_private_key_from_bytes(TL12H.P256, _TLS12_SERVER_P256_PRIVATE_KEY)
     try
-        public_key = TL12H._tls13_p256_public_key(pkey)
+        public_key = TL12H._tls_ec_public_key(TL12H.P256, pkey)
         params = UInt8[0x03, UInt8(TL12H.P256 >> 8), UInt8(TL12H.P256 & 0xff), UInt8(length(public_key))]
         append!(params, public_key)
         signed = vcat(client_random, server_random, params)
@@ -73,7 +73,7 @@ end
             TL12H._TLS12_ECDHE_RSA_WITH_AES_128_GCM_SHA256_ID,
             TL12H._TLS12_ECDHE_RSA_WITH_AES_256_GCM_SHA384_ID,
         ]
-        @test hello.supported_curves == UInt16[TL12H.P256, TL12H.P384]
+        @test hello.supported_curves == UInt16[TL12H.X25519, TL12H.P256, TL12H.P384, TL12H.P521]
         @test hello.supported_points == UInt8[0x00]
         @test hello.extended_master_secret
         @test !hello.ocsp_stapling
@@ -160,9 +160,9 @@ end
     end
 
     @testset "client key exchange generation returns an encoded EC point" begin
-        pkey = TL12H._tls13_p256_private_key_from_bytes(_TLS12_SERVER_P256_PRIVATE_KEY)
+        pkey = TL12H._tls_ec_private_key_from_bytes(TL12H.P256, _TLS12_SERVER_P256_PRIVATE_KEY)
         try
-            public_key = TL12H._tls13_p256_public_key(pkey)
+            public_key = TL12H._tls_ec_public_key(TL12H.P256, pkey)
             result = TL12H._tls12_generate_client_key_exchange(UInt16[TL12H.P256], TL12H.P256, public_key)
             @test result.message isa TL12H._ClientKeyExchangeMsgTLS12
             @test !isempty(result.shared_secret)

--- a/test/tls_handshake_client_tls13_tests.jl
+++ b/test/tls_handshake_client_tls13_tests.jl
@@ -426,6 +426,10 @@ end
         client_p256_pkey = Ptr{Cvoid}(C_NULL)
         client_p256_secret = UInt8[]
         server_p256_secret = UInt8[]
+        client_p384_pkey = Ptr{Cvoid}(C_NULL)
+        server_p384_pkey = Ptr{Cvoid}(C_NULL)
+        client_p384_secret = UInt8[]
+        server_p384_secret = UInt8[]
         p256_cert_pkey = Ptr{Cvoid}(C_NULL)
         p384_cert_pkey = Ptr{Cvoid}(C_NULL)
         p521_cert_pkey = Ptr{Cvoid}(C_NULL)
@@ -460,6 +464,17 @@ end
             @test client_p256_secret == p256_result.secret
             @test_throws ArgumentError TLHC._tls13_p256_peer_public_key(vcat(UInt8[0x02], zeros(UInt8, 32)))
 
+            client_p384_pkey = TLHC._tls13_p384_generate_private_key()
+            server_p384_pkey = TLHC._tls13_p384_generate_private_key()
+            client_p384_share = TLHC._tls13_p384_public_key(client_p384_pkey)
+            server_p384_share = TLHC._tls13_p384_public_key(server_p384_pkey)
+            client_p384_secret = TLHC._tls13_p384_shared_secret(client_p384_pkey, server_p384_share)
+            server_p384_secret = TLHC._tls13_p384_shared_secret(server_p384_pkey, client_p384_share)
+            @test length(client_p384_share) == 97
+            @test length(server_p384_share) == 97
+            @test client_p384_secret == server_p384_secret
+            @test_throws ArgumentError TLHC._tls13_p384_peer_public_key(vcat(UInt8[0x02], zeros(UInt8, 48)))
+
             p256_cert_pkey = _tls13_generate_test_ec_pkey("prime256v1")
             p384_cert_pkey = _tls13_generate_test_ec_pkey("secp384r1")
             p521_cert_pkey = _tls13_generate_test_ec_pkey("secp521r1")
@@ -490,6 +505,8 @@ end
         finally
             TLHC._free_evp_pkey!(client_pkey)
             TLHC._free_evp_pkey!(client_p256_pkey)
+            TLHC._free_evp_pkey!(client_p384_pkey)
+            TLHC._free_evp_pkey!(server_p384_pkey)
             TLHC._free_evp_pkey!(p256_cert_pkey)
             TLHC._free_evp_pkey!(p384_cert_pkey)
             TLHC._free_evp_pkey!(p521_cert_pkey)
@@ -497,6 +514,8 @@ end
             TLHC._securezero!(server_secret)
             TLHC._securezero!(client_p256_secret)
             TLHC._securezero!(server_p256_secret)
+            TLHC._securezero!(client_p384_secret)
+            TLHC._securezero!(server_p384_secret)
         end
     end
 
@@ -783,7 +802,7 @@ end
                  sh.server_share = TLHC._TLSKeyShare(TLHC._TLS_GROUP_X25519, zeros(UInt8, 32))
             end),
             ("unsupported selected group", TLHC._TLS_ALERT_ILLEGAL_PARAMETER,
-             sh -> (sh.selected_group = UInt16(0x0018))),
+             sh -> (sh.selected_group = TLHC._TLS_GROUP_SECP384R1)),
             ("redundant selected group", TLHC._TLS_ALERT_ILLEGAL_PARAMETER,
              sh -> (sh.selected_group = TLHC._TLS_GROUP_X25519)),
             ("unsolicited ECH", TLHC._TLS_ALERT_UNSUPPORTED_EXTENSION,

--- a/test/tls_handshake_client_tls13_tests.jl
+++ b/test/tls_handshake_client_tls13_tests.jl
@@ -140,7 +140,11 @@ function _tls13_server_share_and_secret(client_share::TLHC._TLSKeyShare)
         return TLHC._tls13_openssl_x25519_server_share_and_secret(client_share.data, _TLS13_TEST_SERVER_X25519_PRIVATE_KEY)
     end
     if client_share.group == TLHC._TLS_GROUP_SECP256R1
-        return TLHC._tls13_openssl_p256_server_share_and_secret(client_share.data, _TLS13_TEST_SERVER_P256_PRIVATE_KEY)
+        return TLHC._tls_openssl_ec_server_share_and_secret(
+            TLHC.P256,
+            client_share.data,
+            _TLS13_TEST_SERVER_P256_PRIVATE_KEY,
+        )
     end
     error("unsupported test key-share group $(string(client_share.group, base = 16))")
 end
@@ -426,10 +430,6 @@ end
         client_p256_pkey = Ptr{Cvoid}(C_NULL)
         client_p256_secret = UInt8[]
         server_p256_secret = UInt8[]
-        client_p384_pkey = Ptr{Cvoid}(C_NULL)
-        server_p384_pkey = Ptr{Cvoid}(C_NULL)
-        client_p384_secret = UInt8[]
-        server_p384_secret = UInt8[]
         p256_cert_pkey = Ptr{Cvoid}(C_NULL)
         p384_cert_pkey = Ptr{Cvoid}(C_NULL)
         p521_cert_pkey = Ptr{Cvoid}(C_NULL)
@@ -455,25 +455,49 @@ end
                 @test err isa TLHC.TLSError || err isa ArgumentError
             end
 
-            client_p256_pkey = TLHC._tls13_p256_private_key_from_bytes(_TLS13_TEST_CLIENT_P256_PRIVATE_KEY)
-            client_p256_share = TLHC._tls13_p256_public_key(client_p256_pkey)
-            p256_result = TLHC._tls13_openssl_p256_server_share_and_secret(client_p256_share, _TLS13_TEST_SERVER_P256_PRIVATE_KEY)
+            client_p256_pkey = TLHC._tls_ec_private_key_from_bytes(TLHC.P256, _TLS13_TEST_CLIENT_P256_PRIVATE_KEY)
+            client_p256_share = TLHC._tls_ec_public_key(TLHC.P256, client_p256_pkey)
+            p256_result = TLHC._tls_openssl_ec_server_share_and_secret(
+                TLHC.P256,
+                client_p256_share,
+                _TLS13_TEST_SERVER_P256_PRIVATE_KEY,
+            )
             server_p256_secret = p256_result.secret
-            client_p256_secret = TLHC._tls13_p256_shared_secret(client_p256_pkey, p256_result.share_data)
+            client_p256_secret = TLHC._tls_ec_shared_secret(TLHC.P256, client_p256_pkey, p256_result.share_data)
             @test p256_result.group == TLHC._TLS_GROUP_SECP256R1
             @test client_p256_secret == p256_result.secret
-            @test_throws ArgumentError TLHC._tls13_p256_peer_public_key(vcat(UInt8[0x02], zeros(UInt8, 32)))
+            @test_throws ArgumentError TLHC._tls_ec_peer_public_key(
+                TLHC.P256,
+                vcat(UInt8[0x02], zeros(UInt8, 32)),
+            )
 
-            client_p384_pkey = TLHC._tls13_p384_generate_private_key()
-            server_p384_pkey = TLHC._tls13_p384_generate_private_key()
-            client_p384_share = TLHC._tls13_p384_public_key(client_p384_pkey)
-            server_p384_share = TLHC._tls13_p384_public_key(server_p384_pkey)
-            client_p384_secret = TLHC._tls13_p384_shared_secret(client_p384_pkey, server_p384_share)
-            server_p384_secret = TLHC._tls13_p384_shared_secret(server_p384_pkey, client_p384_share)
-            @test length(client_p384_share) == 97
-            @test length(server_p384_share) == 97
-            @test client_p384_secret == server_p384_secret
-            @test_throws ArgumentError TLHC._tls13_p384_peer_public_key(vcat(UInt8[0x02], zeros(UInt8, 48)))
+            for (group, public_key_length, coordinate_length) in (
+                (TLHC.P384, 97, 48),
+                (TLHC.P521, 133, 66),
+            )
+                client_pkey_nist = TLHC._tls_ec_generate_private_key(group)
+                server_pkey_nist = TLHC._tls_ec_generate_private_key(group)
+                client_secret_nist = UInt8[]
+                server_secret_nist = UInt8[]
+                try
+                    client_share_nist = TLHC._tls_ec_public_key(group, client_pkey_nist)
+                    server_share_nist = TLHC._tls_ec_public_key(group, server_pkey_nist)
+                    client_secret_nist = TLHC._tls_ec_shared_secret(group, client_pkey_nist, server_share_nist)
+                    server_secret_nist = TLHC._tls_ec_shared_secret(group, server_pkey_nist, client_share_nist)
+                    @test length(client_share_nist) == public_key_length
+                    @test length(server_share_nist) == public_key_length
+                    @test client_secret_nist == server_secret_nist
+                    @test_throws ArgumentError TLHC._tls_ec_peer_public_key(
+                        group,
+                        vcat(UInt8[0x02], zeros(UInt8, coordinate_length)),
+                    )
+                finally
+                    TLHC._free_evp_pkey!(client_pkey_nist)
+                    TLHC._free_evp_pkey!(server_pkey_nist)
+                    TLHC._securezero!(client_secret_nist)
+                    TLHC._securezero!(server_secret_nist)
+                end
+            end
 
             p256_cert_pkey = _tls13_generate_test_ec_pkey("prime256v1")
             p384_cert_pkey = _tls13_generate_test_ec_pkey("secp384r1")
@@ -505,8 +529,6 @@ end
         finally
             TLHC._free_evp_pkey!(client_pkey)
             TLHC._free_evp_pkey!(client_p256_pkey)
-            TLHC._free_evp_pkey!(client_p384_pkey)
-            TLHC._free_evp_pkey!(server_p384_pkey)
             TLHC._free_evp_pkey!(p256_cert_pkey)
             TLHC._free_evp_pkey!(p384_cert_pkey)
             TLHC._free_evp_pkey!(p521_cert_pkey)
@@ -514,8 +536,6 @@ end
             TLHC._securezero!(server_secret)
             TLHC._securezero!(client_p256_secret)
             TLHC._securezero!(server_p256_secret)
-            TLHC._securezero!(client_p384_secret)
-            TLHC._securezero!(server_p384_secret)
         end
     end
 

--- a/test/tls_native_tls12_tests.jl
+++ b/test/tls_native_tls12_tests.jl
@@ -784,7 +784,7 @@ end
                     "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
                 )
                 @test !state.using_native_tls13
-                @test state.curve == "P-256"
+                @test state.curve == "X25519"
                 @test read(conn, 4) == UInt8[0x70, 0x69, 0x6e, 0x67]
                 write(conn, UInt8[0x70, 0x6f, 0x6e, 0x67])
                 nothing
@@ -801,7 +801,7 @@ end
                 "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
             )
             @test !state.using_native_tls13
-            @test state.curve == "P-256"
+            @test state.curve == "X25519"
 
             write(client, UInt8[0x70, 0x69, 0x6e, 0x67])
             @test read(client, 4) == UInt8[0x70, 0x6f, 0x6e, 0x67]
@@ -881,9 +881,9 @@ end
         end
     end
 
-    @testset "exact TLS 1.2 curve preferences can negotiate X25519 natively" begin
-        server_cfg = _tls12_server_config(curve_preferences = UInt16[TL12N.X25519])
-        client_cfg = _tls12_native_client_config(curve_preferences = UInt16[TL12N.X25519])
+    @testset "exact TLS 1.2 defaults negotiate X25519 natively" begin
+        server_cfg = _tls12_server_config()
+        client_cfg = _tls12_native_client_config()
         client_state, server_state = _tls12_run_public_roundtrip(server_cfg, client_cfg)
         @test client_state.handshake_complete
         @test server_state.handshake_complete
@@ -895,18 +895,20 @@ end
         @test server_state.curve == "X25519"
     end
 
-    @testset "exact TLS 1.2 curve preferences can negotiate P-384 natively" begin
-        server_cfg = _tls12_server_config(curve_preferences = UInt16[TL12N.P384])
-        client_cfg = _tls12_native_client_config(curve_preferences = UInt16[TL12N.P384])
-        client_state, server_state = _tls12_run_public_roundtrip(server_cfg, client_cfg)
-        @test client_state.handshake_complete
-        @test server_state.handshake_complete
-        @test client_state.version == "TLSv1.2"
-        @test server_state.version == "TLSv1.2"
-        @test client_state.cipher_suite == "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-        @test server_state.cipher_suite == "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-        @test client_state.curve == "P-384"
-        @test server_state.curve == "P-384"
+    for (group, curve_name) in ((TL12N.P384, "P-384"), (TL12N.P521, "P-521"))
+        @testset "exact TLS 1.2 curve preferences can negotiate $curve_name natively" begin
+            server_cfg = _tls12_server_config(curve_preferences = UInt16[group])
+            client_cfg = _tls12_native_client_config(curve_preferences = UInt16[group])
+            client_state, server_state = _tls12_run_public_roundtrip(server_cfg, client_cfg)
+            @test client_state.handshake_complete
+            @test server_state.handshake_complete
+            @test client_state.version == "TLSv1.2"
+            @test server_state.version == "TLSv1.2"
+            @test client_state.cipher_suite == "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+            @test server_state.cipher_suite == "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+            @test client_state.curve == curve_name
+            @test server_state.curve == curve_name
+        end
     end
 
     @testset "exact TLS 1.2 client verifies the server certificate" begin
@@ -1011,8 +1013,8 @@ end
         @test !client_state1.did_resume
         @test !server_state1.did_resume
         @test client_state1.has_resumable_session
-        @test client_state1.curve == "P-256"
-        @test server_state1.curve == "P-256"
+        @test client_state1.curve == "X25519"
+        @test server_state1.curve == "X25519"
 
         client_state2, server_state2 = _tls12_run_public_roundtrip(server_cfg, client_cfg)
         @test client_state2.handshake_complete
@@ -1024,8 +1026,8 @@ end
         @test client_state2.did_resume
         @test server_state2.did_resume
         @test client_state2.has_resumable_session
-        @test client_state2.curve == "P-256"
-        @test server_state2.curve == "P-256"
+        @test client_state2.curve == "X25519"
+        @test server_state2.curve == "X25519"
 
         client_state3, server_state3 = _tls12_run_public_roundtrip(server_cfg, client_cfg)
         @test client_state3.handshake_complete
@@ -1037,8 +1039,8 @@ end
         @test client_state3.did_resume
         @test server_state3.did_resume
         @test client_state3.has_resumable_session
-        @test client_state3.curve == "P-256"
-        @test server_state3.curve == "P-256"
+        @test client_state3.curve == "X25519"
+        @test server_state3.curve == "X25519"
     end
 
     @testset "exact TLS 1.2 ECDSA server certificates negotiate ECDHE-ECDSA" begin
@@ -1058,8 +1060,8 @@ end
         @test server_state.version == "TLSv1.2"
         @test client_state.cipher_suite == "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
         @test server_state.cipher_suite == "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
-        @test client_state.curve == "P-256"
-        @test server_state.curve == "P-256"
+        @test client_state.curve == "X25519"
+        @test server_state.curve == "X25519"
     end
 
     @testset "exact TLS 1.2 ECDSA CN-only certificates are rejected by hostname verification" begin

--- a/test/tls_native_tls12_tests.jl
+++ b/test/tls_native_tls12_tests.jl
@@ -895,6 +895,20 @@ end
         @test server_state.curve == "X25519"
     end
 
+    @testset "exact TLS 1.2 curve preferences can negotiate P-384 natively" begin
+        server_cfg = _tls12_server_config(curve_preferences = UInt16[TL12N.P384])
+        client_cfg = _tls12_native_client_config(curve_preferences = UInt16[TL12N.P384])
+        client_state, server_state = _tls12_run_public_roundtrip(server_cfg, client_cfg)
+        @test client_state.handshake_complete
+        @test server_state.handshake_complete
+        @test client_state.version == "TLSv1.2"
+        @test server_state.version == "TLSv1.2"
+        @test client_state.cipher_suite == "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+        @test server_state.cipher_suite == "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+        @test client_state.curve == "P-384"
+        @test server_state.curve == "P-384"
+    end
+
     @testset "exact TLS 1.2 client verifies the server certificate" begin
         listener = nothing
         client = nothing

--- a/test/tls_native_tls13_tests.jl
+++ b/test/tls_native_tls13_tests.jl
@@ -1526,35 +1526,37 @@ end
         end
     end
 
-    @testset "native server handles HelloRetryRequest with P-384 through public APIs" begin
-        IPN.shutdown!()
-        listener = nothing
-        client = nothing
-        server = nothing
-        server_task = nothing
-        try
-            listener, addr, server_task, _ = _start_tls13_native_server(_tls13_native_server_config(
-                curve_preferences = UInt16[TLN.P384],
-            ))
-            client = TLN.connect(addr, _tls13_native_client_config(server_name = "localhost", verify_peer = false))
-            _finish_tls13_native_server!(server_task::Task)
-            server = fetch(server_task::Task)
-            client_state = TLN.connection_state(client)
-            server_state = TLN.connection_state(server)
-            @test client_state.using_native_tls13
-            @test server_state.using_native_tls13
-            @test client_state.did_hello_retry_request
-            @test server_state.did_hello_retry_request
-            @test client_state.curve == "P-384"
-            @test server_state.curve == "P-384"
-            payload = UInt8[0x41, 0x42, 0x43]
-            @test write(client, payload) == length(payload)
-            @test read(server, length(payload)) == payload
-        finally
-            _tls_native_close_quiet!(server)
-            _tls_native_close_quiet!(client)
-            _tls_native_close_quiet!(listener)
+    for (group, curve_name) in ((TLN.P384, "P-384"), (TLN.P521, "P-521"))
+        @testset "native server handles HelloRetryRequest with $curve_name through public APIs" begin
             IPN.shutdown!()
+            listener = nothing
+            client = nothing
+            server = nothing
+            server_task = nothing
+            try
+                listener, addr, server_task, _ = _start_tls13_native_server(_tls13_native_server_config(
+                    curve_preferences = UInt16[group],
+                ))
+                client = TLN.connect(addr, _tls13_native_client_config(server_name = "localhost", verify_peer = false))
+                _finish_tls13_native_server!(server_task::Task)
+                server = fetch(server_task::Task)
+                client_state = TLN.connection_state(client)
+                server_state = TLN.connection_state(server)
+                @test client_state.using_native_tls13
+                @test server_state.using_native_tls13
+                @test client_state.did_hello_retry_request
+                @test server_state.did_hello_retry_request
+                @test client_state.curve == curve_name
+                @test server_state.curve == curve_name
+                payload = UInt8[0x41, 0x42, 0x43]
+                @test write(client, payload) == length(payload)
+                @test read(server, length(payload)) == payload
+            finally
+                _tls_native_close_quiet!(server)
+                _tls_native_close_quiet!(client)
+                _tls_native_close_quiet!(listener)
+                IPN.shutdown!()
+            end
         end
     end
 

--- a/test/tls_native_tls13_tests.jl
+++ b/test/tls_native_tls13_tests.jl
@@ -1526,6 +1526,38 @@ end
         end
     end
 
+    @testset "native server handles HelloRetryRequest with P-384 through public APIs" begin
+        IPN.shutdown!()
+        listener = nothing
+        client = nothing
+        server = nothing
+        server_task = nothing
+        try
+            listener, addr, server_task, _ = _start_tls13_native_server(_tls13_native_server_config(
+                curve_preferences = UInt16[TLN.P384],
+            ))
+            client = TLN.connect(addr, _tls13_native_client_config(server_name = "localhost", verify_peer = false))
+            _finish_tls13_native_server!(server_task::Task)
+            server = fetch(server_task::Task)
+            client_state = TLN.connection_state(client)
+            server_state = TLN.connection_state(server)
+            @test client_state.using_native_tls13
+            @test server_state.using_native_tls13
+            @test client_state.did_hello_retry_request
+            @test server_state.did_hello_retry_request
+            @test client_state.curve == "P-384"
+            @test server_state.curve == "P-384"
+            payload = UInt8[0x41, 0x42, 0x43]
+            @test write(client, payload) == length(payload)
+            @test read(server, length(payload)) == payload
+        finally
+            _tls_native_close_quiet!(server)
+            _tls_native_close_quiet!(client)
+            _tls_native_close_quiet!(listener)
+            IPN.shutdown!()
+        end
+    end
+
     @testset "live native TLS fragments large application payloads" begin
         IPN.shutdown!()
         listener = nothing

--- a/test/tls_public_api_tests.jl
+++ b/test/tls_public_api_tests.jl
@@ -969,8 +969,8 @@ end
                 @test server_state.version == "TLSv1.2"
                 @test !client_state.using_native_tls13
                 @test !server_state.using_native_tls13
-                @test client_state.curve == "P-256"
-                @test server_state.curve == "P-256"
+                @test client_state.curve == "X25519"
+                @test server_state.curve == "X25519"
             finally
                 _tls_close_quiet!(server)
                 _tls_close_quiet!(client)
@@ -1015,8 +1015,8 @@ end
                 @test server_state.version == "TLSv1.2"
                 @test !client_state.using_native_tls13
                 @test !server_state.using_native_tls13
-                @test client_state.curve == "P-256"
-                @test server_state.curve == "P-256"
+                @test client_state.curve == "X25519"
+                @test server_state.curve == "X25519"
             finally
                 _tls_close_quiet!(server)
                 _tls_close_quiet!(client)
@@ -1132,8 +1132,8 @@ end
             @test !client_state1.did_resume
             @test !server_state1.did_resume
             @test client_state1.has_resumable_session
-            @test client_state1.curve == "P-256"
-            @test server_state1.curve == "P-256"
+            @test client_state1.curve == "X25519"
+            @test server_state1.curve == "X25519"
 
             client_state2, server_state2 = run_once(server_cfg, client_cfg)
             @test client_state2.version == "TLSv1.2"
@@ -1145,8 +1145,8 @@ end
             @test client_state2.did_resume
             @test server_state2.did_resume
             @test client_state2.has_resumable_session
-            @test client_state2.curve == "P-256"
-            @test server_state2.curve == "P-256"
+            @test client_state2.curve == "X25519"
+            @test server_state2.curve == "X25519"
         end
         @testset "mixed-version native server supports TLS 1.2 mTLS and resumption against an exact TLS 1.2 client" begin
             function run_once(server_cfg::TL.Config, client_cfg::TL.Config)
@@ -1208,8 +1208,8 @@ end
             @test !client_state1.did_resume
             @test !server_state1.did_resume
             @test client_state1.has_resumable_session
-            @test client_state1.curve == "P-256"
-            @test server_state1.curve == "P-256"
+            @test client_state1.curve == "X25519"
+            @test server_state1.curve == "X25519"
 
             client_state2, server_state2 = run_once(server_cfg, client_cfg)
             @test client_state2.version == "TLSv1.2"
@@ -1221,8 +1221,8 @@ end
             @test client_state2.did_resume
             @test server_state2.did_resume
             @test client_state2.has_resumable_session
-            @test client_state2.curve == "P-256"
-            @test server_state2.curve == "P-256"
+            @test client_state2.curve == "X25519"
+            @test server_state2.curve == "X25519"
         end
         @testset "mixed-version native client still offers TLS 1.2 resumption when a TLS 1.3 session is cached" begin
             function run_once(server_cfg::TL.Config, client_cfg::TL.Config)::TL.ConnectionState


### PR DESCRIPTION
## Summary

- support Go's complete classical TLS curve set and preference order: X25519, P-256, P-384, and P-521
- share one NIST EC implementation across P-256, P-384, and P-521 key generation, key shares, peer validation, and ECDH
- include X25519 in exact TLS 1.2 defaults, matching the existing mixed-version and TLS 1.3 defaults
- cover exclusive-group TLS 1.2/TLS 1.3 negotiation and P-256/P-384/P-521 HelloRetryRequest behavior

## Root cause

JuliaWeb/HTTP.jl#1338 reports that `https://www.postgresql.org/docs/current/errcodes-appendix.html` fails with a TLS alert 40 through Reseau.

The failure is below HTTP and ALPN: raw Reseau handshakes fail with no ALPN, `http/1.1`, and `h2`, and when forced to either TLS 1.2 or TLS 1.3. All three current PostgreSQL IPv4 mirrors behave the same way.

A controlled OpenSSL server restricted to TLS 1.3 and P-384 reproduces the same alert (`final_key_share:no suitable key share`) with Reseau v1.3.3. OpenSSL succeeds against PostgreSQL only when P-384 is offered; its negotiated key is secp384r1. Reseau's native TLS implementation previously offered only X25519 and P-256.

The same parity audit found two adjacent classical-curve gaps: P-521 was not supported, and exact TLS 1.2 defaults omitted X25519 even though Go uses the same classical set for both TLS versions. The duplicated P-256/P-384 OpenSSL glue is now one group-parameterized path that also handles P-521.

TLS 1.2 ChaCha cipher suites and TLS 1.3 ChaCha record protection remain out of scope.

## Validation

- full Reseau test suite on Julia 1.12, including trim compilation (42/42)
- focused configuration, handshake-helper, native TLS 1.2/TLS 1.3, and public-API suites on Julia 1.10 and 1.12 (1049/1049 assertions per version)
- controlled TLS 1.3 P-384-only OpenSSL server now completes after HelloRetryRequest
- controlled TLS 1.3 P-521-only OpenSSL server completes after HelloRetryRequest
- controlled exact TLS 1.2 handshakes complete against P-521-only and X25519-only OpenSSL servers using default client curves
- unmodified HTTP.jl `master` plus this Reseau branch returns 200 from the reported URL for `protocol=:auto`, `:h1`, and `:h2` (3/3 each)
- raw PostgreSQL TLS/ALPN matrix passes all 15 TLS version and ALPN combinations

Refs JuliaWeb/HTTP.jl#1338

Co-authored by Codex
