### PR TITLE
Reduce deadline scheduling overhead

### DIFF
--- a/src/iopoll/fd.jl
+++ b/src/iopoll/fd.jl
@@ -215,29 +215,32 @@ function _set_deadline_impl!(fd::FD, deadline_ns::Integer, mode::PollMode.T)
         lock(pd.lock)
         try
             (@atomic :acquire pd.closing) && return nothing
+            target = if deadline == 0
+                Int64(0)
+            elseif deadline <= _monotonic_ns()
+                Int64(-1)
+            else
+                deadline
+            end
+            read_unchanged = !_mode_has_read(mode) ||
+                (@atomic :acquire pd.rd_ns) == target
+            write_unchanged = !_mode_has_write(mode) ||
+                (@atomic :acquire pd.wd_ns) == target
+            # Reapplying an identical deadline does not change observable
+            # state. Avoid invalidating timer entries and taking the global
+            # timer-heap lock for this common case.
+            read_unchanged && write_unchanged && return nothing
             if _mode_has_read(mode)
                 # The new sequence invalidates every previously scheduled read
                 # deadline entry for this descriptor.
                 @atomic pd.rseq += UInt64(1)
-                if deadline == 0
-                    @atomic :release pd.rd_ns = Int64(0)
-                elseif deadline <= _monotonic_ns()
-                    @atomic :release pd.rd_ns = Int64(-1)
-                    wake_read = true
-                else
-                    @atomic :release pd.rd_ns = deadline
-                end
+                @atomic :release pd.rd_ns = target
+                wake_read = target < 0
             end
             if _mode_has_write(mode)
                 @atomic pd.wseq += UInt64(1)
-                if deadline == 0
-                    @atomic :release pd.wd_ns = Int64(0)
-                elseif deadline <= _monotonic_ns()
-                    @atomic :release pd.wd_ns = Int64(-1)
-                    wake_write = true
-                else
-                    @atomic :release pd.wd_ns = deadline
-                end
+                @atomic :release pd.wd_ns = target
+                wake_write = target < 0
             end
             rd_ns = @atomic :acquire pd.rd_ns
             wd_ns = @atomic :acquire pd.wd_ns

--- a/src/iopoll/timers.jl
+++ b/src/iopoll/timers.jl
@@ -206,10 +206,22 @@ function schedule_deadlines!(
     lock(state.lock)
     try
         _registration_active_locked(state, pd) || return nothing
-        for entry in _build_deadline_entries(pd, rd_ns, wd_ns, rseq, wseq)
+        if rd_ns > 0 && wd_ns > 0 && rd_ns == wd_ns
+            entry = _deadline_entry(rd_ns, pd, PollMode.READWRITE, rseq, wseq)
             _time_push_locked!(state, entry)
-            if new_earliest == 0 || entry.deadline_ns < new_earliest
+            new_earliest = entry.deadline_ns
+        else
+            if rd_ns > 0
+                entry = _deadline_entry(rd_ns, pd, PollMode.READ, rseq, UInt64(0))
+                _time_push_locked!(state, entry)
                 new_earliest = entry.deadline_ns
+            end
+            if wd_ns > 0
+                entry = _deadline_entry(wd_ns, pd, PollMode.WRITE, UInt64(0), wseq)
+                _time_push_locked!(state, entry)
+                if new_earliest == 0 || entry.deadline_ns < new_earliest
+                    new_earliest = entry.deadline_ns
+                end
             end
         end
     finally

--- a/test/internal_poll_tests.jl
+++ b/test/internal_poll_tests.jl
@@ -230,6 +230,31 @@ end
                 IP.shutdown!()
             end
         end
+        @testset "identical deadlines do not invalidate timer state" begin
+            fd0, fd1 = _ip_socketpair_stream()
+            ipfd = IP.FD(fd0)
+            fd0 = SO.INVALID_SOCKET
+            try
+                IP._set_nonblocking!(ipfd.sysfd)
+                IP.register!(ipfd)
+                initial_rseq = @atomic :acquire ipfd.pd.rseq
+                initial_wseq = @atomic :acquire ipfd.pd.wseq
+                IP.set_deadline!(ipfd, Int64(0))
+                @test (@atomic :acquire ipfd.pd.rseq) == initial_rseq
+                @test (@atomic :acquire ipfd.pd.wseq) == initial_wseq
+
+                future_deadline = Int64(time_ns()) + Int64(5_000_000_000)
+                IP.set_read_deadline!(ipfd, future_deadline)
+                updated_rseq = @atomic :acquire ipfd.pd.rseq
+                IP.set_read_deadline!(ipfd, future_deadline)
+                @test (@atomic :acquire ipfd.pd.rseq) == updated_rseq
+                @test (@atomic :acquire ipfd.pd.rd_ns) == future_deadline
+            finally
+                IP._is_valid_fd(ipfd.sysfd) && close(ipfd)
+                _ip_close_fd(fd1)
+                IP.shutdown!()
+            end
+        end
         @testset "stale deadline timer does not poison future waits" begin
             fd0, fd1 = _ip_socketpair_stream()
             ipfd = IP.FD(fd0)


### PR DESCRIPTION
## Summary

- return early when a descriptor deadline is already unchanged
- push zero, one, or two deadline entries directly into the timer heap
- avoid the temporary deadline-entry vector on every update
- add a regression test for timer sequence stability

## Root cause

HTTP read-idle and write-idle handling can apply deadlines for every body chunk. Reseau invalidated timer sequence state, allocated a temporary vector, and took the shared timer-heap lock even when the requested deadline was identical to the current state. At high connection counts, this became a cross-thread contention point.

The fast path normalizes the requested state first. It returns only when all selected deadline fields are already equal. Expired deadlines still wake the selected waiter when the state first changes.

## Benchmark evidence

The change was identified with `Profile` during a single-process, 64-thread Azure Blob benchmark. It forms part of the stack that reached 38.8 Gbps median download and 26.6 Gbps median upload on the same-region Azure test.

## Validation

- full Reseau suite passes on macOS aarch64 with Julia 1.13.0-rc1
- internal poll regression suite passes: 140 of 140
- IOPoll runtime suite passes: 1,743 of 1,743
- socket operations pass: 19 of 19
- TCP suite passes: 935 of 935
- remaining TLS and trim-compile test files pass on Julia 1.13.0-rc1

The Azure image has an unrelated resolver parity failure because its `/etc/hosts` maps `localhost` only to IPv4. GitHub CI remains the authoritative full-suite environment for that host-specific assertion.

Co-authored by Codex
