### PR TITLE
RFC: BufferIO.jl integration extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,14 +9,24 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
+[weakdeps]
+BufferIO = "ff366017-094f-4144-bd70-a828a0d67152"
+MemoryViews = "a791c907-b98b-4e44-8f4d-e4c2362c6b2f"
+
+[extensions]
+ReseauBufferIOExt = ["BufferIO", "MemoryViews"]
+
 [compat]
+BufferIO = "0.2.5"
+MemoryViews = "0.4"
 OpenSSL_jll = "3"
 PrecompileTools = "1.2"
 julia = "1.10"
 
 [extras]
 JuliaC = "acedd4c2-ced6-4a15-accc-2607eb759ba2"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "JuliaC"]
+test = ["Test", "JuliaC", "Pkg"]

--- a/ext/ReseauBufferIOExt.jl
+++ b/ext/ReseauBufferIOExt.jl
@@ -1,0 +1,212 @@
+"""
+    ReseauBufferIOExt
+
+Integration between Reseau and BufferIO.jl, in three layers:
+
+1. `Base.IO` bridge methods on `TCP.Conn` for MemoryViews buffers
+   (`readbytes!`, `write`), which make the stock `BufferIO.BufReader` /
+   `BufferIO.BufWriter` wrappers correct and syscall-efficient over a `Conn`.
+2. Native `TCP.bufreader` / `TCP.bufwriter` implementations of
+   `AbstractBufReader` / `AbstractBufWriter` that skip the generic wrappers'
+   extra `eof` probe and use the connection's pointer I/O paths directly.
+3. Nothing else: deadlines, close semantics, and error types are the
+   connection's own, surfaced through buffer refills and flushes unchanged.
+"""
+module ReseauBufferIOExt
+
+using Reseau: Reseau, TCP, IOPoll
+using BufferIO: BufferIO, AbstractBufReader, AbstractBufWriter, IOError, IOErrorKinds
+using MemoryViews: MemoryViews, MemoryView, ImmutableMemoryView, MutableMemoryView
+
+# One short read into `v`: blocks until at least 1 byte arrives, returns 0 at
+# EOF. The view is passed as the GC root so the backing Memory stays alive
+# across an async (IOCP) completion.
+function _read_some_into!(conn::TCP.Conn, v::MutableMemoryView{UInt8})::Int
+    isempty(v) && return 0
+    return try
+        GC.@preserve v TCP._read_some!(conn, Base.unsafe_convert(Ptr{UInt8}, v), length(v), v)
+    catch err
+        ex = err::Exception
+        ex isa EOFError || rethrow(ex)
+        0
+    end
+end
+
+"""
+    readbytes!(conn::TCP.Conn, v::MutableMemoryView{UInt8}, nb = length(v); all::Bool = false)
+
+Read up to `nb` bytes from `conn` into the start of `v`, returning the number
+of bytes read.
+
+Unlike the `MutableByteBuffer` methods on `Conn`, `all` defaults to `false`:
+the call blocks only until at least one byte is available (or EOF) and then
+returns what a single read produced. This is the fill contract buffered
+readers such as `BufferIO.BufReader` rely on when they call
+`readbytes!(io, view)` — an `all = true` default would make a buffered
+`readline` stall until the whole free buffer fills. Views cannot be resized,
+so `nb` is clamped to `length(v)`.
+"""
+function Base.readbytes!(
+        conn::TCP.Conn,
+        v::MutableMemoryView{UInt8},
+        nb::Integer = length(v);
+        all::Bool = false,
+    )::Int
+    nb < 0 && throw(ArgumentError("readbytes! byte count must be non-negative"))
+    requested = min(Int(nb), length(v))
+    filled = 0
+    while filled < requested
+        n = _read_some_into!(conn, @inbounds v[(filled + 1):requested])
+        n == 0 && break
+        filled += n
+        all || break
+    end
+    return filled
+end
+
+"""
+    write(conn::TCP.Conn, v::MemoryViews.MemoryView{UInt8}) -> Int
+
+Write the full view to `conn` without an intermediate copy and return the
+number of bytes written.
+"""
+function Base.write(conn::TCP.Conn, v::MemoryView{UInt8})::Int
+    isempty(v) && return 0
+    GC.@preserve v begin
+        return TCP._write_rooted!(conn, Base.unsafe_convert(Ptr{UInt8}, v), length(v), v)
+    end
+end
+
+##########################
+# Native reader
+##########################
+
+mutable struct ConnBufReader <: AbstractBufReader
+    const conn::TCP.Conn
+    buffer::Memory{UInt8}
+    start::Int  # index of the first unread byte
+    stop::Int   # index of the last valid byte; start > stop means empty
+end
+
+function TCP.bufreader(conn::TCP.Conn; buffer_size::Integer = 8192)::ConnBufReader
+    buffer_size < 1 && throw(ArgumentError("buffer_size must be at least 1"))
+    return ConnBufReader(conn, Memory{UInt8}(undef, Int(buffer_size)), 1, 0)
+end
+
+function BufferIO.get_buffer(r::ConnBufReader)::ImmutableMemoryView{UInt8}
+    return @inbounds ImmutableMemoryView(r.buffer)[r.start:r.stop]
+end
+
+function BufferIO.fill_buffer(r::ConnBufReader)::Int
+    if r.start > r.stop
+        # Empty: reuse the whole buffer.
+        r.start = 1
+        r.stop = 0
+    elseif r.stop == length(r.buffer)
+        n_buffered = r.stop - r.start + 1
+        if r.start > 1
+            copyto!(r.buffer, 1, r.buffer, r.start, n_buffered)
+        else
+            # Full from index 1: grow so the fill contract can still add bytes.
+            grown = Memory{UInt8}(undef, 2 * length(r.buffer))
+            copyto!(grown, 1, r.buffer, 1, n_buffered)
+            r.buffer = grown
+        end
+        r.start = 1
+        r.stop = n_buffered
+    end
+    tail = @inbounds MemoryView(r.buffer)[(r.stop + 1):length(r.buffer)]
+    n = _read_some_into!(r.conn, tail)
+    r.stop += n
+    return n
+end
+
+function BufferIO.consume(r::ConnBufReader, n::Int)::Nothing
+    @boundscheck if (n % UInt) > ((r.stop - r.start + 1) % UInt)
+        throw(IOError(IOErrorKinds.ConsumeBufferError))
+    end
+    r.start += n
+    return nothing
+end
+
+Base.close(r::ConnBufReader) = close(r.conn)
+
+function Base.show(io::IO, r::ConnBufReader)
+    print(io, "TCP.bufreader(", r.conn, ", ", r.stop - r.start + 1, " bytes buffered)")
+    return nothing
+end
+
+##########################
+# Native writer
+##########################
+
+mutable struct ConnBufWriter <: AbstractBufWriter
+    const conn::TCP.Conn
+    buffer::Memory{UInt8}
+    consumed::Int  # bytes written into the buffer but not yet flushed
+    is_closed::Bool
+end
+
+function TCP.bufwriter(conn::TCP.Conn; buffer_size::Integer = 4096)::ConnBufWriter
+    buffer_size < 1 && throw(ArgumentError("buffer_size must be at least 1"))
+    return ConnBufWriter(conn, Memory{UInt8}(undef, Int(buffer_size)), 0, false)
+end
+
+function BufferIO.get_buffer(w::ConnBufWriter)::MutableMemoryView{UInt8}
+    return @inbounds MemoryView(w.buffer)[(w.consumed + 1):length(w.buffer)]
+end
+
+function BufferIO.get_unflushed(w::ConnBufWriter)::MutableMemoryView{UInt8}
+    return @inbounds MemoryView(w.buffer)[1:(w.consumed)]
+end
+
+function BufferIO.consume(w::ConnBufWriter, n::Int)::Nothing
+    @boundscheck if (n % UInt) > ((length(w.buffer) - w.consumed) % UInt)
+        throw(IOError(IOErrorKinds.ConsumeBufferError))
+    end
+    w.consumed += n
+    return nothing
+end
+
+function BufferIO.shallow_flush(w::ConnBufWriter)::Int
+    w.is_closed && throw(IOError(IOErrorKinds.ClosedIO))
+    to_flush = w.consumed
+    if !iszero(to_flush)
+        buffer = w.buffer
+        GC.@preserve buffer begin
+            TCP._write_rooted!(w.conn, Base.unsafe_convert(Ptr{UInt8}, buffer), to_flush, buffer)
+        end
+        w.consumed = 0
+    end
+    return to_flush
+end
+
+function BufferIO.grow_buffer(w::ConnBufWriter)::Int
+    flushed = BufferIO.shallow_flush(w)
+    iszero(flushed) || return flushed
+    # A zero-byte flush means the buffer held no pending data; just grow it.
+    old_size = length(w.buffer)
+    w.buffer = Memory{UInt8}(undef, 2 * old_size)
+    return old_size
+end
+
+function Base.flush(w::ConnBufWriter)
+    BufferIO.shallow_flush(w)
+    flush(w.conn)
+    return nothing
+end
+
+function Base.close(w::ConnBufWriter)
+    w.is_closed && return nothing
+    flush(w)
+    w.is_closed = true
+    close(w.conn)
+    return nothing
+end
+
+function Base.show(io::IO, w::ConnBufWriter)
+    print(io, "TCP.bufwriter(", w.conn, ", ", w.consumed, " bytes unflushed)")
+    return nothing
+end
+
+end # module ReseauBufferIOExt

--- a/src/3_tcp.jl
+++ b/src/3_tcp.jl
@@ -1427,4 +1427,34 @@ function Base.show(io::IO, listener::Listener)
     return nothing
 end
 
+"""
+    bufreader(conn::Conn; buffer_size::Integer = 8192)
+
+Return a `BufferIO.AbstractBufReader` that reads from `conn` through an
+internal, growable buffer.
+
+The method is provided by the `ReseauBufferIOExt` package extension and is
+only defined once BufferIO.jl is loaded (BufferIO requires Julia >= 1.11).
+Buffer refills go through the same readiness, deadline, and close machinery as
+direct `Conn` reads, so `DeadlineExceededError`, `NetClosingError`, and
+`SystemError` propagate unchanged. The returned reader is not safe for
+concurrent use from multiple tasks.
+"""
+function bufreader end
+
+"""
+    bufwriter(conn::Conn; buffer_size::Integer = 4096)
+
+Return a `BufferIO.AbstractBufWriter` that coalesces writes into an internal
+buffer before writing them to `conn`.
+
+The method is provided by the `ReseauBufferIOExt` package extension and is
+only defined once BufferIO.jl is loaded (BufferIO requires Julia >= 1.11).
+Buffered bytes reach the socket on `flush`/`BufferIO.shallow_flush`, when the
+buffer must grow, or on `close`; `close(writer)` flushes and then closes
+`conn`. The returned writer is not safe for concurrent use from multiple
+tasks.
+"""
+function bufwriter end
+
 end

--- a/test/bufferio_ext_tests.jl
+++ b/test/bufferio_ext_tests.jl
@@ -1,0 +1,266 @@
+# Tests for the ReseauBufferIOExt package extension.
+#
+# BufferIO.jl requires Julia >= 1.11 while Reseau supports 1.10, so BufferIO
+# cannot be a regular test-target dependency: on 1.10 the test environment
+# would fail to resolve. Instead it is added to the ephemeral test environment
+# here, and this whole file no-ops on older Julia versions.
+
+if VERSION >= v"1.11"
+    import Pkg
+    _log_test_progress("[bufferio_ext] installing BufferIO into the test environment")
+    Pkg.add(
+        [
+            Pkg.PackageSpec(name = "BufferIO", version = "0.2.5"),
+            Pkg.PackageSpec(name = "MemoryViews"),
+        ];
+        preserve = Pkg.PRESERVE_ALL,
+    )
+    _log_test_progress("[bufferio_ext] BufferIO installed")
+
+    using BufferIO: BufferIO,
+        AbstractBufReader,
+        AbstractBufWriter,
+        IOError,
+        IOErrorKinds,
+        get_buffer,
+        fill_buffer,
+        get_nonempty_buffer,
+        consume,
+        shallow_flush,
+        get_unflushed,
+        line_views
+    using MemoryViews: MemoryView, ImmutableMemoryView, MutableMemoryView
+
+    @test Base.get_extension(Reseau, :ReseauBufferIOExt) isa Module
+
+    function _bufio_pair()
+        listener = TCP.listen(TCP.loopback_addr(0))
+        client = TCP.connect(TCP.addr(listener))
+        server = TCP.accept(listener)
+        close(listener)
+        return client, server
+    end
+
+    # Read exactly `n` bytes from `conn` through repeated short view reads.
+    function _bufio_read_exact_via_views(conn::TCP.Conn, n::Int)::Vector{UInt8}
+        out = zeros(UInt8, n)
+        view = MemoryView(out)
+        filled = 0
+        while filled < n
+            got = readbytes!(conn, view[(filled + 1):n])
+            @assert got > 0
+            filled += got
+        end
+        return out
+    end
+
+    @testset "bridge readbytes! short-read default" begin
+        client, server = _bufio_pair()
+        write(server, "hello")
+        # The default all=false contract: each call returns as soon as at
+        # least one byte is available. Termination of this loop without the
+        # server writing more than 5 bytes (or closing) is the proof; an
+        # all=true default would park forever waiting to fill 64 bytes.
+        buf = zeros(UInt8, 64)
+        view = MemoryView(buf)
+        filled = 0
+        while filled < 5
+            n = readbytes!(client, view[(filled + 1):64])
+            @test n >= 1
+            filled += n
+        end
+        @test buf[1:5] == b"hello"
+        close(client)
+        close(server)
+    end
+
+    @testset "bridge readbytes! all=true and nb clamp" begin
+        client, server = _bufio_pair()
+        write(server, "abc")
+        write(server, "defgh")
+        buf = zeros(UInt8, 8)
+        n = readbytes!(client, MemoryView(buf), 8; all = true)
+        @test n == 8
+        @test buf == b"abcdefgh"
+        # nb larger than the view is clamped to the view length.
+        write(server, "xy")
+        small = zeros(UInt8, 2)
+        n = readbytes!(client, MemoryView(small), 100; all = true)
+        @test n == 2
+        @test small == b"xy"
+        @test_throws ArgumentError readbytes!(client, MemoryView(small), -1)
+        # EOF drains to a zero count.
+        closewrite(server)
+        @test readbytes!(client, MemoryView(buf)) == 0
+        close(client)
+        close(server)
+    end
+
+    @testset "bridge write of memory views" begin
+        client, server = _bufio_pair()
+        data = collect(b"view-payload")
+        @test write(client, ImmutableMemoryView(data)) == length(data)
+        @test write(client, MemoryView(data)) == length(data)
+        @test write(client, ImmutableMemoryView(UInt8[])) == 0
+        received = _bufio_read_exact_via_views(server, 2 * length(data))
+        @test received == vcat(data, data)
+        close(client)
+        close(server)
+    end
+
+    @testset "stock BufferIO.BufReader over Conn" begin
+        client, server = _bufio_pair()
+        write(server, "line one\nline two\r\nrest")
+        closewrite(server)
+        # Tiny buffer forces refills and buffer growth across line boundaries.
+        reader = BufferIO.BufReader(client, 4)
+        @test readline(reader) == "line one"
+        @test readline(reader) == "line two"
+        @test readline(reader) == "rest"
+        @test eof(reader)
+        @test readline(reader) == ""
+        close(reader)
+        @test !isopen(client)
+        close(server)
+    end
+
+    @testset "stock BufferIO.BufWriter over Conn" begin
+        client, server = _bufio_pair()
+        writer = BufferIO.BufWriter(client, 8)
+        write(writer, "hi")
+        @test length(get_unflushed(writer)) == 2
+        flush(writer)
+        @test isempty(get_unflushed(writer))
+        @test _bufio_read_exact_via_views(server, 2) == b"hi"
+        close(writer)
+        @test !isopen(client)
+        close(server)
+    end
+
+    @testset "native bufreader: interface contract" begin
+        client, server = _bufio_pair()
+        reader = TCP.bufreader(client; buffer_size = 8)
+        @test reader isa AbstractBufReader
+        @test isempty(get_buffer(reader))
+        @test bytesavailable(reader) == 0
+        write(server, "abcde")
+        n = fill_buffer(reader)
+        @test n >= 1
+        first_buffer = get_buffer(reader)
+        @test !isempty(first_buffer)
+        @test first_buffer[1] == UInt8('a')
+        # consume past the buffered window is a checked error.
+        err = try
+            consume(reader, 100)
+            nothing
+        catch e
+            e
+        end
+        @test err isa IOError
+        @test err.kind == IOErrorKinds.ConsumeBufferError
+        # Byte-by-byte read of the exact payload through BufferIO generics.
+        bytes = UInt8[]
+        for _ in 1:5
+            push!(bytes, read(reader, UInt8))
+        end
+        @test bytes == b"abcde"
+        # EOF: half-close surfaces as fill_buffer() == 0, then IOError(EOF).
+        closewrite(server)
+        @test fill_buffer(reader) == 0
+        @test get_nonempty_buffer(reader) === nothing
+        @test eof(reader)
+        err = try
+            read(reader, UInt8)
+            nothing
+        catch e
+            e
+        end
+        @test err isa IOError
+        @test err.kind == IOErrorKinds.EOF
+        close(reader)
+        @test !isopen(client)
+        close(server)
+    end
+
+    @testset "native bufreader: growth, readline, line_views" begin
+        client, server = _bufio_pair()
+        long_line = "x"^100
+        write(server, long_line * "\nshort\r\ntail")
+        closewrite(server)
+        reader = TCP.bufreader(client; buffer_size = 8)
+        @test readline(reader) == long_line
+        @test [String(line) for line in line_views(reader)] == ["short", "tail"]
+        close(reader)
+        close(server)
+    end
+
+    @testset "native bufreader: fill slide and grow paths" begin
+        client, server = _bufio_pair()
+        reader = TCP.bufreader(client; buffer_size = 8)
+        # Fill the 8-byte buffer exactly full.
+        write(server, "01234567")
+        while bytesavailable(reader) < 8
+            @test fill_buffer(reader) >= 1
+        end
+        # Consume a prefix, then force a fill with the window at the buffer
+        # end: exercises the slide-to-front branch.
+        consume(reader, 3)
+        write(server, "abc")
+        while bytesavailable(reader) < 8
+            @test fill_buffer(reader) >= 1
+        end
+        @test String([read(reader, UInt8) for _ in 1:8]) == "34567abc"
+        # Unconsumed full-from-start buffer: exercises the grow branch.
+        write(server, "ABCDEFGHIJKL")
+        while bytesavailable(reader) < 12
+            @test fill_buffer(reader) >= 1
+        end
+        @test String([read(reader, UInt8) for _ in 1:12]) == "ABCDEFGHIJKL"
+        close(reader)
+        close(server)
+    end
+
+    @testset "native bufreader: deadline and close errors" begin
+        client, server = _bufio_pair()
+        reader = TCP.bufreader(client)
+        # House sentinel: an already-expired absolute deadline.
+        TCP.set_read_deadline!(client, Int64(1))
+        @test_throws TCP.DeadlineExceededError readline(reader)
+        TCP.set_read_deadline!(client, 0)
+        close(client)
+        @test_throws Reseau.IOPoll.NetClosingError readline(reader)
+        close(server)
+    end
+
+    @testset "native bufwriter" begin
+        client, server = _bufio_pair()
+        writer = TCP.bufwriter(client; buffer_size = 8)
+        @test writer isa AbstractBufWriter
+        write(writer, "hi")
+        @test get_unflushed(writer) == b"hi"
+        @test shallow_flush(writer) == 2
+        @test _bufio_read_exact_via_views(server, 2) == b"hi"
+        # Larger than the buffer: BufferIO's generic write path flushes and
+        # refills as needed; close flushes the remainder and closes the conn.
+        payload = "0123456789abcdefghij"
+        write(writer, payload)
+        # An unsigned integer written through the generic PlainTypes path.
+        write(writer, 0x11223344)
+        close(writer)
+        @test !isopen(client)
+        received = read(server)
+        @test received[1:length(payload)] == codeunits(payload)
+        @test reinterpret(UInt32, received[(length(payload) + 1):end])[1] == 0x11223344
+        err = try
+            shallow_flush(writer)
+            nothing
+        catch e
+            e
+        end
+        @test err isa IOError
+        @test err.kind == IOErrorKinds.ClosedIO
+        close(server)
+    end
+else
+    _log_test_progress("[bufferio_ext] skipped: BufferIO requires Julia >= 1.11 (running $(VERSION))")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ test_files = [
     "internal_poll_tests.jl",
     "socket_ops_tests.jl",
     "tcp_tests.jl",
+    "bufferio_ext_tests.jl",
     "host_resolvers_tests.jl",
     "socks_tests.jl",
     "tls_crypto_tests.jl",


### PR DESCRIPTION
## What

A `ReseauBufferIOExt` package extension (weakdeps: **BufferIO**, **MemoryViews**) prototyping the buffered-IO story for `TCP.Conn`, in two layers:

1. **`Base.IO` bridge methods on `Conn`** so the *stock* `BufferIO.BufReader`/`BufWriter` wrappers work correctly and efficiently:
   - `readbytes!(conn, ::MutableMemoryView, nb; all=false)` — one blocking short read per call (≥1 byte unless EOF). Without this method, `BufReader(conn)` dies in MemoryViews' generic fallback (`bytesavailable` MethodError), and any fallback path would be syscall-per-byte.
   - `write(conn, ::MemoryView{UInt8})` — copy-free flush path (otherwise `BufWriter` flushes hit the copying `AbstractVector` fallback).
2. **Native `TCP.bufreader(conn)` / `TCP.bufwriter(conn)`** implementing `AbstractBufReader`/`AbstractBufWriter` directly over the connection's pointer I/O paths — skipping the stock wrapper's per-fill `eof` probe (a `MSG_PEEK` syscall on a `Conn`), with exact EOF semantics (`0` ⇔ peer half-closed) and IOCP-safe buffer rooting.

Deadlines, close semantics, and error types are the connection's own and surface unchanged: `DeadlineExceededError` / `NetClosingError` / `SystemError` propagate from buffer refills; logical-EOF conditions inside BufferIO generics surface as `BufferIO.IOError(EOF)` per that interface's contract.

With this, `readline`/`copyline`/`copyuntil`/`line_views` over a socket run at memchr speed instead of two syscalls per byte, and zero-copy parsers written against `AbstractBufReader` consume Reseau connections directly.

## Deliberate semantic decisions (review focus)

- **`all=false` default** on the `MutableMemoryView` `readbytes!` method, *unlike* the `MutableByteBuffer` methods (`all=true`). Rationale in the docstring: it's the fill contract buffered readers rely on when calling `readbytes!(io, view)` positionally — an `all=true` default would make buffered `readline` stall until the whole free buffer fills. The asymmetry is confined to the view method.
- **Test-dep strategy**: BufferIO requires Julia ≥ 1.11; Reseau's floor is 1.10. BufferIO therefore cannot live in the test target (the `min` CI job would fail to resolve). `test/bufferio_ext_tests.jl` installs BufferIO@0.2.5 into the ephemeral test env at runtime and no-ops with a log line on 1.10.
- Writer `close` mirrors `BufferIO.BufWriter`: flush, then close the underlying conn.
- Not task-safe (matches `AbstractBufReader`'s documented contract and `TLS.Conn`'s one-reader/one-writer stance).

## Tests

`test/bufferio_ext_tests.jl` (56 assertions, deterministic per `test/README.md` rules — no clocks, house deadline sentinels, loopback pairs, exact byte counts): bridge short-read/`all=true`/clamp/EOF; view writes; stock `BufReader` readline incl. growth and CRLF; stock `BufWriter` flush; native reader interface contract (`get_buffer`/`fill_buffer`/`consume` bounds, `IOError` kinds), slide/grow fill paths, `line_views`, deadline + close error propagation; native writer flush/grow/close + `ClosedIO`.

## Out of scope / follow-ups

- `TLS.Conn` reader/writer methods (same shape; wants the same bridge on the TLS read path).
- An `IOReader`-sandwich convenience (`TCP.buffered(conn)::IO`) for code typed `::IO`.
- Docs page + migrate-sockets note (pending the adopt/build decision).
- Upstream asks for BufferIO 0.3 (cancel-kwarg passthrough on blocking entry points, duplex-socket pattern, documenting the raw-IO `readbytes!` fill contract) — being discussed with @jakobnissen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)