### PR TITLE
UDP support: Go-port datagram sockets over the shared netFD

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ hostname-aware dialing, and TLS in one package.
 Reseau provides:
 
 - TCP connections and listeners
+- UDP datagram sockets, connected and unconnected
 - hostname-aware dialing and listening through the `TCP` and `TLS` entrypoints
 - TLS clients and listeners
 - integrated readiness, deadline, and timer handling across macOS, Linux, and Windows
@@ -26,6 +27,7 @@ Pkg.add("Reseau")
 The supported public entry points are the exported `TCP` and `TLS` modules:
 
 - `TCP` for TCP connections, listeners, deadlines, and string-address dialing
+- `UDP` for datagram sockets with the same deadline and readiness model
 - `TLS` for TLS clients and listeners
 
 ## Quick Start

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,6 +15,7 @@ makedocs(
     pages = [
         "Home" => "index.md",
         "TCP" => "tcp.md",
+        "UDP" => "udp.md",
         "TLS" => "tls.md",
         "Name Resolution" => "resolution.md",
         "Sockets Migration Guide" => "migrate-sockets.md",

--- a/docs/src/migrate-sockets.md
+++ b/docs/src/migrate-sockets.md
@@ -142,6 +142,23 @@ Half-close remains explicit:
 - `closewrite(conn)`
 - `TCP.closeread(conn)`
 
+## UDP
+
+The `UDPSocket` flow maps onto `Reseau.UDP`:
+
+| `Sockets` | Reseau |
+| --- | --- |
+| `s = UDPSocket(); bind(s, ip, port)` | `conn = UDP.listen(addr)` |
+| `send(s, ip, port, msg)` | `UDP.sendto(conn, msg, addr)` |
+| `recv(s)` | `UDP.recv(conn)` |
+| `recvfrom(s)` returning `(addr, data)` | `UDP.recvfrom(conn)` returning `(data, addr)` |
+| timeout wrapper tasks | `UDP.set_read_deadline!(conn, deadline_ns)` |
+
+Two behavioral differences to plan for: `recvfrom` returns `(data, addr)` in
+the opposite order with a fused `SocketAddr`, and closing a socket wakes
+pending receives with `NetClosingError` rather than `EOFError` (consistent
+with `TCP`). Multicast options are not yet available.
+
 ## Porting Checklist
 
 1. Replace `Sockets.connect(host, port)` with `TCP.connect("host:port")` when you want hostname resolution.

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -18,6 +18,7 @@ Depth = 2:2
 ```@docs
 Reseau
 Reseau.TCP
+Reseau.UDP
 Reseau.TLS
 ```
 
@@ -76,34 +77,34 @@ addr
 
 ## UDP
 
-```@docs
-Reseau.UDP
+```@meta
+CurrentModule = Reseau.UDP
 ```
 
 ### Connections and Datagram I/O
 
 ```@docs
-UDP.Conn
-UDP.listen
-UDP.connect
-UDP.send
-UDP.sendto
-UDP.recv
-UDP.recv!
-UDP.recvfrom
-UDP.recvfrom!
-UDP.TruncatedDatagramError
+Conn
+listen
+connect
+send
+sendto
+recv
+recv!
+recvfrom
+recvfrom!
+TruncatedDatagramError
 ```
 
 ### Deadlines, Socket Options, and Address Inspection
 
 ```@docs
 UDP.DeadlineExceededError
-UDP.set_deadline!
-UDP.set_read_deadline!
-UDP.set_write_deadline!
-UDP.set_broadcast!
-UDP.set_ttl!
+set_deadline!
+set_read_deadline!
+set_write_deadline!
+set_broadcast!
+set_ttl!
 UDP.local_addr
 UDP.remote_addr
 ```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -74,6 +74,40 @@ remote_addr
 addr
 ```
 
+## UDP
+
+```@docs
+Reseau.UDP
+```
+
+### Connections and Datagram I/O
+
+```@docs
+UDP.Conn
+UDP.listen
+UDP.connect
+UDP.send
+UDP.sendto
+UDP.recv
+UDP.recv!
+UDP.recvfrom
+UDP.recvfrom!
+UDP.TruncatedDatagramError
+```
+
+### Deadlines, Socket Options, and Address Inspection
+
+```@docs
+UDP.DeadlineExceededError
+UDP.set_deadline!
+UDP.set_read_deadline!
+UDP.set_write_deadline!
+UDP.set_broadcast!
+UDP.set_ttl!
+UDP.local_addr
+UDP.remote_addr
+```
+
 ## TLS
 
 ```@meta

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -176,6 +176,7 @@ CurrentModule = Main
 Reseau.SocketOps
 Reseau.IOPoll
 Reseau.IOPoll.PollMode
+Reseau.NetCommon
 Reseau.HostResolvers
 Reseau.SOCKS
 Reseau.SOCKS.BoundAddr

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -105,6 +105,8 @@ set_read_deadline!
 set_write_deadline!
 set_broadcast!
 set_ttl!
+set_read_buffer!
+set_write_buffer!
 UDP.local_addr
 UDP.remote_addr
 ```

--- a/docs/src/udp.md
+++ b/docs/src/udp.md
@@ -80,6 +80,25 @@ semantics). The allocating [`UDP.recv`](@ref UDP.recv) and
 [`UDP.recvfrom`](@ref UDP.recvfrom) default to a `maxsize` that holds any
 datagram, so they never truncate unless a smaller `maxsize` is requested.
 
+## Socket options and dual-stack behavior
+
+Broadcast (`SO_BROADCAST`) is **enabled by default** on every UDP socket,
+matching Go's `setDefaultSockopts`; disable it with
+`UDP.set_broadcast!(conn, false)`. Kernel buffer sizes are set with
+`UDP.set_read_buffer!`/`UDP.set_write_buffer!` (datagrams that arrive while
+the receive buffer is full are dropped), and `UDP.set_ttl!` sets the IPv4 TTL
+or IPv6 hop limit.
+
+AF_INET6 sockets are dual-stack by default (except with the `"udp6"` network
+name), and addresses convert the way Go's `ipToSockaddr` converts them: an
+IPv4 destination on an IPv6 socket is carried as an IPv4-mapped IPv6 address,
+an IPv4-mapped destination on an IPv4 socket collapses to plain IPv4, and
+`connect` picks `AF_INET` only when every given address is IPv4 (Go's
+`favoriteAddrFamily`). A wildcard dial destination means "this host": the
+kernel interprets it directly where supported, and Reseau rewrites it to the
+loopback address on Windows, FreeBSD, and OpenBSD exactly as Go's
+`internetSocket` does.
+
 ## Deadlines
 
 The deadline model is identical to TCP: absolute monotonic timestamps on the
@@ -104,6 +123,24 @@ conn = UDP.connect("localhost:9000")
 wild = UDP.listen(":9000")
 four = UDP.listen("udp4", "127.0.0.1:9000")
 ```
+
+## Differences from Go
+
+`Reseau.UDP` follows Go's `net.UDPConn` semantics closely. The deliberate
+deviations, chosen where Julia idiom or cross-platform consistency wins:
+
+| Area | Go | Reseau |
+| --- | --- | --- |
+| Stream interface | `UDPConn` implements `io.Reader`/`io.Writer` | `Conn` is not an `IO`; datagram verbs only |
+| Truncation | Silent prefix on POSIX, error on Windows | Uniform: throws `TruncatedDatagramError` unless `allow_truncate=true` |
+| Mode misuse | Runtime error values (`ErrWriteToConnected`, kernel `EDESTADDRREQ`) | `ArgumentError` at the API boundary |
+| Empty receive buffer | Consumes a datagram on POSIX, returns without I/O on Windows | Consumes (and flags truncation) on every platform |
+| Spurious Windows resets | Not handled (`WSAECONNRESET` leaks to unconnected sockets) | `SIO_UDP_CONNRESET` disabled on unconnected sockets |
+| Error wrapping | Every operation returns `*net.OpError` | Direct-address calls throw raw errors; only string-address entrypoints wrap in `OpError` (house convention) |
+| IPv6 scopes | `Zone` interface name string | Numeric `scope_id` |
+| Convenience | `ListenUDP` accepts a nil address | Use `UDP.listen(":0")` or `any_addr(0)` |
+| Allocating receives | Caller always supplies the buffer | `recv`/`recvfrom` allocate right-sized results (Sockets-stdlib migration affordance) |
+| Raw access | `SyscallConn`/`File` | Not provided |
 
 ## Not yet implemented
 

--- a/docs/src/udp.md
+++ b/docs/src/udp.md
@@ -124,24 +124,6 @@ wild = UDP.listen(":9000")
 four = UDP.listen("udp4", "127.0.0.1:9000")
 ```
 
-## Differences from Go
-
-`Reseau.UDP` follows Go's `net.UDPConn` semantics closely. The deliberate
-deviations, chosen where Julia idiom or cross-platform consistency wins:
-
-| Area | Go | Reseau |
-| --- | --- | --- |
-| Stream interface | `UDPConn` implements `io.Reader`/`io.Writer` | `Conn` is not an `IO`; datagram verbs only |
-| Truncation | Silent prefix on POSIX, error on Windows | Uniform: throws `TruncatedDatagramError` unless `allow_truncate=true` |
-| Mode misuse | Runtime error values (`ErrWriteToConnected`, kernel `EDESTADDRREQ`) | `ArgumentError` at the API boundary |
-| Empty receive buffer | Consumes a datagram on POSIX, returns without I/O on Windows | Consumes (and flags truncation) on every platform |
-| Spurious Windows resets | Not handled (`WSAECONNRESET` leaks to unconnected sockets) | `SIO_UDP_CONNRESET` disabled on unconnected sockets |
-| Error wrapping | Every operation returns `*net.OpError` | Direct-address calls throw raw errors; only string-address entrypoints wrap in `OpError` (house convention) |
-| IPv6 scopes | `Zone` interface name string | Numeric `scope_id` |
-| Convenience | `ListenUDP` accepts a nil address | Use `UDP.listen(":0")` or `any_addr(0)` |
-| Allocating receives | Caller always supplies the buffer | `recv`/`recvfrom` allocate right-sized results (Sockets-stdlib migration affordance) |
-| Raw access | `SyscallConn`/`File` | Not provided |
-
 ## Not yet implemented
 
 Multicast group management (`join_multicast_group`-style APIs), control-message

--- a/docs/src/udp.md
+++ b/docs/src/udp.md
@@ -1,0 +1,112 @@
+```@meta
+Description = "UDP datagram sockets in Reseau.jl: connected and unconnected use, deadlines, and truncation policy."
+```
+
+# [UDP](@id udp-manual)
+
+`Reseau.UDP` provides datagram sockets with the same readiness, deadline, and
+close machinery as [`Reseau.TCP`](@ref), mirroring Go's `net.UDPConn`: one
+[`UDP.Conn`](@ref UDP.Conn) type serves both unconnected and connected use.
+
+```@contents
+Pages = ["udp.md"]
+Depth = 2:3
+```
+
+## Unconnected sockets
+
+[`UDP.listen`](@ref UDP.listen) binds a socket that can exchange datagrams
+with any peer:
+
+```julia
+using Reseau
+
+a = UDP.listen(UDP.loopback_addr(0))
+b = UDP.listen(UDP.loopback_addr(0))
+
+UDP.sendto(a, "ping", UDP.local_addr(b))
+data, from = UDP.recvfrom(b)
+UDP.sendto(b, "pong", from)
+
+close(a); close(b)
+```
+
+Despite the name, no `listen(2)` syscall is involved; the name matches Go's
+`ListenUDP` and marks the socket as the passive, bound side.
+
+## Connected sockets
+
+[`UDP.connect`](@ref UDP.connect) fixes a peer. Connecting a UDP socket is a
+local operation — no packets are exchanged — but the kernel then filters
+inbound datagrams to that peer and surfaces ICMP errors (such as
+`ECONNREFUSED`) on later operations:
+
+```julia
+using Reseau
+
+server = UDP.listen(UDP.loopback_addr(0))
+client = UDP.connect(UDP.local_addr(server))
+
+UDP.send(client, "hello")
+data, from = UDP.recvfrom(server)
+UDP.sendto(server, "reply", from)
+reply = UDP.recv(client)
+
+close(client); close(server)
+```
+
+`send` requires a connected socket and `sendto` an unconnected one (Go's
+`ErrWriteToConnected` semantics); the `recv` family works on both.
+
+## Datagram semantics
+
+- A datagram is sent and received whole. There are no partial transfers.
+- A zero-byte datagram is valid data, never EOF. `UDP.Conn` has no EOF
+  concept at all and is deliberately **not** an `IO` — stream helpers like
+  `readline` would corrupt message boundaries.
+- Sends larger than the UDP maximum payload (65,507 bytes) fail with the
+  kernel's `EMSGSIZE` and leave the socket usable.
+
+### Truncation
+
+If an incoming datagram is longer than the receive buffer, the kernel
+delivers a prefix and discards the rest. Reseau makes this explicit and
+uniform across platforms: with the default `allow_truncate=false`,
+[`UDP.recv!`](@ref UDP.recv!) and [`UDP.recvfrom!`](@ref UDP.recvfrom!) throw
+[`UDP.TruncatedDatagramError`](@ref UDP.TruncatedDatagramError); with
+`allow_truncate=true` the truncated prefix is returned silently (Go
+semantics). The allocating [`UDP.recv`](@ref UDP.recv) and
+[`UDP.recvfrom`](@ref UDP.recvfrom) default to a `maxsize` that holds any
+datagram, so they never truncate unless a smaller `maxsize` is requested.
+
+## Deadlines
+
+The deadline model is identical to TCP: absolute monotonic timestamps on the
+`time_ns()` clock, sticky per socket, surfaced as
+[`UDP.DeadlineExceededError`](@ref UDP.DeadlineExceededError).
+
+```julia
+conn = UDP.listen(UDP.loopback_addr(0))
+UDP.set_read_deadline!(conn, time_ns() + 5_000_000_000)
+```
+
+## String addresses
+
+The resolver-backed entrypoints accept `"host:port"` strings and the network
+names `"udp"`, `"udp4"`, and `"udp6"` (`"udp6"` binds IPv6-only). There is no
+Happy-Eyeballs race and no dial timeout: connecting a UDP socket is
+immediate, so only name resolution can block. Failures are wrapped in
+`HostResolvers.OpError` like TCP dialing.
+
+```julia
+conn = UDP.connect("localhost:9000")
+wild = UDP.listen(":9000")
+four = UDP.listen("udp4", "127.0.0.1:9000")
+```
+
+## Not yet implemented
+
+Multicast group management (`join_multicast_group`-style APIs), control-message
+(`recvmsg` ancillary data) access, and batched datagram I/O are planned
+follow-ups; the socket-ops layer already carries most of the required
+plumbing.

--- a/docs/src/udp.md
+++ b/docs/src/udp.md
@@ -1,4 +1,5 @@
 ```@meta
+CurrentModule = Reseau
 Description = "UDP datagram sockets in Reseau.jl: connected and unconnected use, deadlines, and truncation policy."
 ```
 

--- a/live_demos.jl
+++ b/live_demos.jl
@@ -1,0 +1,104 @@
+# Live demo A: TCP echo + deadline
+using Reseau
+
+listener = TCP.listen(TCP.loopback_addr(0))
+release_server = Channel{Nothing}(1)
+
+server_task = errormonitor(@async begin
+    conn = TCP.accept(listener)
+    try
+        request = String(read(conn, 5))
+        write(conn, "echo:" * request)
+        take!(release_server) # Stay silent while the client tests its deadline.
+    finally
+        close(conn)
+    end
+end)
+
+client = TCP.connect(TCP.addr(listener))
+try
+    write(client, "hello")
+    println("TCP echo: ", String(read(client, 10)))
+
+    TCP.set_read_deadline!(client, time_ns() + 500_000_000)
+    try
+        read(client, UInt8)
+    catch err
+        err isa TCP.DeadlineExceededError || rethrow()
+        println(
+            "TCP deadline: ",
+            nameof(typeof(err)),
+            " (",
+            sprint(showerror, err),
+            ")",
+        )
+    finally
+        TCP.set_read_deadline!(client, 0)
+    end
+finally
+    put!(release_server, nothing)
+    close(client)
+    close(listener)
+    wait(server_task)
+end
+
+# Expected output:
+# TCP echo: echo:hello
+# TCP deadline: DeadlineExceededError (i/o timeout)
+
+
+# Live demo B: TLS ALPN loopback
+cert_file = joinpath(pkgdir(Reseau), "test", "resources", "native_tls_server.crt")
+key_file = joinpath(pkgdir(Reseau), "test", "resources", "native_tls_server.key")
+ca_file = joinpath(pkgdir(Reseau), "test", "resources", "native_tls_ca.crt")
+protocols = ["h2", "http/1.1"]
+
+server_config = TLS.Config(
+    cert_file = cert_file,
+    key_file = key_file,
+    verify_peer = false,
+    alpn_protocols = protocols,
+    handshake_timeout_ns = 5_000_000_000,
+)
+listener = TLS.listen(TCP.loopback_addr(0), server_config)
+
+server_task = errormonitor(@async begin
+    conn = TLS.accept(listener)
+    try
+        TLS.handshake!(conn)
+        request = String(read(conn, 5))
+        write(conn, "secure:" * request)
+        return TLS.connection_state(conn)
+    finally
+        close(conn)
+    end
+end)
+
+client_config = TLS.Config(
+    server_name = "localhost",
+    ca_file = ca_file,
+    alpn_protocols = protocols,
+    handshake_timeout_ns = 5_000_000_000,
+)
+client = TLS.connect(TLS.addr(listener), client_config)
+
+try
+    write(client, "hello")
+    reply = String(read(client, 12))
+    client_state = TLS.connection_state(client)
+    server_state = fetch(server_task)
+
+    println("TLS echo: ", reply)
+    println("TLS version: ", client_state.version)
+    println("Client ALPN: ", client_state.alpn_protocol)
+    println("Server ALPN: ", server_state.alpn_protocol)
+finally
+    close(client)
+    close(listener)
+end
+
+# Expected output:
+# TLS echo: secure:hello
+# TLS version: TLSv1.3
+# Client ALPN: h2
+# Server ALPN: h2

--- a/src/1_socket_ops.jl
+++ b/src/1_socket_ops.jl
@@ -58,6 +58,8 @@ const SO_BROADCAST = @static Sys.islinux() ? Cint(0x0006) : Cint(0x0020)
 const SO_REUSEPORT = @static Sys.islinux() ? Cint(15) : Cint(0x0200)
 const IP_TTL = @static Sys.islinux() ? Cint(2) : Cint(4)
 const IPV6_UNICAST_HOPS = @static Sys.islinux() ? Cint(16) : Cint(4)
+const SO_RCVBUF = @static Sys.islinux() ? Cint(0x0008) : Cint(0x1002)
+const SO_SNDBUF = @static Sys.islinux() ? Cint(0x0007) : Cint(0x1001)
 # Windows reports datagram truncation through WSAEMSGSIZE rather than a
 # recvmsg flag, so the constant is only meaningful on POSIX platforms.
 const MSG_TRUNC = @static Sys.iswindows() ? Cint(0) :

--- a/src/1_socket_ops.jl
+++ b/src/1_socket_ops.jl
@@ -51,6 +51,17 @@ const SO_ERROR = @static Sys.islinux() ? Cint(0x0004) : Cint(0x1007)
 const SO_REUSEADDR = @static Sys.islinux() ? Cint(0x0002) : Cint(0x0004)
 const SO_KEEPALIVE = @static Sys.islinux() ? Cint(0x0009) : Cint(0x0008)
 const TCP_NODELAY = Cint(0x01)
+const IPPROTO_IP = Cint(0)
+const IPPROTO_UDP = Cint(17)
+const SO_BROADCAST = @static Sys.islinux() ? Cint(0x0006) : Cint(0x0020)
+# No SO_REUSEPORT exists on Windows; the UDP layer rejects the option there.
+const SO_REUSEPORT = @static Sys.islinux() ? Cint(15) : Cint(0x0200)
+const IP_TTL = @static Sys.islinux() ? Cint(2) : Cint(4)
+const IPV6_UNICAST_HOPS = @static Sys.islinux() ? Cint(16) : Cint(4)
+# Windows reports datagram truncation through WSAEMSGSIZE rather than a
+# recvmsg flag, so the constant is only meaningful on POSIX platforms.
+const MSG_TRUNC = @static Sys.iswindows() ? Cint(0) :
+    Sys.islinux() ? Cint(0x20) : Cint(0x10)
 
 @static if Sys.isbsd()
     """
@@ -150,6 +161,31 @@ else
 end
 
 const AcceptPeer = Union{Nothing, SockAddrIn, SockAddrIn6}
+
+"""
+    decode_sockaddr(ptr, len) -> AcceptPeer
+
+Decode a raw sockaddr buffer of `len` bytes into `SockAddrIn`/`SockAddrIn6`,
+or `nothing` when the family is unknown or the buffer is too short. The caller
+must keep the memory behind `ptr` rooted for the duration of the call.
+"""
+function decode_sockaddr(ptr::Ptr{UInt8}, len::Integer)::AcceptPeer
+    n = Int(len)
+    n < 2 && return nothing
+    family = @static if Sys.isbsd()
+        # BSD sockaddrs lead with a length byte; the family is the second byte.
+        Cint(unsafe_load(ptr, 2))
+    else
+        Cint(unsafe_load(Ptr{UInt16}(Ptr{Cvoid}(ptr))))
+    end
+    if family == AF_INET && n >= sizeof(SockAddrIn)
+        return unsafe_load(Ptr{SockAddrIn}(Ptr{Cvoid}(ptr)))
+    end
+    if family == AF_INET6 && n >= sizeof(SockAddrIn6)
+        return unsafe_load(Ptr{SockAddrIn6}(Ptr{Cvoid}(ptr)))
+    end
+    return nothing
+end
 
 @inline function _is_little_endian()::Bool
     return Base.ENDIAN_BOM == 0x04030201

--- a/src/3_netcommon.jl
+++ b/src/3_netcommon.jl
@@ -1,0 +1,347 @@
+"""
+    NetCommon
+
+Shared socket-address types and the internal `FD` (netFD) owner used by the
+`TCP` and `UDP` transport layers.
+
+This mirrors Go's `net` package structure, where one `netFD` and one set of
+sockaddr conversion helpers back every socket type. Public API surfaces live in
+`TCP` and `UDP`; those modules re-expose the address types defined here so the
+documented names (`TCP.SocketAddrV4`, ...) keep working unchanged.
+"""
+module NetCommon
+
+using ..Reseau.IOPoll
+using ..Reseau.SocketOps
+
+"""
+    SocketAddr
+
+Abstract network endpoint type for socket addresses.
+"""
+abstract type SocketAddr end
+
+"""
+    SocketAddrV4
+
+IPv4 endpoint snapshot.
+
+The address bytes are stored in presentation order and the port is stored in
+host byte order. Conversion to platform sockaddr structs happens lazily when a
+socket operation actually needs one.
+"""
+struct SocketAddrV4 <: SocketAddr
+    ip::NTuple{4, UInt8}
+    port::UInt16
+    function SocketAddrV4(ip::NTuple{4, UInt8}, port::Integer)
+        (port < 0 || port > 0xffff) && throw(ArgumentError("port must be in [0, 65535]"))
+        return new(ip, UInt16(port))
+    end
+end
+
+"""
+    SocketAddrV6
+
+IPv6 endpoint snapshot.
+
+`scope_id` is used for scoped link-local addresses and is preserved all the way
+down to the platform sockaddr representation so bind/connect can target the same
+interface the caller selected.
+"""
+struct SocketAddrV6 <: SocketAddr
+    ip::NTuple{16, UInt8}
+    port::UInt16
+    scope_id::UInt32
+    function SocketAddrV6(ip::NTuple{16, UInt8}, port::Integer; scope_id::Integer = 0)
+        (port < 0 || port > 0xffff) && throw(ArgumentError("port must be in [0, 65535]"))
+        (scope_id < 0 || scope_id > typemax(UInt32)) && throw(ArgumentError("scope_id must be in [0, 2^32-1]"))
+        return new(ip, UInt16(port), UInt32(scope_id))
+    end
+end
+
+const SocketEndpoint = Union{SocketAddrV4, SocketAddrV6}
+
+function SocketAddrV4(ip::NTuple{4, <:Integer}, port::Integer)
+    return SocketAddrV4((UInt8(ip[1]), UInt8(ip[2]), UInt8(ip[3]), UInt8(ip[4])), port)
+end
+
+function SocketAddrV6(ip::NTuple{16, <:Integer}, port::Integer; scope_id::Integer = 0)
+    return SocketAddrV6((
+            UInt8(ip[1]), UInt8(ip[2]), UInt8(ip[3]), UInt8(ip[4]),
+            UInt8(ip[5]), UInt8(ip[6]), UInt8(ip[7]), UInt8(ip[8]),
+            UInt8(ip[9]), UInt8(ip[10]), UInt8(ip[11]), UInt8(ip[12]),
+            UInt8(ip[13]), UInt8(ip[14]), UInt8(ip[15]), UInt8(ip[16]),
+        ),
+        port;
+        scope_id = scope_id,
+    )
+end
+
+"""
+    loopback_addr(port) -> SocketAddrV4
+
+Convenience constructor for `127.0.0.1:port`.
+"""
+function loopback_addr(port::Integer)::SocketAddrV4
+    return SocketAddrV4((UInt8(127), UInt8(0), UInt8(0), UInt8(1)), port)
+end
+
+"""
+    any_addr(port) -> SocketAddrV4
+
+Convenience constructor for `0.0.0.0:port`, typically used for wildcard binds.
+"""
+function any_addr(port::Integer)::SocketAddrV4
+    return SocketAddrV4((UInt8(0), UInt8(0), UInt8(0), UInt8(0)), port)
+end
+
+"""
+    loopback_addr6(port; scope_id=0) -> SocketAddrV6
+
+Convenience constructor for `[::1]:port`.
+"""
+function loopback_addr6(port::Integer; scope_id::Integer = 0)::SocketAddrV6
+    return SocketAddrV6((
+            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+            UInt8(0), UInt8(0), UInt8(0), UInt8(1),
+        ),
+        port;
+        scope_id = scope_id,
+    )
+end
+
+"""
+    any_addr6(port; scope_id=0) -> SocketAddrV6
+
+Convenience constructor for the IPv6 wildcard bind address `[::]:port`.
+"""
+function any_addr6(port::Integer; scope_id::Integer = 0)::SocketAddrV6
+    return SocketAddrV6((
+            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
+        ),
+        port;
+        scope_id = scope_id,
+    )
+end
+
+function _format_ipv6(ip::NTuple{16, UInt8})::String
+    groups = UInt16[]
+    for i in 1:8
+        hi = UInt16(ip[(2 * i) - 1])
+        lo = UInt16(ip[2 * i])
+        push!(groups, (hi << 8) | lo)
+    end
+    best_start = 0
+    best_len = 0
+    i = 1
+    while i <= length(groups)
+        if groups[i] == 0
+            j = i
+            while j <= length(groups) && groups[j] == 0
+                j += 1
+            end
+            run_len = j - i
+            if run_len > best_len && run_len >= 2
+                best_start = i
+                best_len = run_len
+            end
+            i = j
+        else
+            i += 1
+        end
+    end
+    if best_len >= 2
+        left = [string(groups[idx], base = 16) for idx in 1:(best_start - 1)]
+        right_start = best_start + best_len
+        right = [string(groups[idx], base = 16) for idx in right_start:length(groups)]
+        if isempty(left) && isempty(right)
+            return "::"
+        elseif isempty(left)
+            return "::" * join(right, ":")
+        elseif isempty(right)
+            return join(left, ":") * "::"
+        else
+            return join(left, ":") * "::" * join(right, ":")
+        end
+    end
+    return join((string(group, base = 16) for group in groups), ":")
+end
+
+function Base.show(io::IO, addr::SocketAddrV4)
+    print(io, string(addr))
+    return nothing
+end
+
+function Base.show(io::IO, addr::SocketAddrV6)
+    print(io, string(addr))
+    return nothing
+end
+
+function Base.string(addr::SocketAddrV4)
+    return "$(addr.ip[1]).$(addr.ip[2]).$(addr.ip[3]).$(addr.ip[4]):$(addr.port)"
+end
+
+function Base.string(addr::SocketAddrV6)
+    if addr.scope_id != 0
+        return "[$(_format_ipv6(addr.ip))%$(addr.scope_id)]:$(addr.port)"
+    end
+    return "[$(_format_ipv6(addr.ip))]:$(addr.port)"
+end
+
+"""
+    FD
+
+Internal socket owner built on `IOPoll.FD`.
+
+This is the internal object that owns the actual socket. Public callers usually
+interact with the `TCP`/`UDP` connection and listener types, but the transport
+implementations keep the extra metadata here so they can cache local/remote
+addresses, remember the socket family and type, and share
+shutdown/close/deadline behavior with the poll layer.
+"""
+mutable struct FD
+    pfd::IOPoll.FD
+    family::Cint
+    sotype::Cint
+    net::Symbol
+    @atomic is_connected::Bool
+    laddr::Union{Nothing, SocketAddr}
+    raddr::Union{Nothing, SocketAddr}
+end
+
+@inline _addr_family(::SocketAddrV4)::Cint = SocketOps.AF_INET
+@inline _addr_family(::SocketAddrV6)::Cint = SocketOps.AF_INET6
+
+@inline function _to_sockaddr(addr::SocketAddrV4)::SocketOps.SockAddrIn
+    return SocketOps.sockaddr_in(addr.ip, Int(addr.port))
+end
+
+@inline function _to_sockaddr(addr::SocketAddrV6)::SocketOps.SockAddrIn6
+    return SocketOps.sockaddr_in6(addr.ip, Int(addr.port); scope_id = Int(addr.scope_id))
+end
+
+@inline function _from_sockaddr(addr::SocketOps.SockAddrIn)::SocketAddrV4
+    return SocketAddrV4(SocketOps.sockaddr_in_ip(addr), Int(SocketOps.sockaddr_in_port(addr)))
+end
+
+@inline function _from_sockaddr(addr::SocketOps.SockAddrIn6)::SocketAddrV6
+    return SocketAddrV6(
+        SocketOps.sockaddr_in6_ip(addr),
+        Int(SocketOps.sockaddr_in6_port(addr));
+        scope_id = Int(SocketOps.sockaddr_in6_scopeid(addr)),
+    )
+end
+
+@inline function _is_temporary_unconnected(err::SystemError)::Bool
+    return err.errnum == Int(Base.Libc.ENOTCONN) || err.errnum == Int(Base.Libc.EINVAL)
+end
+
+function _new_netfd(
+        sysfd::SocketOps.SocketFD;
+        family::Cint = SocketOps.AF_INET,
+        sotype::Cint = SocketOps.SOCK_STREAM,
+        net::Symbol = :tcp,
+        is_connected::Bool = false,
+    )::FD
+    # Stream sockets chunk large transfers and treat zero-byte reads as EOF;
+    # datagram sockets do neither (an empty datagram is valid data).
+    is_stream = sotype == SocketOps.SOCK_STREAM
+    pfd = IOPoll.FD(sysfd; is_stream = is_stream, zero_read_is_eof = is_stream, is_file = false)
+    return FD(pfd, family, sotype, net, is_connected, nothing, nothing)
+end
+
+"""
+    open_net_fd!(; family=AF_INET, sotype=SOCK_STREAM, net=:tcp)
+
+Open a non-blocking, close-on-exec socket of the requested family and type and
+wrap it in `FD`.
+
+The returned descriptor is not yet registered with `IOPoll`; callers that plan
+to issue readiness-driven operations should call `IOPoll.register!` before use.
+Throws `SystemError` on socket creation failure.
+"""
+function open_net_fd!(;
+        family::Cint = SocketOps.AF_INET,
+        sotype::Cint = SocketOps.SOCK_STREAM,
+        net::Symbol = :tcp,
+    )::FD
+    sysfd = SocketOps.open_socket(family, sotype)
+    return _new_netfd(sysfd; family = family, sotype = sotype, net = net, is_connected = false)
+end
+
+function _set_local_addr!(fd::FD)
+    if fd.family == SocketOps.AF_INET6
+        fd.laddr = _from_sockaddr(SocketOps.get_socket_name_in6(fd.pfd.sysfd))
+        return nothing
+    end
+    fd.laddr = _from_sockaddr(SocketOps.get_socket_name_in(fd.pfd.sysfd))
+    return nothing
+end
+
+function _set_remote_addr!(fd::FD)
+    if fd.family == SocketOps.AF_INET6
+        fd.raddr = _from_sockaddr(SocketOps.get_peer_name_in6(fd.pfd.sysfd))
+        return nothing
+    end
+    fd.raddr = _from_sockaddr(SocketOps.get_peer_name_in(fd.pfd.sysfd))
+    return nothing
+end
+
+function _finalize_connected_addrs!(fd::FD, fallback_remote::SocketAddr)
+    # `getpeername` can lag slightly behind the moment the kernel considers a
+    # non-blocking connect complete. We optimistically refresh both ends, but
+    # fall back to the requested remote address when the peer lookup is only
+    # temporarily unavailable.
+    _set_local_addr!(fd)
+    if fd.raddr === nothing
+        try
+            _set_remote_addr!(fd)
+        catch err
+            if !(err isa SystemError) || !_is_temporary_unconnected(err)
+                rethrow(err)
+            end
+            fd.raddr = fallback_remote
+        end
+    end
+    @atomic :release fd.is_connected = true
+    return nothing
+end
+
+@inline function _set_ipv6_only!(fd::FD, enabled::Bool)
+    @static if Sys.isopenbsd() || Sys.isdragonfly()
+        # These kernels enforce IPv6-only sockets and reject attempts to change
+        # IPV6_V6ONLY. This is the same capability exception Go applies.
+        return nothing
+    else
+        try
+            SocketOps.set_sockopt_int(
+                fd.pfd.sysfd,
+                SocketOps.IPPROTO_IPV6,
+                SocketOps.IPV6_V6ONLY,
+                enabled ? 1 : 0,
+            )
+        catch err
+            ex = err::Exception
+            # Go parity: some operating systems never admit this option, so a
+            # setsockopt failure is deliberately ignored.
+            ex isa SystemError || rethrow(ex)
+        end
+        return nothing
+    end
+end
+
+@inline function _show_endpoint(io::IO, endpoint::Union{Nothing, SocketAddr})
+    if endpoint === nothing
+        print(io, "?")
+    else
+        show(io, endpoint)
+    end
+    return nothing
+end
+
+end

--- a/src/3_tcp.jl
+++ b/src/3_tcp.jl
@@ -18,6 +18,11 @@ module TCP
 using ..Reseau: ByteMemory, MutableByteBuffer
 using ..Reseau.IOPoll
 using ..Reseau.SocketOps
+using ..Reseau.NetCommon: SocketAddr, SocketAddrV4, SocketAddrV6, SocketEndpoint, FD,
+    loopback_addr, any_addr, loopback_addr6, any_addr6,
+    _addr_family, _to_sockaddr, _from_sockaddr, _new_netfd, open_net_fd!,
+    _set_local_addr!, _set_remote_addr!, _finalize_connected_addrs!,
+    _is_temporary_unconnected, _set_ipv6_only!, _show_endpoint
 
 """
     DeadlineExceededError
@@ -54,204 +59,6 @@ Accept one inbound `Conn` from a `TCP.Listener`.
 """
 function accept end
 
-"""
-    SocketAddr
-
-Abstract network endpoint type for TCP socket addresses.
-"""
-abstract type SocketAddr end
-
-"""
-    SocketAddrV4
-
-IPv4 endpoint snapshot.
-
-The address bytes are stored in presentation order and the port is stored in
-host byte order. Conversion to platform sockaddr structs happens lazily when a
-socket operation actually needs one.
-"""
-struct SocketAddrV4 <: SocketAddr
-    ip::NTuple{4, UInt8}
-    port::UInt16
-    function SocketAddrV4(ip::NTuple{4, UInt8}, port::Integer)
-        (port < 0 || port > 0xffff) && throw(ArgumentError("port must be in [0, 65535]"))
-        return new(ip, UInt16(port))
-    end
-end
-
-"""
-    SocketAddrV6
-
-IPv6 endpoint snapshot.
-
-`scope_id` is used for scoped link-local addresses and is preserved all the way
-down to the platform sockaddr representation so bind/connect can target the same
-interface the caller selected.
-"""
-struct SocketAddrV6 <: SocketAddr
-    ip::NTuple{16, UInt8}
-    port::UInt16
-    scope_id::UInt32
-    function SocketAddrV6(ip::NTuple{16, UInt8}, port::Integer; scope_id::Integer = 0)
-        (port < 0 || port > 0xffff) && throw(ArgumentError("port must be in [0, 65535]"))
-        (scope_id < 0 || scope_id > typemax(UInt32)) && throw(ArgumentError("scope_id must be in [0, 2^32-1]"))
-        return new(ip, UInt16(port), UInt32(scope_id))
-    end
-end
-
-const SocketEndpoint = Union{SocketAddrV4, SocketAddrV6}
-
-function SocketAddrV4(ip::NTuple{4, <:Integer}, port::Integer)
-    return SocketAddrV4((UInt8(ip[1]), UInt8(ip[2]), UInt8(ip[3]), UInt8(ip[4])), port)
-end
-
-function SocketAddrV6(ip::NTuple{16, <:Integer}, port::Integer; scope_id::Integer = 0)
-    return SocketAddrV6((
-            UInt8(ip[1]), UInt8(ip[2]), UInt8(ip[3]), UInt8(ip[4]),
-            UInt8(ip[5]), UInt8(ip[6]), UInt8(ip[7]), UInt8(ip[8]),
-            UInt8(ip[9]), UInt8(ip[10]), UInt8(ip[11]), UInt8(ip[12]),
-            UInt8(ip[13]), UInt8(ip[14]), UInt8(ip[15]), UInt8(ip[16]),
-        ),
-        port;
-        scope_id = scope_id,
-    )
-end
-
-"""
-    loopback_addr(port) -> SocketAddrV4
-
-Convenience constructor for `127.0.0.1:port`.
-"""
-function loopback_addr(port::Integer)::SocketAddrV4
-    return SocketAddrV4((UInt8(127), UInt8(0), UInt8(0), UInt8(1)), port)
-end
-
-"""
-    any_addr(port) -> SocketAddrV4
-
-Convenience constructor for `0.0.0.0:port`, typically used for wildcard binds.
-"""
-function any_addr(port::Integer)::SocketAddrV4
-    return SocketAddrV4((UInt8(0), UInt8(0), UInt8(0), UInt8(0)), port)
-end
-
-"""
-    loopback_addr6(port; scope_id=0) -> SocketAddrV6
-
-Convenience constructor for `[::1]:port`.
-"""
-function loopback_addr6(port::Integer; scope_id::Integer = 0)::SocketAddrV6
-    return SocketAddrV6((
-            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
-            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
-            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
-            UInt8(0), UInt8(0), UInt8(0), UInt8(1),
-        ),
-        port;
-        scope_id = scope_id,
-    )
-end
-
-"""
-    any_addr6(port; scope_id=0) -> SocketAddrV6
-
-Convenience constructor for the IPv6 wildcard bind address `[::]:port`.
-"""
-function any_addr6(port::Integer; scope_id::Integer = 0)::SocketAddrV6
-    return SocketAddrV6((
-            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
-            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
-            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
-            UInt8(0), UInt8(0), UInt8(0), UInt8(0),
-        ),
-        port;
-        scope_id = scope_id,
-    )
-end
-
-function _format_ipv6(ip::NTuple{16, UInt8})::String
-    groups = UInt16[]
-    for i in 1:8
-        hi = UInt16(ip[(2 * i) - 1])
-        lo = UInt16(ip[2 * i])
-        push!(groups, (hi << 8) | lo)
-    end
-    best_start = 0
-    best_len = 0
-    i = 1
-    while i <= length(groups)
-        if groups[i] == 0
-            j = i
-            while j <= length(groups) && groups[j] == 0
-                j += 1
-            end
-            run_len = j - i
-            if run_len > best_len && run_len >= 2
-                best_start = i
-                best_len = run_len
-            end
-            i = j
-        else
-            i += 1
-        end
-    end
-    if best_len >= 2
-        left = [string(groups[idx], base = 16) for idx in 1:(best_start - 1)]
-        right_start = best_start + best_len
-        right = [string(groups[idx], base = 16) for idx in right_start:length(groups)]
-        if isempty(left) && isempty(right)
-            return "::"
-        elseif isempty(left)
-            return "::" * join(right, ":")
-        elseif isempty(right)
-            return join(left, ":") * "::"
-        else
-            return join(left, ":") * "::" * join(right, ":")
-        end
-    end
-    return join((string(group, base = 16) for group in groups), ":")
-end
-
-function Base.show(io::IO, addr::SocketAddrV4)
-    print(io, string(addr))
-    return nothing
-end
-
-function Base.show(io::IO, addr::SocketAddrV6)
-    print(io, string(addr))
-    return nothing
-end
-
-function Base.string(addr::SocketAddrV4)
-    return "$(addr.ip[1]).$(addr.ip[2]).$(addr.ip[3]).$(addr.ip[4]):$(addr.port)"
-end
-
-function Base.string(addr::SocketAddrV6)
-    if addr.scope_id != 0
-        return "[$(_format_ipv6(addr.ip))%$(addr.scope_id)]:$(addr.port)"
-    end
-    return "[$(_format_ipv6(addr.ip))]:$(addr.port)"
-end
-
-"""
-    FD
-
-Internal socket owner built on `IOPoll.FD`.
-
-This is the internal object that owns the actual socket. Public callers usually
-interact with `Conn` or `Listener`, but the transport implementation keeps the
-extra metadata here so it can cache local/remote addresses, remember the socket
-family, and share shutdown/close/deadline behavior with the poll layer.
-"""
-mutable struct FD
-    pfd::IOPoll.FD
-    family::Cint
-    sotype::Cint
-    net::Symbol
-    @atomic is_connected::Bool
-    laddr::Union{Nothing, SocketAddr}
-    raddr::Union{Nothing, SocketAddr}
-end
 
 """
     Conn
@@ -287,29 +94,6 @@ struct ConnectCanceledError <: Exception end
 @inline _connect_wait_register!(::Any, ::FD) = nothing
 @inline _connect_wait_unregister!(::Any, ::FD) = nothing
 
-@inline _addr_family(::SocketAddrV4)::Cint = SocketOps.AF_INET
-@inline _addr_family(::SocketAddrV6)::Cint = SocketOps.AF_INET6
-
-@inline function _to_sockaddr(addr::SocketAddrV4)::SocketOps.SockAddrIn
-    return SocketOps.sockaddr_in(addr.ip, Int(addr.port))
-end
-
-@inline function _to_sockaddr(addr::SocketAddrV6)::SocketOps.SockAddrIn6
-    return SocketOps.sockaddr_in6(addr.ip, Int(addr.port); scope_id = Int(addr.scope_id))
-end
-
-@inline function _from_sockaddr(addr::SocketOps.SockAddrIn)::SocketAddrV4
-    return SocketAddrV4(SocketOps.sockaddr_in_ip(addr), Int(SocketOps.sockaddr_in_port(addr)))
-end
-
-@inline function _from_sockaddr(addr::SocketOps.SockAddrIn6)::SocketAddrV6
-    return SocketAddrV6(
-        SocketOps.sockaddr_in6_ip(addr),
-        Int(SocketOps.sockaddr_in6_port(addr));
-        scope_id = Int(SocketOps.sockaddr_in6_scopeid(addr)),
-    )
-end
-
 @inline function _set_remote_addr_from_accept!(fd::FD, peer_addr::SocketOps.AcceptPeer)
     if peer_addr isa SocketOps.SockAddrIn
         fd.raddr = _from_sockaddr(peer_addr::SocketOps.SockAddrIn)
@@ -329,59 +113,6 @@ end
 
 @inline function _is_accept_retry_errno(errno::Int32)::Bool
     return errno == Int32(Base.Libc.EINTR) || errno == Int32(Base.Libc.ECONNABORTED)
-end
-
-@inline function _is_temporary_unconnected(err::SystemError)::Bool
-    return err.errnum == Int(Base.Libc.ENOTCONN) || err.errnum == Int(Base.Libc.EINVAL)
-end
-
-function _new_netfd(
-        sysfd::SocketOps.SocketFD;
-        family::Cint = SocketOps.AF_INET,
-        sotype::Cint = SocketOps.SOCK_STREAM,
-        net::Symbol = :tcp,
-        is_connected::Bool = false,
-    )::FD
-    pfd = IOPoll.FD(sysfd; is_stream = true, zero_read_is_eof = true, is_file = false)
-    return FD(pfd, family, sotype, net, is_connected, nothing, nothing)
-end
-
-function _set_local_addr!(fd::FD)
-    if fd.family == SocketOps.AF_INET6
-        fd.laddr = _from_sockaddr(SocketOps.get_socket_name_in6(fd.pfd.sysfd))
-        return nothing
-    end
-    fd.laddr = _from_sockaddr(SocketOps.get_socket_name_in(fd.pfd.sysfd))
-    return nothing
-end
-
-function _set_remote_addr!(fd::FD)
-    if fd.family == SocketOps.AF_INET6
-        fd.raddr = _from_sockaddr(SocketOps.get_peer_name_in6(fd.pfd.sysfd))
-        return nothing
-    end
-    fd.raddr = _from_sockaddr(SocketOps.get_peer_name_in(fd.pfd.sysfd))
-    return nothing
-end
-
-function _finalize_connected_addrs!(fd::FD, fallback_remote::SocketAddr)
-    # `getpeername` can lag slightly behind the moment the kernel considers a
-    # non-blocking connect complete. We optimistically refresh both ends, but
-    # fall back to the requested remote address when the peer lookup is only
-    # temporarily unavailable.
-    _set_local_addr!(fd)
-    if fd.raddr === nothing
-        try
-            _set_remote_addr!(fd)
-        catch err
-            if !(err isa SystemError) || !_is_temporary_unconnected(err)
-                rethrow(err)
-            end
-            fd.raddr = fallback_remote
-        end
-    end
-    @atomic :release fd.is_connected = true
-    return nothing
 end
 
 function _apply_default_tcp_opts!(fd::FD)
@@ -506,31 +237,7 @@ function open_tcp_fd!(;
         family::Cint = SocketOps.AF_INET,
         net::Symbol = :tcp,
     )::FD
-    sysfd = SocketOps.open_socket(family, SocketOps.SOCK_STREAM)
-    return _new_netfd(sysfd; family = family, sotype = SocketOps.SOCK_STREAM, net = net, is_connected = false)
-end
-
-@inline function _set_ipv6_only!(fd::FD, enabled::Bool)
-    @static if Sys.isopenbsd() || Sys.isdragonfly()
-        # These kernels enforce IPv6-only sockets and reject attempts to change
-        # IPV6_V6ONLY. This is the same capability exception Go applies.
-        return nothing
-    else
-        try
-            SocketOps.set_sockopt_int(
-                fd.pfd.sysfd,
-                SocketOps.IPPROTO_IPV6,
-                SocketOps.IPV6_V6ONLY,
-                enabled ? 1 : 0,
-            )
-        catch err
-            ex = err::Exception
-            # Go parity: some operating systems never admit this option, so a
-            # setsockopt failure is deliberately ignored.
-            ex isa SystemError || rethrow(ex)
-        end
-        return nothing
-    end
+    return open_net_fd!(; family = family, sotype = SocketOps.SOCK_STREAM, net = net)
 end
 
 @inline function _connect_socketaddr_family(
@@ -1397,15 +1104,6 @@ Return the listener's bound local endpoint, if known.
 """
 function addr(listener::Listener)::Union{Nothing, SocketAddr}
     return listener.fd.laddr
-end
-
-@inline function _show_endpoint(io::IO, endpoint::Union{Nothing, SocketAddr})
-    if endpoint === nothing
-        print(io, "?")
-    else
-        show(io, endpoint)
-    end
-    return nothing
 end
 
 @inline _show_state(conn::Conn) = IOPoll._fdlock_closing(conn.fd.pfd.fdlock) ? "closed" : "open"

--- a/src/3_tcp.jl
+++ b/src/3_tcp.jl
@@ -20,7 +20,7 @@ using ..Reseau.IOPoll
 using ..Reseau.SocketOps
 using ..Reseau.NetCommon: SocketAddr, SocketAddrV4, SocketAddrV6, SocketEndpoint, FD,
     loopback_addr, any_addr, loopback_addr6, any_addr6,
-    _addr_family, _to_sockaddr, _from_sockaddr, _new_netfd, open_net_fd!,
+    _addr_family, _to_sockaddr, _from_sockaddr, _format_ipv6, _new_netfd, open_net_fd!,
     _set_local_addr!, _set_remote_addr!, _finalize_connected_addrs!,
     _is_temporary_unconnected, _set_ipv6_only!, _show_endpoint
 

--- a/src/3_udp.jl
+++ b/src/3_udp.jl
@@ -91,6 +91,54 @@ string-address overload added later in the file load order.
 """
 function listen end
 
+@inline _is_wildcard_ip(addr::SocketAddrV4)::Bool = addr.ip == (0x00, 0x00, 0x00, 0x00)
+@inline _is_wildcard_ip(addr::SocketAddrV6)::Bool = all(iszero, addr.ip)
+
+# Go internetSocket parity: kernels that reject wildcard dial destinations
+# (Windows, FreeBSD, OpenBSD) get them rewritten to the same-family loopback.
+# Elsewhere the kernel itself interprets a wildcard destination as localhost.
+@inline function _prepare_dial_remote(remote_addr::SocketAddr)::SocketAddr
+    @static if Sys.iswindows() || Sys.isfreebsd() || Sys.isopenbsd()
+        _is_wildcard_ip(remote_addr) || return remote_addr
+        if remote_addr isa SocketAddrV6
+            return loopback_addr6(remote_addr.port; scope_id = remote_addr.scope_id)
+        end
+        return loopback_addr(remote_addr.port)
+    else
+        return remote_addr
+    end
+end
+
+const _V4_MAPPED_PREFIX = (
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff,
+)
+
+"""
+    _coerce_family(addr, family) -> SocketEndpoint
+
+Convert `addr` to the socket's address family, mirroring Go's `ipToSockaddr`:
+an IPv4 address becomes an IPv4-mapped IPv6 address on an `AF_INET6` socket
+(the IPv4 wildcard maps to the IPv6 wildcard), and an IPv4-mapped IPv6
+address collapses to plain IPv4 on an `AF_INET` socket. Anything else with a
+mismatched family throws `ArgumentError`.
+"""
+@inline function _coerce_family(addr::SocketAddr, family::Cint)::SocketEndpoint
+    _addr_family(addr) == family && return addr::SocketEndpoint
+    if family == SocketOps.AF_INET6 && addr isa SocketAddrV4
+        _is_wildcard_ip(addr) && return any_addr6(addr.port)
+        ip = addr.ip
+        return SocketAddrV6((_V4_MAPPED_PREFIX..., ip[1], ip[2], ip[3], ip[4]), addr.port)
+    end
+    if family == SocketOps.AF_INET && addr isa SocketAddrV6
+        ip = addr.ip
+        if ip[1:12] == _V4_MAPPED_PREFIX && addr.scope_id == 0
+            return SocketAddrV4((ip[13], ip[14], ip[15], ip[16]), addr.port)
+        end
+    end
+    throw(ArgumentError("address family does not match the socket family"))
+end
+
+
 @inline function _is_connected(conn::Conn)::Bool
     return @atomic :acquire conn.fd.is_connected
 end
@@ -139,6 +187,9 @@ function _listen_impl(
     ok = false
     try
         family == SocketOps.AF_INET6 && _set_ipv6_only!(fd, v6only)
+        # Go parity (setDefaultSockopts): datagram sockets allow broadcast out
+        # of the box. Unlike the v6only option above, a failure is surfaced.
+        SocketOps.set_sockopt_int(fd.pfd.sysfd, SocketOps.SOL_SOCKET, SocketOps.SO_BROADCAST, 1)
         if reuseaddr
             SocketOps.set_sockopt_int(fd.pfd.sysfd, SocketOps.SOL_SOCKET, SocketOps.SO_REUSEADDR, 1)
         end
@@ -186,25 +237,38 @@ function _connect_impl(
         v6only::Bool,
         net::Symbol,
     )::Conn
-    family = _addr_family(remote_addr)
-    if local_addr !== nothing && _addr_family(local_addr) != family
-        throw(ArgumentError("local and remote address families must match"))
+    remote_addr = _prepare_dial_remote(remote_addr)
+    # Go favoriteAddrFamily parity: the socket is AF_INET only when every
+    # given address is IPv4; otherwise it is AF_INET6 and IPv4 addresses are
+    # carried as IPv4-mapped IPv6.
+    family = if local_addr === nothing
+        _addr_family(remote_addr)
+    elseif _addr_family(local_addr) == SocketOps.AF_INET &&
+            _addr_family(remote_addr) == SocketOps.AF_INET
+        SocketOps.AF_INET
+    else
+        SocketOps.AF_INET6
     end
+    remote_endpoint = _coerce_family(remote_addr, family)
+    local_endpoint = local_addr === nothing ? nothing : _coerce_family(local_addr, family)
     fd = open_net_fd!(; family = family, sotype = SocketOps.SOCK_DGRAM, net = net)
     registered = false
     ok = false
     try
         family == SocketOps.AF_INET6 && _set_ipv6_only!(fd, v6only)
-        if local_addr !== nothing
-            SocketOps.bind_socket(fd.pfd.sysfd, _to_sockaddr(local_addr))
+        # Go parity (setDefaultSockopts): datagram sockets allow broadcast out
+        # of the box. Unlike the v6only option above, a failure is surfaced.
+        SocketOps.set_sockopt_int(fd.pfd.sysfd, SocketOps.SOL_SOCKET, SocketOps.SO_BROADCAST, 1)
+        if local_endpoint !== nothing
+            SocketOps.bind_socket(fd.pfd.sysfd, _to_sockaddr(local_endpoint))
         end
-        errno = SocketOps.connect_socket(fd.pfd.sysfd, _to_sockaddr(remote_addr))
+        errno = SocketOps.connect_socket(fd.pfd.sysfd, _to_sockaddr(remote_endpoint))
         if errno != Int32(0) && errno != Int32(Base.Libc.EISCONN)
             throw(SystemError("connect", Int(errno)))
         end
         IOPoll.register!(fd.pfd)
         registered = true
-        _finalize_connected_addrs!(fd, remote_addr)
+        _finalize_connected_addrs!(fd, remote_endpoint)
         ok = true
         return Conn(fd)
     finally
@@ -274,10 +338,8 @@ socket's.
 """
 function sendto(conn::Conn, data, addr::SocketAddr)::Nothing
     _is_connected(conn) && throw(ArgumentError("sendto on a connected UDP socket; use send(conn, data)"))
-    if _addr_family(addr) != conn.fd.family
-        throw(ArgumentError("destination address family does not match the socket family"))
-    end
-    _send_payload!(conn, data, addr)
+    dest = _coerce_family(addr, conn.fd.family)
+    _send_payload!(conn, data, dest)
     return nothing
 end
 
@@ -370,10 +432,37 @@ end
 """
     set_broadcast!(conn::Conn, enabled=true)
 
-Toggle `SO_BROADCAST`, allowing sends to broadcast addresses.
+Toggle `SO_BROADCAST`. Broadcast is **enabled by default** on every UDP
+socket (Go parity); use `set_broadcast!(conn, false)` to disable it.
 """
 function set_broadcast!(conn::Conn, enabled::Bool = true)
     IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.SOL_SOCKET, SocketOps.SO_BROADCAST, enabled ? 1 : 0)
+    return nothing
+end
+
+
+"""
+    set_read_buffer!(conn::Conn, nbytes::Integer)
+
+Set the kernel receive buffer size (`SO_RCVBUF`). Kernels may round the
+value (Linux doubles it). Datagrams that arrive while the buffer is full are
+dropped, so servers expecting bursts should raise this.
+"""
+function set_read_buffer!(conn::Conn, nbytes::Integer)
+    nbytes > 0 || throw(ArgumentError("buffer size must be positive"))
+    IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.SOL_SOCKET, SocketOps.SO_RCVBUF, Int(nbytes))
+    return nothing
+end
+
+"""
+    set_write_buffer!(conn::Conn, nbytes::Integer)
+
+Set the kernel send buffer size (`SO_SNDBUF`). Kernels may round the value
+(Linux doubles it).
+"""
+function set_write_buffer!(conn::Conn, nbytes::Integer)
+    nbytes > 0 || throw(ArgumentError("buffer size must be positive"))
+    IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.SOL_SOCKET, SocketOps.SO_SNDBUF, Int(nbytes))
     return nothing
 end
 

--- a/src/3_udp.jl
+++ b/src/3_udp.jl
@@ -120,15 +120,25 @@ Windows, which has no equivalent option. IPv6 sockets are opened dual-stack
 where the platform allows it, matching `TCP`.
 """
 function listen(local_addr::SocketAddr; reuseaddr::Bool = false, reuseport::Bool = false)::Conn
+    return _listen_impl(local_addr; reuseaddr = reuseaddr, reuseport = reuseport, v6only = false, net = :udp)
+end
+
+function _listen_impl(
+        local_addr::SocketAddr;
+        reuseaddr::Bool,
+        reuseport::Bool,
+        v6only::Bool,
+        net::Symbol,
+    )::Conn
     @static if Sys.iswindows()
         reuseport && throw(ArgumentError("reuseport is not supported on Windows"))
     end
     family = _addr_family(local_addr)
-    fd = open_net_fd!(; family = family, sotype = SocketOps.SOCK_DGRAM, net = :udp)
+    fd = open_net_fd!(; family = family, sotype = SocketOps.SOCK_DGRAM, net = net)
     registered = false
     ok = false
     try
-        family == SocketOps.AF_INET6 && _set_ipv6_only!(fd, false)
+        family == SocketOps.AF_INET6 && _set_ipv6_only!(fd, v6only)
         if reuseaddr
             SocketOps.set_sockopt_int(fd.pfd.sysfd, SocketOps.SOL_SOCKET, SocketOps.SO_REUSEADDR, 1)
         end
@@ -167,15 +177,24 @@ function connect(
         remote_addr::SocketAddr;
         local_addr::Union{Nothing, SocketAddr} = nothing,
     )::Conn
+    return _connect_impl(remote_addr; local_addr = local_addr, v6only = false, net = :udp)
+end
+
+function _connect_impl(
+        remote_addr::SocketAddr;
+        local_addr::Union{Nothing, SocketAddr},
+        v6only::Bool,
+        net::Symbol,
+    )::Conn
     family = _addr_family(remote_addr)
     if local_addr !== nothing && _addr_family(local_addr) != family
         throw(ArgumentError("local and remote address families must match"))
     end
-    fd = open_net_fd!(; family = family, sotype = SocketOps.SOCK_DGRAM, net = :udp)
+    fd = open_net_fd!(; family = family, sotype = SocketOps.SOCK_DGRAM, net = net)
     registered = false
     ok = false
     try
-        family == SocketOps.AF_INET6 && _set_ipv6_only!(fd, false)
+        family == SocketOps.AF_INET6 && _set_ipv6_only!(fd, v6only)
         if local_addr !== nothing
             SocketOps.bind_socket(fd.pfd.sysfd, _to_sockaddr(local_addr))
         end

--- a/src/3_udp.jl
+++ b/src/3_udp.jl
@@ -1,0 +1,474 @@
+"""
+    UDP
+
+Core UDP socket operations and the datagram connection type.
+
+This layer sits directly above `SocketOps`, `IOPoll`, and `NetCommon`, and
+mirrors Go's `net.UDPConn`:
+- one `Conn` type serves both unconnected (bound) and connected sockets
+- `listen` binds a socket for `sendto`/`recvfrom`-style use; `connect` fixes a
+  peer so `send`/`recv` apply and ICMP errors surface as `SystemError`s
+- a datagram is sent and received whole: there are no partial transfers, a
+  zero-byte datagram is valid data rather than EOF, and `Conn` is deliberately
+  **not** an `IO` (stream helpers like `readline` would corrupt datagram
+  boundaries)
+- deadline expiry is surfaced as `UDP.DeadlineExceededError`, with the same
+  sticky per-socket deadline model as `TCP`
+"""
+module UDP
+
+using ..Reseau: ByteMemory, MutableByteBuffer
+using ..Reseau.IOPoll
+using ..Reseau.SocketOps
+using ..Reseau.NetCommon: SocketAddr, SocketAddrV4, SocketAddrV6, SocketEndpoint, FD,
+    loopback_addr, any_addr, loopback_addr6, any_addr6,
+    _addr_family, _to_sockaddr, _from_sockaddr, _new_netfd, open_net_fd!,
+    _set_local_addr!, _finalize_connected_addrs!, _set_ipv6_only!, _show_endpoint
+
+"""
+    DeadlineExceededError
+
+Raised when blocking UDP I/O exceeds the active deadline.
+
+Catch `UDP.DeadlineExceededError` when a deadline set by `set_deadline!`,
+`set_read_deadline!`, or `set_write_deadline!` expires. This aliases the
+underlying poller timeout type so downstream code does not need to depend on
+`Reseau.IOPoll` directly.
+"""
+const DeadlineExceededError = IOPoll.DeadlineExceededError
+
+"""
+    TruncatedDatagramError
+
+Raised by `recv!`/`recvfrom!` (and the allocating forms with a small `maxsize`)
+when an incoming datagram was longer than the destination buffer and
+`allow_truncate=false` (the default). `nread` is the number of bytes that were
+delivered; the rest of the datagram is discarded by the kernel. The socket
+remains usable.
+"""
+struct TruncatedDatagramError <: Exception
+    nread::Int
+end
+
+function Base.showerror(io::IO, err::TruncatedDatagramError)
+    print(io, "datagram truncated after $(err.nread) bytes; pass allow_truncate=true to accept truncated reads")
+    return nothing
+end
+
+"""
+    Conn
+
+User-facing UDP socket.
+
+One type serves both modes, mirroring Go's `net.UDPConn`:
+- an *unconnected* socket (from [`listen`](@ref)) exchanges datagrams with any
+  peer via [`sendto`](@ref) and [`recvfrom`](@ref)/[`recvfrom!`](@ref)
+- a *connected* socket (from [`connect`](@ref)) has a fixed peer, uses
+  [`send`](@ref) and [`recv`](@ref)/[`recv!`](@ref), and surfaces ICMP
+  errors (e.g. `ECONNREFUSED`) on subsequent operations
+
+`recv`-family calls work on both modes; `send` requires a connected socket and
+`sendto` an unconnected one. `Conn` is not an `IO`: datagrams are messages,
+not a byte stream.
+"""
+struct Conn
+    fd::FD
+end
+
+"""
+    connect
+
+Create a connected UDP socket from a concrete `SocketAddr` or a string-address
+overload added later in the file load order.
+"""
+function connect end
+
+"""
+    listen
+
+Bind an unconnected UDP socket from a concrete `SocketAddr` or a
+string-address overload added later in the file load order.
+"""
+function listen end
+
+@inline function _is_connected(conn::Conn)::Bool
+    return @atomic :acquire conn.fd.is_connected
+end
+
+function _close_partial!(fd::FD, registered::Bool)
+    if registered
+        try
+            Base.close(fd.pfd)
+        catch
+        end
+    else
+        SocketOps.close_socket_nothrow(fd.pfd.sysfd)
+    end
+    return nothing
+end
+
+"""
+    listen(local_addr::SocketAddr; reuseaddr=false, reuseport=false) -> Conn
+
+Bind an unconnected UDP socket to `local_addr` and return it.
+
+Port `0` binds an ephemeral port; read it back with [`local_addr`](@ref).
+`reuseaddr` sets `SO_REUSEADDR`. `reuseport` sets `SO_REUSEPORT` (kernel
+load-balancing of datagrams across sockets bound to the same port on Linux;
+BSD port-sharing semantics on Darwin/BSD) and throws `ArgumentError` on
+Windows, which has no equivalent option. IPv6 sockets are opened dual-stack
+where the platform allows it, matching `TCP`.
+"""
+function listen(local_addr::SocketAddr; reuseaddr::Bool = false, reuseport::Bool = false)::Conn
+    @static if Sys.iswindows()
+        reuseport && throw(ArgumentError("reuseport is not supported on Windows"))
+    end
+    family = _addr_family(local_addr)
+    fd = open_net_fd!(; family = family, sotype = SocketOps.SOCK_DGRAM, net = :udp)
+    registered = false
+    ok = false
+    try
+        family == SocketOps.AF_INET6 && _set_ipv6_only!(fd, false)
+        if reuseaddr
+            SocketOps.set_sockopt_int(fd.pfd.sysfd, SocketOps.SOL_SOCKET, SocketOps.SO_REUSEADDR, 1)
+        end
+        @static if !Sys.iswindows()
+            if reuseport
+                SocketOps.set_sockopt_int(fd.pfd.sysfd, SocketOps.SOL_SOCKET, SocketOps.SO_REUSEPORT, 1)
+            end
+        end
+        @static if Sys.iswindows()
+            # One dead peer must not poison a shared unconnected socket with
+            # spurious WSAECONNRESET failures (see set_udp_connreset!).
+            SocketOps.set_udp_connreset!(fd.pfd.sysfd, false)
+        end
+        SocketOps.bind_socket(fd.pfd.sysfd, _to_sockaddr(local_addr))
+        IOPoll.register!(fd.pfd)
+        registered = true
+        _set_local_addr!(fd)
+        ok = true
+        return Conn(fd)
+    finally
+        ok || _close_partial!(fd, registered)
+    end
+end
+
+"""
+    connect(remote_addr::SocketAddr; local_addr=nothing) -> Conn
+
+Create a connected UDP socket with `remote_addr` as its fixed peer.
+
+Connecting a UDP socket is a local operation: no packets are exchanged, the
+kernel simply filters inbound datagrams to the peer and lets ICMP errors from
+prior sends surface on later operations (Go semantics). `local_addr`, when
+given, must share the remote's address family and is bound before connecting.
+"""
+function connect(
+        remote_addr::SocketAddr;
+        local_addr::Union{Nothing, SocketAddr} = nothing,
+    )::Conn
+    family = _addr_family(remote_addr)
+    if local_addr !== nothing && _addr_family(local_addr) != family
+        throw(ArgumentError("local and remote address families must match"))
+    end
+    fd = open_net_fd!(; family = family, sotype = SocketOps.SOCK_DGRAM, net = :udp)
+    registered = false
+    ok = false
+    try
+        family == SocketOps.AF_INET6 && _set_ipv6_only!(fd, false)
+        if local_addr !== nothing
+            SocketOps.bind_socket(fd.pfd.sysfd, _to_sockaddr(local_addr))
+        end
+        errno = SocketOps.connect_socket(fd.pfd.sysfd, _to_sockaddr(remote_addr))
+        if errno != Int32(0) && errno != Int32(Base.Libc.EISCONN)
+            throw(SystemError("connect", Int(errno)))
+        end
+        IOPoll.register!(fd.pfd)
+        registered = true
+        _finalize_connected_addrs!(fd, remote_addr)
+        ok = true
+        return Conn(fd)
+    finally
+        ok || _close_partial!(fd, registered)
+    end
+end
+
+##########################
+# Send paths
+##########################
+
+@inline function _send_ptr!(conn::Conn, p::Ptr{UInt8}, nbytes::Int, root, ::Nothing)::Int
+    return IOPoll.sendto_ptr!(conn.fd.pfd, p, nbytes, root, nothing, 0)
+end
+
+@inline function _send_ptr!(conn::Conn, p::Ptr{UInt8}, nbytes::Int, root, addr::SocketAddrV4)::Int
+    dest = Ref(_to_sockaddr(addr))
+    return IOPoll.sendto_ptr!(conn.fd.pfd, p, nbytes, root, dest, sizeof(SocketOps.SockAddrIn))
+end
+
+@inline function _send_ptr!(conn::Conn, p::Ptr{UInt8}, nbytes::Int, root, addr::SocketAddrV6)::Int
+    dest = Ref(_to_sockaddr(addr))
+    return IOPoll.sendto_ptr!(conn.fd.pfd, p, nbytes, root, dest, sizeof(SocketOps.SockAddrIn6))
+end
+
+function _send_payload!(conn::Conn, data::Union{Vector{UInt8}, ByteMemory}, dest)::Int
+    GC.@preserve data begin
+        return _send_ptr!(conn, pointer(data), length(data), data, dest)
+    end
+end
+
+function _send_payload!(conn::Conn, data::Union{String, SubString{String}}, dest)::Int
+    GC.@preserve data begin
+        return _send_ptr!(conn, pointer(data), ncodeunits(data), data, dest)
+    end
+end
+
+function _send_payload!(conn::Conn, data::AbstractVector{UInt8}, dest)::Int
+    return _send_payload!(conn, Vector{UInt8}(data), dest)
+end
+
+"""
+    send(conn::Conn, data) -> Nothing
+
+Send `data` as one datagram to the connected peer.
+
+Throws `ArgumentError` if `conn` is unconnected (use [`sendto`](@ref)).
+`data` may be a byte vector or a string; an empty payload sends a valid
+empty datagram. Payloads are limited to the UDP maximum (65,507 bytes);
+oversized sends surface the kernel's `EMSGSIZE` as a `SystemError` and leave
+the socket usable.
+"""
+function send(conn::Conn, data)::Nothing
+    _is_connected(conn) || throw(ArgumentError("send requires a connected UDP socket; use sendto(conn, data, addr)"))
+    _send_payload!(conn, data, nothing)
+    return nothing
+end
+
+"""
+    sendto(conn::Conn, data, addr::SocketAddr) -> Nothing
+
+Send `data` as one datagram to `addr` on an unconnected socket.
+
+Throws `ArgumentError` if `conn` is connected (Go's `ErrWriteToConnected`
+semantics; use [`send`](@ref)) or if `addr`'s family does not match the
+socket's.
+"""
+function sendto(conn::Conn, data, addr::SocketAddr)::Nothing
+    _is_connected(conn) && throw(ArgumentError("sendto on a connected UDP socket; use send(conn, data)"))
+    if _addr_family(addr) != conn.fd.family
+        throw(ArgumentError("destination address family does not match the socket family"))
+    end
+    _send_payload!(conn, data, addr)
+    return nothing
+end
+
+##########################
+# Receive paths
+##########################
+
+@inline _peer_endpoint(::Nothing)::Union{Nothing, SocketEndpoint} = nothing
+@inline _peer_endpoint(sa::SocketOps.SockAddrIn)::Union{Nothing, SocketEndpoint} = _from_sockaddr(sa)
+@inline _peer_endpoint(sa::SocketOps.SockAddrIn6)::Union{Nothing, SocketEndpoint} = _from_sockaddr(sa)
+
+function _recv_datagram!(conn::Conn, buf::MutableByteBuffer, allow_truncate::Bool)
+    n, peer, truncated = GC.@preserve buf IOPoll.recvfrom_ptr!(
+        conn.fd.pfd,
+        Base.unsafe_convert(Ptr{UInt8}, buf),
+        length(buf),
+        buf,
+    )
+    if truncated && !allow_truncate
+        throw(TruncatedDatagramError(n))
+    end
+    return n, _peer_endpoint(peer)
+end
+
+"""
+    recvfrom!(conn::Conn, buf; allow_truncate=false) -> (nread, addr)
+
+Receive one datagram into `buf`, returning the byte count and the sender's
+address.
+
+Blocks until a datagram arrives (or the read deadline expires). If the
+datagram is longer than `buf`, the excess is discarded by the kernel and, with
+`allow_truncate=false` (the default), a [`TruncatedDatagramError`](@ref) is
+thrown; with `allow_truncate=true` the truncated prefix is returned silently
+(Go semantics). A zero-byte result is a valid empty datagram, never EOF.
+"""
+function recvfrom!(
+        conn::Conn,
+        buf::MutableByteBuffer;
+        allow_truncate::Bool = false,
+    )::Tuple{Int, Union{Nothing, SocketEndpoint}}
+    return _recv_datagram!(conn, buf, allow_truncate)
+end
+
+"""
+    recv!(conn::Conn, buf; allow_truncate=false) -> Int
+
+Receive one datagram into `buf` and return the byte count, discarding the
+sender address. Works on connected and unconnected sockets alike; truncation
+behaves as in [`recvfrom!`](@ref).
+"""
+function recv!(conn::Conn, buf::MutableByteBuffer; allow_truncate::Bool = false)::Int
+    n, _ = _recv_datagram!(conn, buf, allow_truncate)
+    return n
+end
+
+"""
+    recvfrom(conn::Conn; maxsize=65535) -> (data::Vector{UInt8}, addr)
+
+Receive one datagram, allocating a right-sized result vector.
+
+The default `maxsize` holds any UDP datagram, so the default call never
+truncates. A smaller `maxsize` throws [`TruncatedDatagramError`](@ref) for
+longer datagrams.
+"""
+function recvfrom(conn::Conn; maxsize::Integer = 65535)::Tuple{Vector{UInt8}, Union{Nothing, SocketEndpoint}}
+    buf = Vector{UInt8}(undef, Int(maxsize))
+    n, addr = _recv_datagram!(conn, buf, false)
+    resize!(buf, n)
+    return buf, addr
+end
+
+"""
+    recv(conn::Conn; maxsize=65535) -> Vector{UInt8}
+
+Receive one datagram, allocating a right-sized result vector and discarding
+the sender address. See [`recvfrom`](@ref) for `maxsize` semantics.
+"""
+function recv(conn::Conn; maxsize::Integer = 65535)::Vector{UInt8}
+    buf = Vector{UInt8}(undef, Int(maxsize))
+    n, _ = _recv_datagram!(conn, buf, false)
+    resize!(buf, n)
+    return buf
+end
+
+##########################
+# Options
+##########################
+
+"""
+    set_broadcast!(conn::Conn, enabled=true)
+
+Toggle `SO_BROADCAST`, allowing sends to broadcast addresses.
+"""
+function set_broadcast!(conn::Conn, enabled::Bool = true)
+    IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.SOL_SOCKET, SocketOps.SO_BROADCAST, enabled ? 1 : 0)
+    return nothing
+end
+
+"""
+    set_ttl!(conn::Conn, ttl::Integer)
+
+Set the unicast time-to-live (IPv4 `IP_TTL`) or hop limit (IPv6
+`IPV6_UNICAST_HOPS`) for outgoing datagrams.
+"""
+function set_ttl!(conn::Conn, ttl::Integer)
+    (ttl < 0 || ttl > 255) && throw(ArgumentError("ttl must be in [0, 255]"))
+    if conn.fd.family == SocketOps.AF_INET6
+        IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.IPPROTO_IPV6, SocketOps.IPV6_UNICAST_HOPS, Int(ttl))
+    else
+        IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.IPPROTO_IP, SocketOps.IP_TTL, Int(ttl))
+    end
+    return nothing
+end
+
+##########################
+# Deadlines
+##########################
+
+"""
+    set_deadline!(conn::Conn, deadline_ns::Integer)
+
+Set both the read and write deadline to the absolute monotonic timestamp
+`deadline_ns` (the `time_ns()` clock). `0` clears; a value `<= time_ns()`
+expires immediately, waking any parked operation with
+`UDP.DeadlineExceededError`.
+"""
+function set_deadline!(conn::Conn, deadline_ns::Integer)
+    IOPoll.set_deadline!(conn.fd.pfd, Int64(deadline_ns))
+    return nothing
+end
+
+"""
+    set_read_deadline!(conn::Conn, deadline_ns::Integer)
+
+Set the deadline for `recv`-family operations. See [`set_deadline!`](@ref).
+"""
+function set_read_deadline!(conn::Conn, deadline_ns::Integer)
+    IOPoll.set_read_deadline!(conn.fd.pfd, Int64(deadline_ns))
+    return nothing
+end
+
+"""
+    set_write_deadline!(conn::Conn, deadline_ns::Integer)
+
+Set the deadline for `send`-family operations. See [`set_deadline!`](@ref).
+"""
+function set_write_deadline!(conn::Conn, deadline_ns::Integer)
+    IOPoll.set_write_deadline!(conn.fd.pfd, Int64(deadline_ns))
+    return nothing
+end
+
+##########################
+# Introspection and lifecycle
+##########################
+
+"""
+    local_addr(conn::Conn) -> Union{Nothing, SocketAddr}
+
+The socket's bound local address, cached at `listen`/`connect` time.
+"""
+function local_addr(conn::Conn)::Union{Nothing, SocketAddr}
+    return conn.fd.laddr
+end
+
+"""
+    remote_addr(conn::Conn) -> Union{Nothing, SocketAddr}
+
+The connected peer address, or `nothing` for unconnected sockets.
+"""
+function remote_addr(conn::Conn)::Union{Nothing, SocketAddr}
+    return conn.fd.raddr
+end
+
+"""
+    close(conn::Conn)
+
+Close the socket, waking any parked operations with `NetClosingError`.
+Idempotent.
+"""
+function Base.close(conn::Conn)
+    try
+        Base.close(conn.fd.pfd)
+    catch err
+        ex = err::Exception
+        ex isa IOPoll.NetClosingError || rethrow(ex)
+    end
+    return nothing
+end
+
+"""
+    isopen(conn::Conn) -> Bool
+
+Return `true` while `conn` still owns an open socket.
+"""
+function Base.isopen(conn::Conn)::Bool
+    return !IOPoll._fdlock_closing(conn.fd.pfd.fdlock)
+end
+
+@inline _show_state(conn::Conn) = IOPoll._fdlock_closing(conn.fd.pfd.fdlock) ? "closed" : "open"
+
+function Base.show(io::IO, conn::Conn)
+    print(io, "UDP.Conn(")
+    _show_endpoint(io, local_addr(conn))
+    if _is_connected(conn)
+        print(io, " => ")
+        _show_endpoint(io, remote_addr(conn))
+    end
+    print(io, ", ", _show_state(conn), ")")
+    return nothing
+end
+
+end

--- a/src/3_udp.jl
+++ b/src/3_udp.jl
@@ -165,18 +165,15 @@ Port `0` binds an ephemeral port; read it back with [`local_addr`](@ref).
 load-balancing of datagrams across sockets bound to the same port on Linux;
 BSD port-sharing semantics on Darwin/BSD) and throws `ArgumentError` on
 Windows, which has no equivalent option. IPv6 sockets are opened dual-stack
-where the platform allows it, matching `TCP`.
+where the platform allows it, matching `TCP`; the string-address entrypoints
+pass `v6only=true` and `net` for `"udp6"` binds.
 """
-function listen(local_addr::SocketAddr; reuseaddr::Bool = false, reuseport::Bool = false)::Conn
-    return _listen_impl(local_addr; reuseaddr = reuseaddr, reuseport = reuseport, v6only = false, net = :udp)
-end
-
-function _listen_impl(
+function listen(
         local_addr::SocketAddr;
-        reuseaddr::Bool,
-        reuseport::Bool,
-        v6only::Bool,
-        net::Symbol,
+        reuseaddr::Bool = false,
+        reuseport::Bool = false,
+        v6only::Bool = false,
+        net::Symbol = :udp,
     )::Conn
     @static if Sys.iswindows()
         reuseport && throw(ArgumentError("reuseport is not supported on Windows"))
@@ -222,20 +219,15 @@ Create a connected UDP socket with `remote_addr` as its fixed peer.
 Connecting a UDP socket is a local operation: no packets are exchanged, the
 kernel simply filters inbound datagrams to the peer and lets ICMP errors from
 prior sends surface on later operations (Go semantics). `local_addr`, when
-given, must share the remote's address family and is bound before connecting.
+given, is bound before connecting; mixed IPv4/IPv6 pairs follow Go's
+`favoriteAddrFamily` rule. The string-address entrypoints pass `v6only=true`
+and `net` for `"udp6"` dials.
 """
 function connect(
         remote_addr::SocketAddr;
         local_addr::Union{Nothing, SocketAddr} = nothing,
-    )::Conn
-    return _connect_impl(remote_addr; local_addr = local_addr, v6only = false, net = :udp)
-end
-
-function _connect_impl(
-        remote_addr::SocketAddr;
-        local_addr::Union{Nothing, SocketAddr},
-        v6only::Bool,
-        net::Symbol,
+        v6only::Bool = false,
+        net::Symbol = :udp,
     )::Conn
     remote_addr = _prepare_dial_remote(remote_addr)
     # Go favoriteAddrFamily parity: the socket is AF_INET only when every

--- a/src/4_host_resolvers.jl
+++ b/src/4_host_resolvers.jl
@@ -23,6 +23,7 @@ using ..Reseau.IOPoll
 
 using ..Reseau.TCP
 import ..Reseau.TCP: connect, listen
+import ..Reseau.UDP
 
 """
     AddressError
@@ -1124,6 +1125,9 @@ end
     n == "tcp" && return :tcp
     n == "tcp4" && return :tcp4
     n == "tcp6" && return :tcp6
+    n == "udp" && return :udp
+    n == "udp4" && return :udp4
+    n == "udp6" && return :udp6
     throw(UnknownNetworkError(n))
 end
 
@@ -1209,24 +1213,24 @@ function _apply_policy_and_network(
         kind::Symbol,
         policy::ResolverPolicy,
     )
-    out = if kind == :tcp4 || (!policy.allow_ipv6 && policy.allow_ipv4)
+    out = if kind == :tcp4 || kind == :udp4 || (!policy.allow_ipv6 && policy.allow_ipv4)
         TCP.SocketAddrV4[]
-    elseif kind == :tcp6 || (!policy.allow_ipv4 && policy.allow_ipv6)
+    elseif kind == :tcp6 || kind == :udp6 || (!policy.allow_ipv4 && policy.allow_ipv6)
         TCP.SocketAddrV6[]
     else
         TCP.SocketEndpoint[]
     end
     for addr in addrs
-        if kind == :tcp4 && !(addr isa TCP.SocketAddrV4)
+        if (kind == :tcp4 || kind == :udp4) && !(addr isa TCP.SocketAddrV4)
             continue
         end
-        if kind == :tcp6 && !(addr isa TCP.SocketAddrV6)
+        if (kind == :tcp6 || kind == :udp6) && !(addr isa TCP.SocketAddrV6)
             continue
         end
         _policy_accepts(policy, addr) || continue
         push!(out, addr)
     end
-    if policy.prefer_ipv6 && kind == :tcp
+    if policy.prefer_ipv6 && (kind == :tcp || kind == :udp)
         sort!(out; by = a -> a isa TCP.SocketAddrV6 ? 0 : 1)
     end
     return out
@@ -1545,7 +1549,7 @@ lookup_port(resolver::CachingResolver, network::AbstractString, service::Abstrac
     lookup_port((resolver::CachingResolver).parent, network, service)
 
 @inline function _wildcard_addrs(kind::Symbol, op::Symbol)::Vector{TCP.SocketEndpoint}
-    if kind == :tcp && op == :listen
+    if (kind == :tcp || kind == :udp) && op == :listen
         @static if Sys.isopenbsd() || Sys.isdragonfly()
             # These kernels do not support IPv4-mapped IPv6 listeners, so a
             # generic wildcard must prefer IPv4 just as Go's capability probe
@@ -2378,7 +2382,9 @@ function connect(
         throw(_wrap_op_error("connect", network, d.local_addr, nothing, DialTimeoutError(String(address))))
     end
     kind = try
-        _network_kind(network)
+        k = _network_kind(network)
+        (k === :tcp || k === :tcp4 || k === :tcp6) || throw(UnknownNetworkError(String(network)))
+        k
     catch err
         throw(_wrap_op_error("connect", network, d.local_addr, nothing, _as_exception(err)))
     end
@@ -2447,7 +2453,9 @@ function listen(
         reuseaddr::Bool = true,
     )::TCP.Listener
     kind = try
-        _network_kind(network)
+        k = _network_kind(network)
+        (k === :tcp || k === :tcp4 || k === :tcp6) || throw(UnknownNetworkError(String(network)))
+        k
     catch err
         throw(_wrap_op_error("listen", network, nothing, nothing, _as_exception(err)))
     end
@@ -2491,4 +2499,126 @@ function listen(
     )::TCP.Listener
     return listen(HostResolver(), network, address; backlog = backlog, reuseaddr = reuseaddr)
 end
+##########################
+# UDP string-address entrypoints
+##########################
+
+@inline function _udp_network_kind(network::AbstractString, op::String)::Symbol
+    kind = try
+        _network_kind(network)
+    catch err
+        throw(_wrap_op_error(op, network, nothing, nothing, _as_exception(err)))
+    end
+    if !(kind === :udp || kind === :udp4 || kind === :udp6)
+        throw(_wrap_op_error(op, network, nothing, nothing, UnknownNetworkError(String(network))))
+    end
+    return kind
+end
+
+"""
+    UDP.connect(network, address; resolver=DEFAULT_RESOLVER, policy=ResolverPolicy(), local_addr=nothing) -> UDP.Conn
+
+Resolve `address` (`"host:port"`, with named services supported) and return a
+connected UDP socket to the first candidate that accepts the local connect.
+
+`network` must be `"udp"`, `"udp4"`, or `"udp6"`; `"udp6"` binds IPv6-only.
+Unlike TCP dialing there is no Happy-Eyeballs race or dial timeout: connecting
+a UDP socket is a local, immediate operation, so only name resolution can
+block. Failures are wrapped in `HostResolvers.OpError`.
+"""
+function UDP.connect(
+        network::AbstractString,
+        address::AbstractString;
+        resolver::AbstractResolver = DEFAULT_RESOLVER,
+        policy::ResolverPolicy = ResolverPolicy(),
+        local_addr::Union{Nothing, TCP.SocketAddr} = nothing,
+    )::UDP.Conn
+    kind = _udp_network_kind(network, "connect")
+    addrs = try
+        resolve_tcp_addrs(resolver, network, address; op = :connect, policy = policy)
+    catch err
+        throw(_wrap_op_error("connect", network, local_addr, nothing, _as_exception(err)))
+    end
+    first_err::Union{Nothing, Exception} = nothing
+    for remote_addr in addrs
+        try
+            return UDP._connect_impl(
+                remote_addr;
+                local_addr = local_addr,
+                v6only = kind === :udp6,
+                net = kind,
+            )
+        catch err
+            first_err === nothing && (first_err = _as_exception(err))
+        end
+    end
+    if first_err === nothing
+        first_err = LookupError("no suitable address", String(address))
+    end
+    first_err isa OpError && throw(first_err)
+    throw(_wrap_op_error("connect", network, local_addr, nothing, first_err))
+end
+
+"""
+    UDP.connect(address; kwargs...) -> UDP.Conn
+
+Shorthand for `UDP.connect("udp", address; kwargs...)`.
+"""
+function UDP.connect(address::AbstractString; kwargs...)::UDP.Conn
+    return UDP.connect("udp", address; kwargs...)
+end
+
+"""
+    UDP.listen(network, address; resolver=DEFAULT_RESOLVER, policy=ResolverPolicy(), reuseaddr=false, reuseport=false) -> UDP.Conn
+
+Resolve `address` and bind an unconnected UDP socket to the first candidate
+that binds successfully. An empty host (`":9000"`) binds the wildcard address.
+
+`network` must be `"udp"`, `"udp4"`, or `"udp6"`; `"udp6"` binds IPv6-only.
+Failures are wrapped in `HostResolvers.OpError`.
+"""
+function UDP.listen(
+        network::AbstractString,
+        address::AbstractString;
+        resolver::AbstractResolver = DEFAULT_RESOLVER,
+        policy::ResolverPolicy = ResolverPolicy(),
+        reuseaddr::Bool = false,
+        reuseport::Bool = false,
+    )::UDP.Conn
+    kind = _udp_network_kind(network, "listen")
+    addrs = try
+        resolve_tcp_addrs(resolver, network, address; op = :listen, policy = policy)
+    catch err
+        throw(_wrap_op_error("listen", network, nothing, nothing, _as_exception(err)))
+    end
+    first_err::Union{Nothing, Exception} = nothing
+    for local_addr in addrs
+        try
+            return UDP._listen_impl(
+                local_addr;
+                reuseaddr = reuseaddr,
+                reuseport = reuseport,
+                v6only = kind === :udp6,
+                net = kind,
+            )
+        catch err
+            first_err === nothing && (first_err = _as_exception(err))
+        end
+    end
+    if first_err === nothing
+        first_err = LookupError("no suitable address", String(address))
+    end
+    first_err isa OpError && throw(first_err)
+    throw(_wrap_op_error("listen", network, nothing, nothing, first_err))
+end
+
+"""
+    UDP.listen(address; kwargs...) -> UDP.Conn
+
+Shorthand for `UDP.listen("udp", address; kwargs...)`.
+"""
+function UDP.listen(address::AbstractString; kwargs...)::UDP.Conn
+    return UDP.listen("udp", address; kwargs...)
+end
+
 end

--- a/src/4_host_resolvers.jl
+++ b/src/4_host_resolvers.jl
@@ -2542,7 +2542,7 @@ function UDP.connect(
     first_err::Union{Nothing, Exception} = nothing
     for remote_addr in addrs
         try
-            return UDP._connect_impl(
+            return UDP.connect(
                 remote_addr;
                 local_addr = local_addr,
                 v6only = kind === :udp6,
@@ -2594,7 +2594,7 @@ function UDP.listen(
     first_err::Union{Nothing, Exception} = nothing
     for local_addr in addrs
         try
-            return UDP._listen_impl(
+            return UDP.listen(
                 local_addr;
                 reuseaddr = reuseaddr,
                 reuseport = reuseport,

--- a/src/6_precompile_workload.jl
+++ b/src/6_precompile_workload.jl
@@ -6,6 +6,7 @@ const IP = IOPoll
 const SO = SocketOps
 const NC = TCP
 const ND = HostResolvers
+const NU = UDP
 const TL = TLS
 
 @inline function _pc_runtime_supported()::Bool
@@ -252,6 +253,36 @@ function _pc_run_socket_ops_workload!()
         SO.is_valid_socket(client) && SO.close_socket_nothrow(client)
         SO.is_valid_socket(listener) && SO.close_socket_nothrow(listener)
         IP.shutdown!()
+    end
+    return nothing
+end
+
+function _pc_run_udp_workload!()
+    _pc_runtime_supported() || return nothing
+    receiver = nothing
+    sender = nothing
+    try
+        receiver = NU.listen(NU.loopback_addr(0))
+        raddr = NU.local_addr(receiver)
+        sender = NU.connect(raddr::NU.SocketAddrV4)
+        payload = UInt8[0x44, 0x45, 0x46]
+        NU.send(sender, payload)
+        buf = Vector{UInt8}(undef, 8)
+        n, from = NU.recvfrom!(receiver, buf)
+        n == length(payload) || throw(ArgumentError("udp workload expected a 3-byte datagram"))
+        from === nothing && throw(ArgumentError("udp workload expected a peer address"))
+        NU.sendto(receiver, payload, from)
+        reply = NU.recv(sender)
+        reply == payload || throw(ArgumentError("udp workload reply mismatch"))
+    finally
+        try
+            sender === nothing || close(sender)
+        catch
+        end
+        try
+            receiver === nothing || close(receiver)
+        catch
+        end
     end
     return nothing
 end
@@ -762,6 +793,7 @@ function _pc_run_selected_workloads!()::Nothing
     _pc_workload_enabled("eventloops") && _pc_run_eventloops_workload!()
     _pc_workload_enabled("internal_poll") && _pc_run_internal_poll_workload!()
     _pc_workload_enabled("socket_ops") && _pc_run_socket_ops_workload!()
+    _pc_workload_enabled("udp") && _pc_run_udp_workload!()
     _pc_workload_enabled("tcp") && _pc_run_tcp_workload!()
     _pc_workload_enabled("host_resolvers") && _pc_run_host_resolvers_workload!()
     _pc_workload_enabled("tls") && _pc_run_tls_workload!()

--- a/src/Reseau.jl
+++ b/src/Reseau.jl
@@ -12,6 +12,7 @@ export TCP, TLS
 include("0_compat.jl")
 include("1_socket_ops.jl")
 include("2_iopoll.jl")
+include("3_netcommon.jl")
 include("3_tcp.jl")
 include("4_host_resolvers.jl")
 include("5_socks.jl")

--- a/src/Reseau.jl
+++ b/src/Reseau.jl
@@ -3,17 +3,18 @@
 
 Root module for Reseau's networking transport stack.
 
-The primary public entrypoints are `TCP` and `TLS`.
+The primary public entrypoints are `TCP`, `UDP`, and `TLS`.
 """
 module Reseau
 
-export TCP, TLS
+export TCP, TLS, UDP
 
 include("0_compat.jl")
 include("1_socket_ops.jl")
 include("2_iopoll.jl")
 include("3_netcommon.jl")
 include("3_tcp.jl")
+include("3_udp.jl")
 include("4_host_resolvers.jl")
 include("5_socks.jl")
 include("5_tls.jl")

--- a/src/iopoll/fd.jl
+++ b/src/iopoll/fd.jl
@@ -953,3 +953,214 @@ function _write_ptr!(fd::FD, p::Ptr{UInt8}, nbytes::Int, root=nothing)::Int
         _fd_write_unlock!(fd)
     end
 end
+
+############
+# Datagram (UDP) I/O
+############
+
+# Max UDP payload is 65,507 bytes, so a 64 KiB scratch always holds a whole
+# datagram. The Windows receive path relies on this to detect truncation by
+# size comparison instead of WSAEMSGSIZE handling.
+const _UDP_MAX_DATAGRAM = 64 * 1024
+
+const _DatagramDest = Union{
+    Nothing,
+    Base.RefValue{SocketOps.SockAddrIn},
+    Base.RefValue{SocketOps.SockAddrIn6},
+}
+
+"""
+    sendto_ptr!(fd, p, nbytes, root, dest, destlen) -> Int
+
+Send one datagram of `nbytes` starting at `p`. `dest === nothing` sends on the
+socket's connected peer; otherwise `dest` is a `Ref` to a platform sockaddr of
+`destlen` bytes. Unlike the stream write path there is no partial-write loop:
+the kernel transmits a datagram whole or not at all, and a zero-byte send is a
+valid empty datagram rather than EOF.
+
+`root`, when supplied, keeps the WSASend/WSASendTo source buffer reachable for
+the overlapped op's full lifetime on Windows; pointer-only callers fall back to
+a private copy.
+"""
+function sendto_ptr!(
+        fd::FD,
+        p::Ptr{UInt8},
+        nbytes::Int,
+        root,
+        dest::_DatagramDest,
+        destlen::Int,
+    )::Int
+    nbytes <= _UDP_MAX_DATAGRAM || throw(ArgumentError("datagram payload exceeds 64 KiB"))
+    _fd_write_lock!(fd)
+    try
+        @static if Sys.iswindows()
+            preparewrite(fd.pd, fd.is_file)
+            registration = _poll_registration(fd.pd)
+            raw_pointer = root === nothing
+            io_root = raw_pointer ? Vector{UInt8}(undef, nbytes) : root
+            io_ptr = p
+            if raw_pointer
+                GC.@preserve io_root unsafe_copyto!(pointer(io_root::Vector{UInt8}), p, nbytes)
+                io_ptr = pointer(io_root::Vector{UInt8})
+            end
+            bytes = UInt32(0)
+            result = Int32(0)
+            GC.@preserve io_root begin
+                if dest === nothing
+                    while true
+                        errno = _iocp_submit_write!(registration, io_ptr, UInt32(nbytes), io_root)
+                        errno == Int32(0) && break
+                        if errno == Int32(Base.Libc.EALREADY)
+                            waitwrite(fd.pd, fd.is_file)
+                            continue
+                        end
+                        throw(SystemError("send", Int(errno)))
+                    end
+                else
+                    addrbytes = Vector{UInt8}(undef, destlen)
+                    GC.@preserve dest unsafe_copyto!(
+                        pointer(addrbytes),
+                        Ptr{UInt8}(Base.unsafe_convert(Ptr{Cvoid}, dest)),
+                        destlen,
+                    )
+                    request = IocpSendToRequest(addrbytes)
+                    while true
+                        errno = _iocp_submit_sendto!(registration, io_ptr, UInt32(nbytes), io_root, request)
+                        errno == Int32(0) && break
+                        if errno == Int32(Base.Libc.EALREADY)
+                            waitwrite(fd.pd, fd.is_file)
+                            continue
+                        end
+                        throw(SystemError("sendto", Int(errno)))
+                    end
+                end
+                try
+                    _wait_iocp_completion!(registration, fd.pd, PollMode.WRITE, fd.is_file)
+                catch err
+                    _drain_canceled_iocp_op!(registration, PollMode.WRITE)
+                    rethrow(err)
+                end
+                bytes, result = _iocp_finish_write!(registration)
+            end
+            result == Int32(0) || throw(SystemError(dest === nothing ? "send" : "sendto", Int(result)))
+            return Int(bytes)
+        end
+        preparewrite(fd.pd, fd.is_file)
+        while true
+            n = if dest === nothing
+                SocketOps.send_to!(fd.sysfd, p, Csize_t(nbytes))
+            else
+                GC.@preserve dest SocketOps.send_to!(
+                    fd.sysfd,
+                    p,
+                    Csize_t(nbytes),
+                    Cint(0),
+                    Base.unsafe_convert(Ptr{Cvoid}, dest),
+                    SocketOps.SockLen(destlen),
+                )
+            end
+            n >= 0 && return Int(n)
+            errno = SocketOps.last_error()
+            if errno == Int32(Base.Libc.EAGAIN) && pollable(fd.pd)
+                waitwrite(fd.pd, fd.is_file)
+                continue
+            end
+            throw(SystemError(dest === nothing ? "send" : "sendto", Int(errno)))
+        end
+    finally
+        _fd_write_unlock!(fd)
+    end
+end
+
+"""
+    recvfrom_ptr!(fd, p, nbytes, root) -> (nread, peer, truncated)
+
+Receive one datagram into `p`, returning the number of bytes delivered to the
+caller, the peer address (`nothing` when the kernel reports none), and whether
+the datagram was longer than `nbytes` and therefore truncated. A zero-byte
+return is a valid empty datagram, never EOF.
+
+On POSIX platforms this is a `recvmsg` loop so truncation can be read from
+`MSG_TRUNC`; on Windows the datagram lands in a whole-datagram scratch first
+and truncation is detected by size comparison. `root`, when supplied, keeps
+the destination reachable while a blocking wait is parked.
+"""
+function recvfrom_ptr!(
+        fd::FD,
+        p::Ptr{UInt8},
+        nbytes::Int,
+        root,
+    )::Tuple{Int, SocketOps.AcceptPeer, Bool}
+    _fd_read_lock!(fd)
+    try
+        @static if Sys.iswindows()
+            prepareread(fd.pd, fd.is_file, false)
+            registration = _poll_registration(fd.pd)
+            bounce = Vector{UInt8}(undef, _UDP_MAX_DATAGRAM)
+            request = IocpRecvFromRequest(Vector{UInt8}(undef, 128), Ref(Cint(128)))
+            bytes = UInt32(0)
+            result = Int32(0)
+            GC.@preserve bounce begin
+                while true
+                    errno = _iocp_submit_recvfrom!(
+                        registration,
+                        pointer(bounce),
+                        UInt32(length(bounce)),
+                        bounce,
+                        request,
+                    )
+                    errno == Int32(0) && break
+                    if errno == Int32(Base.Libc.EALREADY)
+                        waitread(fd.pd, fd.is_file)
+                        continue
+                    end
+                    throw(SystemError("recvfrom", Int(errno)))
+                end
+                try
+                    _wait_iocp_completion!(registration, fd.pd, PollMode.READ, fd.is_file)
+                catch err
+                    _drain_canceled_iocp_op!(registration, PollMode.READ)
+                    rethrow(err)
+                end
+                bytes, result = _iocp_finish_read!(registration)
+            end
+            result == Int32(0) || throw(SystemError("recvfrom", Int(result)))
+            n = Int(bytes)
+            ncopy = min(n, nbytes)
+            if ncopy > 0
+                GC.@preserve bounce unsafe_copyto!(p, pointer(bounce), ncopy)
+            end
+            addrbuf = request.addrbuf
+            peer = GC.@preserve addrbuf SocketOps.decode_sockaddr(
+                pointer(addrbuf),
+                Int(request.addrlen[]),
+            )
+            return ncopy, peer, n > nbytes
+        end
+        prepareread(fd.pd, fd.is_file, false)
+        namebuf = Ref{NTuple{128, UInt8}}()
+        iov = Ref(SocketOps.IOVec(Ptr{Cvoid}(p), Csize_t(nbytes)))
+        GC.@preserve namebuf iov root begin
+            name_ptr = Base.unsafe_convert(Ptr{Cvoid}, namebuf)
+            iov_ptr = Base.unsafe_convert(Ptr{SocketOps.IOVec}, iov)
+            while true
+                msg = Ref(SocketOps.MsgHdr(name_ptr, SocketOps.SockLen(128), iov_ptr, 1, C_NULL, 0, Cint(0)))
+                n = SocketOps.recv_msg!(fd.sysfd, msg)
+                if n >= 0
+                    hdr = msg[]
+                    peer = SocketOps.decode_sockaddr(Ptr{UInt8}(name_ptr), Int(hdr.msg_namelen))
+                    truncated = (hdr.msg_flags & SocketOps.MSG_TRUNC) != Cint(0)
+                    return Int(n), peer, truncated
+                end
+                errno = SocketOps.last_error()
+                if errno == Int32(Base.Libc.EAGAIN) && pollable(fd.pd)
+                    waitread(fd.pd, fd.is_file)
+                    continue
+                end
+                throw(SystemError("recvmsg", Int(errno)))
+            end
+        end
+    finally
+        _fd_read_unlock!(fd)
+    end
+end

--- a/src/iopoll/iocp.jl
+++ b/src/iopoll/iocp.jl
@@ -107,7 +107,25 @@ mutable struct IocpAcceptRequest
     addrbuf::Vector{UInt8}
 end
 
-const IocpRequest = Union{Nothing, IocpConnectRequest, IocpAcceptRequest}
+# WSARecvFrom writes the peer sockaddr and its length at completion time, so
+# both out-buffers must stay reachable for the op's whole lifetime; rooting
+# them here mirrors how CONNECT/ACCEPT root their address buffers.
+mutable struct IocpRecvFromRequest
+    addrbuf::Vector{UInt8}
+    addrlen::Base.RefValue{Cint}
+end
+
+mutable struct IocpSendToRequest
+    addrbuf::Vector{UInt8}
+end
+
+const IocpRequest = Union{
+    Nothing,
+    IocpConnectRequest,
+    IocpAcceptRequest,
+    IocpRecvFromRequest,
+    IocpSendToRequest,
+}
 
 mutable struct IocpOp
     storage::Base.RefValue{Overlapped}
@@ -365,7 +383,8 @@ function _submit_iocp_op!(
     )::Int32
     _, ok = @atomicreplace(op.active, false => true)
     ok || return Int32(Base.Libc.EALREADY)
-    if (kind == IocpOpKind.READ || kind == IocpOpKind.WRITE) && buffer === nothing
+    if (kind == IocpOpKind.READ || kind == IocpOpKind.WRITE ||
+            kind == IocpOpKind.RECVFROM || kind == IocpOpKind.SENDTO) && buffer === nothing
         # An existing operation must win with EALREADY before validating the
         # next request. The read/write wrappers clear a newly failed
         # submission, so returning EINVAL for an already-active op would reset
@@ -434,6 +453,47 @@ function _submit_iocp_op!(
                 UInt32(1)::UInt32,
                 bytes::Ref{UInt32},
                 UInt32(0)::UInt32,
+                _op_ptr(op)::Ptr{Cvoid},
+                C_NULL::Ptr{Cvoid},
+            )::Cint
+        end
+    elseif op.kind == IocpOpKind.RECVFROM
+        request = op.request
+        request isa IocpRecvFromRequest || throw(ArgumentError("missing RecvFrom request"))
+        wsabuf = Ref(WSABUF(nbytes, ptr))
+        bytes = Ref{UInt32}(UInt32(0))
+        flags = Ref{UInt32}(UInt32(0))
+        addrbuf = request.addrbuf
+        addrlen = request.addrlen
+        addrlen[] = Cint(length(addrbuf))
+        rc = GC.@preserve op wsabuf bytes flags addrbuf addrlen begin
+            @gcsafe_ccall _WS2_32.WSARecvFrom(
+                _socket_value(reg.fd)::UInt,
+                wsabuf::Ref{WSABUF},
+                UInt32(1)::UInt32,
+                bytes::Ref{UInt32},
+                flags::Ref{UInt32},
+                pointer(addrbuf)::Ptr{UInt8},
+                Base.unsafe_convert(Ptr{Cint}, addrlen)::Ptr{Cint},
+                _op_ptr(op)::Ptr{Cvoid},
+                C_NULL::Ptr{Cvoid},
+            )::Cint
+        end
+    elseif op.kind == IocpOpKind.SENDTO
+        request = op.request
+        request isa IocpSendToRequest || throw(ArgumentError("missing SendTo request"))
+        wsabuf = Ref(WSABUF(nbytes, ptr))
+        bytes = Ref{UInt32}(UInt32(0))
+        addrbuf = request.addrbuf
+        rc = GC.@preserve op wsabuf bytes addrbuf begin
+            @gcsafe_ccall _WS2_32.WSASendTo(
+                _socket_value(reg.fd)::UInt,
+                wsabuf::Ref{WSABUF},
+                UInt32(1)::UInt32,
+                bytes::Ref{UInt32},
+                UInt32(0)::UInt32,
+                pointer(addrbuf)::Ptr{UInt8},
+                Cint(length(addrbuf))::Cint,
                 _op_ptr(op)::Ptr{Cvoid},
                 C_NULL::Ptr{Cvoid},
             )::Cint
@@ -664,6 +724,58 @@ end
 
 function _iocp_finish_write!(registration::Registration)::Tuple{UInt32, Int32}
     return _finish_iocp_mode_with_bytes!(registration, PollMode.WRITE)
+end
+
+function _iocp_submit_recvfrom!(
+        registration::Registration,
+        ptr::Ptr{UInt8},
+        nbytes::UInt32,
+        root,
+        request::IocpRecvFromRequest,
+    )::Int32
+    isassigned(POLLER) || return Int32(Base.Libc.ENOSYS)
+    state = POLLER[]
+    (@atomic :acquire state.running) || return Int32(Base.Libc.EBADF)
+    errno = Int32(0)
+    lock(state.lock)
+    try
+        reg = _lookup_iocp_registration(state, registration)
+        reg === nothing && return Int32(Base.Libc.EBADF)
+        op = reg.read_op
+        errno = _submit_iocp_op!(registration, reg, op; ptr, nbytes, kind=IocpOpKind.RECVFROM, request=request, buffer=root)
+        if errno != Int32(0) && errno != Int32(Base.Libc.EALREADY)
+            _clear_iocp_op!(op)
+        end
+    finally
+        unlock(state.lock)
+    end
+    return errno
+end
+
+function _iocp_submit_sendto!(
+        registration::Registration,
+        ptr::Ptr{UInt8},
+        nbytes::UInt32,
+        root,
+        request::IocpSendToRequest,
+    )::Int32
+    isassigned(POLLER) || return Int32(Base.Libc.ENOSYS)
+    state = POLLER[]
+    (@atomic :acquire state.running) || return Int32(Base.Libc.EBADF)
+    errno = Int32(0)
+    lock(state.lock)
+    try
+        reg = _lookup_iocp_registration(state, registration)
+        reg === nothing && return Int32(Base.Libc.EBADF)
+        op = reg.write_op
+        errno = _submit_iocp_op!(registration, reg, op; ptr, nbytes, kind=IocpOpKind.SENDTO, request=request, buffer=root)
+        if errno != Int32(0) && errno != Int32(Base.Libc.EALREADY)
+            _clear_iocp_op!(op)
+        end
+    finally
+        unlock(state.lock)
+    end
+    return errno
 end
 
 function _iocp_submit_connect!(registration::Registration, addrbuf::Vector{UInt8}, addrlen::Int32)::Int32

--- a/src/iopoll/iocp.jl
+++ b/src/iopoll/iocp.jl
@@ -560,7 +560,10 @@ function _submit_iocp_op!(
         _notify_registration!(registration, op.mode)
         return Int32(0)
     end
-    if op.kind == IocpOpKind.READ || op.kind == IocpOpKind.WRITE
+    if op.kind == IocpOpKind.READ || op.kind == IocpOpKind.WRITE ||
+            op.kind == IocpOpKind.RECVFROM || op.kind == IocpOpKind.SENDTO
+        # WSARecv/WSASend/WSARecvFrom/WSASendTo return 0 on synchronous
+        # success, unlike the ConnectEx/AcceptEx BOOL convention handled below.
         if rc == 0
             reg.wait_on_success && return Int32(0)
             @atomic :release op.active = false

--- a/src/iopoll/types.jl
+++ b/src/iopoll/types.jl
@@ -39,6 +39,8 @@ Base.@enum T::UInt8 begin
     ACCEPT = 0x04
     READ = 0x05
     WRITE = 0x06
+    RECVFROM = 0x07
+    SENDTO = 0x08
 end
 end
 

--- a/src/socket_ops/windows.jl
+++ b/src/socket_ops/windows.jl
@@ -309,6 +309,36 @@ function _load_extension_ptr!(sock::SocketFD, guid::Guid)::Ptr{Cvoid}
     return out_ref[]
 end
 
+const _SIO_UDP_CONNRESET = UInt32(0x9800000C)
+
+"""
+    set_udp_connreset!(sock, enabled)
+
+Toggle delivery of `WSAECONNRESET` on a UDP socket. Windows reports ICMP
+port-unreachable from *any* prior send as a reset on subsequent receives;
+unconnected sockets disable this so one dead peer cannot poison a shared
+socket, while connected sockets keep it so refused sends surface as errors.
+"""
+function set_udp_connreset!(sock::SocketFD, enabled::Bool)::Nothing
+    in_ref = Ref{UInt32}(enabled ? UInt32(1) : UInt32(0))
+    bytes_ref = Ref{UInt32}(UInt32(0))
+    rc = GC.@preserve in_ref bytes_ref begin
+        @gcsafe_ccall _WS2_32.WSAIoctl(
+            _socket_value(sock)::UInt,
+            _SIO_UDP_CONNRESET::UInt32,
+            in_ref::Ref{UInt32},
+            UInt32(sizeof(UInt32))::UInt32,
+            C_NULL::Ptr{Cvoid},
+            UInt32(0)::UInt32,
+            bytes_ref::Ref{UInt32},
+            C_NULL::Ptr{Cvoid},
+            C_NULL::Ptr{Cvoid},
+        )::Cint
+    end
+    rc == 0 || _throw_errno("WSAIoctl(SIO_UDP_CONNRESET)", _map_wsa_errno(_wsa_get_last_error()))
+    return nothing
+end
+
 function _load_sendrecvmsg_ptrs!()::Tuple{Ptr{Cvoid}, Ptr{Cvoid}}
     send_ptr = _wsasendmsg_ptr[]
     recv_ptr = _wsarecvmsg_ptr[]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ _log_test_progress("[runtests] loaded Reseau")
 _log_test_progress("[runtests] julia threads: $(Threads.nthreads())")
 
 @test TCP === Reseau.TCP
+@test UDP === Reseau.UDP
 @test TLS === Reseau.TLS
 
 function _include_with_progress(path::AbstractString)
@@ -27,6 +28,7 @@ test_files = [
     "internal_poll_tests.jl",
     "socket_ops_tests.jl",
     "tcp_tests.jl",
+    "udp_tests.jl",
     "host_resolvers_tests.jl",
     "socks_tests.jl",
     "tls_crypto_tests.jl",

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -147,6 +147,7 @@ end
             ("iopoll_runtime_trim_safe.jl", "iopoll_runtime_trim_safe"),
             ("socket_ops_trim_safe.jl", "socket_ops_trim_safe"),
             ("tcp_trim_safe.jl", "tcp_trim_safe"),
+            ("udp_trim_safe.jl", "udp_trim_safe"),
             ("socks_trim_safe.jl", "socks_trim_safe"),
             ("host_resolvers_trim_safe.jl", "host_resolvers_trim_safe"),
             ("host_resolvers_system_trim_safe.jl", "host_resolvers_system_trim_safe"),

--- a/test/udp_tests.jl
+++ b/test/udp_tests.jl
@@ -217,13 +217,33 @@ end
 
     @testset "socket options" begin
         a = UDP.listen(UDP.loopback_addr(0))
-        UDP.set_broadcast!(a, true)
+        # Broadcast defaults on (Go setDefaultSockopts parity).
         @test Reseau.SocketOps.get_sockopt_int(
             a.fd.pfd.sysfd,
             Reseau.SocketOps.SOL_SOCKET,
             Reseau.SocketOps.SO_BROADCAST,
         ) != 0
         UDP.set_broadcast!(a, false)
+        @test Reseau.SocketOps.get_sockopt_int(
+            a.fd.pfd.sysfd,
+            Reseau.SocketOps.SOL_SOCKET,
+            Reseau.SocketOps.SO_BROADCAST,
+        ) == 0
+        UDP.set_broadcast!(a, true)
+        UDP.set_read_buffer!(a, 64 * 1024)
+        @test Reseau.SocketOps.get_sockopt_int(
+            a.fd.pfd.sysfd,
+            Reseau.SocketOps.SOL_SOCKET,
+            Reseau.SocketOps.SO_RCVBUF,
+        ) >= 64 * 1024
+        UDP.set_write_buffer!(a, 64 * 1024)
+        @test Reseau.SocketOps.get_sockopt_int(
+            a.fd.pfd.sysfd,
+            Reseau.SocketOps.SOL_SOCKET,
+            Reseau.SocketOps.SO_SNDBUF,
+        ) >= 64 * 1024
+        @test_throws ArgumentError UDP.set_read_buffer!(a, 0)
+        @test_throws ArgumentError UDP.set_write_buffer!(a, 0)
         UDP.set_ttl!(a, 3)
         @test Reseau.SocketOps.get_sockopt_int(
             a.fd.pfd.sysfd,
@@ -240,6 +260,46 @@ end
         ) == 5
         close(a)
         close(v6)
+    end
+
+    @testset "dual-stack address coercion" begin
+        four = UDP.listen(UDP.loopback_addr(0))
+        four_addr = UDP.local_addr(four)
+
+        # An IPv4 destination on an AF_INET6 socket becomes IPv4-mapped.
+        six = UDP.listen(UDP.any_addr6(0))
+        UDP.sendto(six, "mapped", four_addr)
+        data, _ = UDP.recvfrom(four)
+        @test String(data) == "mapped"
+
+        # An IPv4-mapped IPv6 destination on an AF_INET socket collapses.
+        mapped = UDP.SocketAddrV6(
+            (0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+             0x00, 0x00, 0xff, 0xff, 0x7f, 0x00, 0x00, 0x01),
+            Int(four_addr.port),
+        )
+        sender4 = UDP.listen(UDP.loopback_addr(0))
+        UDP.sendto(sender4, "collapsed", mapped)
+        data, _ = UDP.recvfrom(four)
+        @test String(data) == "collapsed"
+
+        # connect with a v6 local and a v4 remote opens an AF_INET6 socket
+        # and carries the remote as IPv4-mapped (Go favoriteAddrFamily).
+        mixed = UDP.connect(four_addr; local_addr = UDP.any_addr6(0))
+        @test UDP.remote_addr(mixed) isa UDP.SocketAddrV6
+        UDP.send(mixed, "mixed families")
+        data, _ = UDP.recvfrom(four)
+        @test String(data) == "mixed families"
+
+        # A wildcard dial destination means the local system (Go
+        # internetSocket parity; rewritten to loopback where kernels
+        # reject it).
+        wild = UDP.connect(UDP.any_addr(Int(four_addr.port)))
+        UDP.send(wild, "wildcard dial")
+        data, _ = UDP.recvfrom(four)
+        @test String(data) == "wildcard dial"
+
+        foreach(close, (four, six, sender4, mixed, wild))
     end
 
     @testset "string-address entrypoints" begin

--- a/test/udp_tests.jl
+++ b/test/udp_tests.jl
@@ -1,0 +1,280 @@
+# UDP transport tests.
+#
+# Determinism rules (test/README.md): no clocks, no sleeps, no timing
+# assertions. Datagram tests keep counts small and always park the receiver
+# logic after the sends are already queued in the loopback socket buffer, or
+# rely on blocking recv calls that complete exactly when the datagram arrives.
+
+function _udp_pair()
+    a = UDP.listen(UDP.loopback_addr(0))
+    b = UDP.connect(UDP.local_addr(a))
+    return a, b
+end
+
+@testset "UDP" begin
+    @testset "listen binds an ephemeral port" begin
+        a = UDP.listen(UDP.loopback_addr(0))
+        addr = UDP.local_addr(a)
+        @test addr isa UDP.SocketAddrV4
+        @test addr.port != 0
+        @test UDP.remote_addr(a) === nothing
+        @test isopen(a)
+        @test occursin("UDP.Conn(", repr(a))
+        @test occursin("open", repr(a))
+        close(a)
+        @test !isopen(a)
+        @test occursin("closed", repr(a))
+        close(a)
+    end
+
+    @testset "connected round trip" begin
+        a, b = _udp_pair()
+        @test UDP.remote_addr(b) == UDP.local_addr(a)
+        UDP.send(b, "hello")
+        buf = zeros(UInt8, 16)
+        n, from = UDP.recvfrom!(a, buf)
+        @test n == 5
+        @test buf[1:5] == b"hello"
+        @test from == UDP.local_addr(b)
+        UDP.sendto(a, "world!", from)
+        @test String(UDP.recv(b)) == "world!"
+        close(a)
+        close(b)
+    end
+
+    @testset "unconnected sendto/recvfrom both directions" begin
+        a = UDP.listen(UDP.loopback_addr(0))
+        b = UDP.listen(UDP.loopback_addr(0))
+        UDP.sendto(a, b"ping", UDP.local_addr(b))
+        data, from = UDP.recvfrom(b)
+        @test data == b"ping"
+        @test from == UDP.local_addr(a)
+        UDP.sendto(b, b"pong", from)
+        data2, from2 = UDP.recvfrom(a)
+        @test data2 == b"pong"
+        @test from2 == UDP.local_addr(b)
+        close(a)
+        close(b)
+    end
+
+    @testset "connected/unconnected guards" begin
+        a, b = _udp_pair()
+        @test_throws ArgumentError UDP.sendto(b, "x", UDP.local_addr(a))
+        @test_throws ArgumentError UDP.send(a, "x")
+        @test_throws ArgumentError UDP.sendto(a, "x", UDP.loopback_addr6(1))
+        close(a)
+        close(b)
+    end
+
+    @testset "empty datagram is data, not EOF" begin
+        a, b = _udp_pair()
+        UDP.send(b, UInt8[])
+        buf = zeros(UInt8, 4)
+        n, from = UDP.recvfrom!(a, buf)
+        @test n == 0
+        @test from == UDP.local_addr(b)
+        UDP.send(b, "after")
+        @test String(UDP.recv(a)) == "after"
+        close(a)
+        close(b)
+    end
+
+    @testset "payload types and buffer views" begin
+        a, b = _udp_pair()
+        UDP.send(b, "str")
+        UDP.send(b, codeunits("cu?"))
+        UDP.send(b, view(collect(b"viewpay"), 1:4))
+        backing = zeros(UInt8, 12)
+        n = UDP.recv!(a, view(backing, 5:8))
+        @test n == 3
+        @test backing[5:7] == b"str"
+        @test String(UDP.recv(a)) == "cu?"
+        @test UDP.recv(a) == b"view"
+        close(a)
+        close(b)
+    end
+
+    @testset "truncation policy" begin
+        a, b = _udp_pair()
+        UDP.send(b, "0123456789")
+        buf = zeros(UInt8, 4)
+        err = try
+            UDP.recv!(a, buf)
+            nothing
+        catch e
+            e
+        end
+        @test err isa UDP.TruncatedDatagramError
+        @test err.nread == 4
+        @test occursin("allow_truncate", sprint(showerror, err))
+        # The truncated prefix was delivered and the rest of the datagram
+        # dropped; the socket stays usable (a Sockets stdlib invariant worth
+        # keeping).
+        UDP.send(b, "0123456789")
+        @test UDP.recv!(a, buf; allow_truncate = true) == 4
+        @test buf == b"0123"
+        UDP.send(b, "ok")
+        @test String(UDP.recv(a)) == "ok"
+        # Allocating forms honor maxsize the same way.
+        UDP.send(b, "0123456789")
+        @test_throws UDP.TruncatedDatagramError UDP.recv(a; maxsize = 4)
+        UDP.send(b, "fits")
+        @test String(UDP.recv(a; maxsize = 4)) == "fits"
+        close(a)
+        close(b)
+    end
+
+    @testset "datagram boundaries and FIFO order" begin
+        a, b = _udp_pair()
+        for i in 1:8
+            UDP.send(b, "msg-$(i)")
+        end
+        for i in 1:8
+            @test String(UDP.recv(a)) == "msg-$(i)"
+        end
+        close(a)
+        close(b)
+    end
+
+    @testset "oversized send surfaces EMSGSIZE and keeps the socket" begin
+        a, b = _udp_pair()
+        # 64 KiB exceeds the UDP maximum payload everywhere.
+        err = try
+            UDP.send(b, zeros(UInt8, 64 * 1024))
+            nothing
+        catch e
+            e
+        end
+        @test err isa Union{ArgumentError, SystemError}
+        UDP.send(b, "still works")
+        @test String(UDP.recv(a)) == "still works"
+        close(a)
+        close(b)
+    end
+
+    @testset "read deadline" begin
+        a, b = _udp_pair()
+        UDP.set_read_deadline!(a, Int64(1))
+        @test_throws UDP.DeadlineExceededError UDP.recv!(a, zeros(UInt8, 4))
+        UDP.set_read_deadline!(a, 0)
+        UDP.send(b, "post-clear")
+        @test String(UDP.recv(a)) == "post-clear"
+        close(a)
+        close(b)
+    end
+
+    @testset "write deadline" begin
+        a, b = _udp_pair()
+        UDP.set_write_deadline!(b, Int64(1))
+        @test_throws UDP.DeadlineExceededError UDP.send(b, "never")
+        UDP.set_write_deadline!(b, 0)
+        UDP.send(b, "sent")
+        @test String(UDP.recv(a)) == "sent"
+        UDP.set_deadline!(b, Int64(1))
+        @test_throws UDP.DeadlineExceededError UDP.send(b, "never")
+        close(a)
+        close(b)
+    end
+
+    @testset "close wakes and rejects operations" begin
+        a, b = _udp_pair()
+        close(a)
+        @test_throws Reseau.IOPoll.NetClosingError UDP.recv!(a, zeros(UInt8, 4))
+        close(b)
+        @test_throws Reseau.IOPoll.NetClosingError UDP.send(b, "x")
+        close(a)
+        close(b)
+    end
+
+    @testset "ipv6 loopback round trip" begin
+        a = UDP.listen(UDP.loopback_addr6(0))
+        addr = UDP.local_addr(a)
+        @test addr isa UDP.SocketAddrV6
+        b = UDP.connect(addr)
+        UDP.send(b, "v6 datagram")
+        data, from = UDP.recvfrom(a)
+        @test String(data) == "v6 datagram"
+        @test from == UDP.local_addr(b)
+        close(a)
+        close(b)
+    end
+
+    @testset "reuseaddr and reuseport" begin
+        a = UDP.listen(UDP.loopback_addr(0); reuseaddr = true)
+        @test isopen(a)
+        close(a)
+        @static if Sys.iswindows()
+            @test_throws ArgumentError UDP.listen(UDP.loopback_addr(0); reuseport = true)
+        else
+            l1 = UDP.listen(UDP.loopback_addr(0); reuseport = true)
+            port = Int(UDP.local_addr(l1).port)
+            l2 = UDP.listen(UDP.loopback_addr(port); reuseport = true)
+            @test Int(UDP.local_addr(l2).port) == port
+            close(l1)
+            close(l2)
+        end
+    end
+
+    @testset "socket options" begin
+        a = UDP.listen(UDP.loopback_addr(0))
+        UDP.set_broadcast!(a, true)
+        @test Reseau.SocketOps.get_sockopt_int(
+            a.fd.pfd.sysfd,
+            Reseau.SocketOps.SOL_SOCKET,
+            Reseau.SocketOps.SO_BROADCAST,
+        ) != 0
+        UDP.set_broadcast!(a, false)
+        UDP.set_ttl!(a, 3)
+        @test Reseau.SocketOps.get_sockopt_int(
+            a.fd.pfd.sysfd,
+            Reseau.SocketOps.IPPROTO_IP,
+            Reseau.SocketOps.IP_TTL,
+        ) == 3
+        @test_throws ArgumentError UDP.set_ttl!(a, 300)
+        v6 = UDP.listen(UDP.loopback_addr6(0))
+        UDP.set_ttl!(v6, 5)
+        @test Reseau.SocketOps.get_sockopt_int(
+            v6.fd.pfd.sysfd,
+            Reseau.SocketOps.IPPROTO_IPV6,
+            Reseau.SocketOps.IPV6_UNICAST_HOPS,
+        ) == 5
+        close(a)
+        close(v6)
+    end
+
+    @testset "string-address entrypoints" begin
+        a = UDP.listen("udp4", "127.0.0.1:0")
+        @test UDP.local_addr(a) isa UDP.SocketAddrV4
+        b = UDP.connect("127.0.0.1:$(Int(UDP.local_addr(a).port))")
+        UDP.send(b, "resolved")
+        @test String(UDP.recv(a)) == "resolved"
+        close(a)
+        close(b)
+
+        wild = UDP.listen(":0")
+        @test UDP.local_addr(wild) !== nothing
+        close(wild)
+
+        v6 = UDP.listen("udp6", "[::1]:0")
+        @test UDP.local_addr(v6) isa UDP.SocketAddrV6
+        close(v6)
+
+        err = try
+            UDP.connect("nope", "127.0.0.1:1")
+            nothing
+        catch e
+            e
+        end
+        @test err isa Reseau.HostResolvers.OpError
+        @test err.err isa Reseau.HostResolvers.UnknownNetworkError
+
+        err = try
+            TCP.connect("udp", "127.0.0.1:1")
+            nothing
+        catch e
+            e
+        end
+        @test err isa Reseau.HostResolvers.OpError
+        @test err.err isa Reseau.HostResolvers.UnknownNetworkError
+    end
+end

--- a/test/udp_trim_safe.jl
+++ b/test/udp_trim_safe.jl
@@ -1,0 +1,46 @@
+using Reseau
+
+const NU = Reseau.UDP
+
+function _close_quiet!(x)
+    x === nothing && return nothing
+    try
+        close(x)
+    catch
+    end
+    return nothing
+end
+
+function run_udp_trim_sample()::Nothing
+    receiver::Union{Nothing, NU.Conn} = nothing
+    sender::Union{Nothing, NU.Conn} = nothing
+    try
+        receiver = NU.listen(NU.loopback_addr(0))
+        raddr = NU.local_addr(receiver)::NU.SocketAddrV4
+        raddr.port == 0 && error("expected an ephemeral UDP port")
+        sender = NU.connect(raddr)
+        NU.remote_addr(sender)::NU.SocketAddrV4 == raddr || error("sender remote mismatch")
+        payload = UInt8[0x61, 0x62, 0x63]
+        NU.send(sender, payload)
+        buf = Vector{UInt8}(undef, 8)
+        n, from = NU.recvfrom!(receiver, buf)
+        n == length(payload) || error("expected a 3-byte datagram")
+        buf[1:n] == payload || error("UDP payload mismatch")
+        from::NU.SocketAddrV4 == NU.local_addr(sender)::NU.SocketAddrV4 || error("peer mismatch")
+        NU.sendto(receiver, payload, from)
+        reply = NU.recv(sender)
+        reply == payload || error("UDP reply mismatch")
+    finally
+        _close_quiet!(sender)
+        _close_quiet!(receiver)
+    end
+    return nothing
+end
+
+function @main(args::Vector{String})::Cint
+    _ = args
+    run_udp_trim_sample()
+    return 0
+end
+
+Base.Experimental.entrypoint(main, (Vector{String},))


### PR DESCRIPTION
## What

Native UDP support as a third public surface (`export TCP, TLS, UDP`), ported from Go's `net.UDPConn` per the design in the Sockets-replacement audit. Three commits:

**1. `refactor(net)`: NetCommon extraction.** The socket-address types, sockaddr conversions, and the internal `FD` (netFD) owner move out of `TCP` into a shared `NetCommon` module — Go's structure, where one `netFD` backs every socket type. `TCP` re-exposes every public name unchanged (`TCP.SocketAddrV4 === NetCommon.SocketAddrV4`); `_new_netfd` now derives `is_stream`/`zero_read_is_eof` from the socket type, finally exercising the datagram FD mode that has been dormant in `IOPoll` since the rewrite. Pure move; TCP tests pass unchanged (347/347).

**2. `feat(udp)`: core module + datagram I/O paths.**
- One `UDP.Conn` for both modes: `listen` (unconnected: `sendto`/`recvfrom[!]`) and `connect` (connected: `send`/`recv[!]`; ICMP errors surface on later ops). Go's guards: `sendto` on a connected socket and `send` on an unconnected one are `ArgumentError`s; `recv` works on both.
- **Datagram semantics are explicit**: sends are whole-or-nothing (no partial-write loop), a zero-byte datagram is valid data (never EOF), and `Conn` is deliberately **not** an `IO` — stream fallbacks like `readline` would corrupt message boundaries.
- **Uniform truncation policy** (improves on both Go and Sockets): `allow_truncate=false` (default) throws `TruncatedDatagramError` with the socket left usable; `allow_truncate=true` gives Go/POSIX silent-prefix semantics. Detection is `recvmsg`+`MSG_TRUNC` on POSIX and whole-datagram-scratch comparison on Windows — no platform divergence.
- **IOPoll** grows `sendto_ptr!`/`recvfrom_ptr!`: POSIX is the canonical nonblocking-syscall + readiness-wait loop; Windows adds true overlapped `WSARecvFrom`/`WSASendTo` op kinds with completion-lifetime sockaddr rooting (mirroring the ConnectEx/AcceptEx request pattern), while connected-mode send/recv reuse the existing READ/WRITE ops. Unconnected sockets set `SIO_UDP_CONNRESET` off so one dead peer can't poison them with spurious `WSAECONNRESET` (the classic Windows UDP landmine; libuv does the same).
- Deadlines are the same sticky per-socket model as TCP (`UDP.DeadlineExceededError`), plus `set_broadcast!`/`set_ttl!` (IPv4 TTL / IPv6 unicast hops).

**3. `feat(udp)`: resolver, tests, docs, validation.** `_network_kind` accepts `udp/udp4/udp6` (family policy and wildcard handling treat them like their tcp counterparts; the TCP string entrypoints now reject non-tcp networks explicitly, preserving the existing `OpError{UnknownNetworkError}` behavior). `UDP.connect`/`UDP.listen` string forms run through the full resolver stack (policies, caching, named services; `"udp6"` binds v6-only) — no Happy Eyeballs and no dial timeout, since UDP connect is local and immediate. Plus: docs page + reference + migrate-sockets section, `udp_trim_safe.jl` in the trim matrix, and a `_pc_run_udp_workload!` precompile workload.

## Tests

69 new deterministic assertions (`udp_tests.jl`, under the strict no-clock rules): both socket modes and both directions, guards, empty datagrams, payload/view types, truncation both ways plus post-truncation usability, FIFO datagram boundaries, `EMSGSIZE` recovery, read *and* write deadlines via sentinel expiry, close-rejects-ops, IPv6 loopback, `reuseaddr`/`reuseport` (Windows rejects `reuseport` by design), option value roundtrips, and the string entrypoints incl. error wrapping. Full local suite green on macOS including trim compile.

## Scope notes

Deliberately deferred (documented in the manual): multicast group management (needs the byte-buffer sockopt layer — the one remaining piece of plumbing), control-message/ancillary-data APIs, and batched I/O (`recvmmsg`/GSO). SOCKS `UDP ASSOCIATE` remains out of scope.

One naming note for review: `UDP.listen` performs no `listen(2)` — the name follows Go's `ListenUDP` (passive, bound side) and keeps the TCP/UDP surfaces parallel; `bind` was the alternative considered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)