### PR TITLE
Skip trim compile tests when a non-Apple codesign shadows PATH

### DIFF
--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -74,6 +74,20 @@ function _trim_compiler_available()::Bool
     end
 end
 
+# JuliaC's macOS bundling step invokes `codesign` by PATH lookup, so a
+# non-Apple shim (e.g. sigtool's from conda-forge/Nix toolchains) earlier on
+# PATH fails the bundle signing with an unsupported-arguments error (#144).
+# Returns the shadowing path, or `nothing` when signing can work.
+function _trim_codesign_conflict()::Union{Nothing, String}
+    @static if Sys.isapple()
+        cs = Sys.which("codesign")
+        (cs === nothing || cs == "/usr/bin/codesign") && return nothing
+        return cs
+    else
+        return nothing
+    end
+end
+
 function _trim_output_path(dir::String, output_name::String)::String
     path = joinpath(dir, output_name)
     isfile(path) && return path
@@ -140,6 +154,9 @@ end
         @test true
     elseif !_trim_compiler_available()
         @warn "Reseau trim compile tests are being skipped." reason = "no C compiler found" action = "install gcc/clang or set JULIA_CC to run trim compilation tests"
+        @test true
+    elseif (_codesign_conflict = _trim_codesign_conflict()) !== nothing
+        @warn "Reseau trim compile tests are being skipped." reason = "a non-Apple `codesign` shadows /usr/bin/codesign on PATH and JuliaC's bundle signing would fail" codesign = _codesign_conflict action = "reorder PATH so /usr/bin/codesign wins, then rerun the trim tests"
         @test true
     else
         project_path = normpath(joinpath(@__DIR__, ".."))


### PR DESCRIPTION
## Summary

Fixes the local-test failure mode reported in #144: JuliaC's macOS bundling resolves `codesign` via `Sys.which`, so a non-Apple shim earlier on PATH (e.g. sigtool's `codesign` from conda-forge/Nix toolchains) rejects the `-f -s - --deep --timestamp=none` invocation and the trim tests die with an opaque `codesign failed` error deep inside JuliaC.

This adds a preflight to the trim-compile testset: on macOS, if `Sys.which("codesign")` resolves to anything other than `/usr/bin/codesign`, the trim cases are skipped with a warning that names the shadowing binary and the fix (reorder PATH), matching the existing no-C-compiler skip. When `codesign` resolves normally — including all CI runners — behavior is unchanged.

The root cause is also filed upstream against JuliaC (prefer `/usr/bin/codesign` over the PATH lookup); this gate just turns an obscure failure into an actionable one-line message until that lands.

## Verification

- Test file parses clean; `_trim_codesign_conflict()` returns `nothing` on a clean PATH (tests run) and returns the shim path when a fake `codesign` is prepended to PATH (tests skip with the warning).

Refs #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
