### PR TITLE
TCP stdlib-parity fixes from the Sockets audit

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -70,6 +70,12 @@ set_write_deadline!
 DeadlineExceededError
 set_nodelay!
 set_keepalive!
+set_quickack!
+set_linger!
+set_read_buffer!
+set_write_buffer!
+listenany
+rawfd
 local_addr
 remote_addr
 addr

--- a/src/1_socket_ops.jl
+++ b/src/1_socket_ops.jl
@@ -67,18 +67,25 @@ const MSG_TRUNC = @static Sys.iswindows() ? Cint(0) :
 const SO_LINGER = @static Sys.islinux() ? Cint(0x000D) : Cint(0x0080)
 # Keepalive tuning knobs. Darwin spells idle-before-first-probe TCP_KEEPALIVE;
 # Windows gained the TCP_KEEP* setsockopt names in Server 2016/Windows 10 1709.
-# OpenBSD has no per-socket keepalive tuning; the kernel rejects the option.
+# OpenBSD has no per-socket keepalive tuning. Use an invalid option number there
+# so the kernel returns ENOPROTOOPT instead of targeting an unrelated option.
 const TCP_KEEPIDLE = @static Sys.iswindows() ? Cint(3) :
         Sys.islinux() ? Cint(4) :
         Sys.isapple() ? Cint(0x10) :
+        Sys.isnetbsd() ? Cint(3) :
+        Sys.isopenbsd() ? Cint(-1) :
         Cint(0x100)
 const TCP_KEEPINTVL = @static Sys.iswindows() ? Cint(17) :
         Sys.islinux() ? Cint(5) :
         Sys.isapple() ? Cint(0x101) :
+        Sys.isnetbsd() ? Cint(5) :
+        Sys.isopenbsd() ? Cint(-1) :
         Cint(0x200)
 const TCP_KEEPCNT = @static Sys.iswindows() ? Cint(16) :
         Sys.islinux() ? Cint(6) :
         Sys.isapple() ? Cint(0x102) :
+        Sys.isnetbsd() ? Cint(6) :
+        Sys.isopenbsd() ? Cint(-1) :
         Cint(0x400)
 const TCP_QUICKACK = Cint(12)  # Linux-only
 

--- a/src/1_socket_ops.jl
+++ b/src/1_socket_ops.jl
@@ -211,6 +211,7 @@ function decode_sockaddr(ptr::Ptr{UInt8}, len::Integer)::AcceptPeer
         return unsafe_load(Ptr{SockAddrIn6}(Ptr{Cvoid}(ptr)))
     end
     return nothing
+end
 
 @static if Sys.iswindows()
     """

--- a/src/1_socket_ops.jl
+++ b/src/1_socket_ops.jl
@@ -64,6 +64,23 @@ const SO_SNDBUF = @static Sys.islinux() ? Cint(0x0007) : Cint(0x1001)
 # recvmsg flag, so the constant is only meaningful on POSIX platforms.
 const MSG_TRUNC = @static Sys.iswindows() ? Cint(0) :
     Sys.islinux() ? Cint(0x20) : Cint(0x10)
+const SO_LINGER = @static Sys.islinux() ? Cint(0x000D) : Cint(0x0080)
+# Keepalive tuning knobs. Darwin spells idle-before-first-probe TCP_KEEPALIVE;
+# Windows gained the TCP_KEEP* setsockopt names in Server 2016/Windows 10 1709.
+# OpenBSD has no per-socket keepalive tuning; the kernel rejects the option.
+const TCP_KEEPIDLE = @static Sys.iswindows() ? Cint(3) :
+        Sys.islinux() ? Cint(4) :
+        Sys.isapple() ? Cint(0x10) :
+        Cint(0x100)
+const TCP_KEEPINTVL = @static Sys.iswindows() ? Cint(17) :
+        Sys.islinux() ? Cint(5) :
+        Sys.isapple() ? Cint(0x101) :
+        Cint(0x200)
+const TCP_KEEPCNT = @static Sys.iswindows() ? Cint(16) :
+        Sys.islinux() ? Cint(6) :
+        Sys.isapple() ? Cint(0x102) :
+        Cint(0x400)
+const TCP_QUICKACK = Cint(12)  # Linux-only
 
 @static if Sys.isbsd()
     """
@@ -187,6 +204,23 @@ function decode_sockaddr(ptr::Ptr{UInt8}, len::Integer)::AcceptPeer
         return unsafe_load(Ptr{SockAddrIn6}(Ptr{Cvoid}(ptr)))
     end
     return nothing
+
+@static if Sys.iswindows()
+    """
+    Windows-compatible `struct linger` (`u_short` fields).
+    """
+    struct Linger
+        l_onoff::UInt16
+        l_linger::UInt16
+    end
+else
+    """
+    POSIX-compatible `struct linger`.
+    """
+    struct Linger
+        l_onoff::Cint
+        l_linger::Cint
+    end
 end
 
 @inline function _is_little_endian()::Bool
@@ -543,6 +577,14 @@ function set_sockopt_int(fd::SocketFD, level::Cint, optname::Cint, value::Intege
     _ = optname
     _ = value
     _throw_enosys("setsockopt")
+end
+
+function set_sockopt_bytes(fd::SocketFD, level::Cint, optname::Cint, ptr::Ptr{Cvoid}, len::Integer)::Nothing
+    _throw_enosys("set_sockopt_bytes")
+end
+
+function get_sockopt_bytes!(fd::SocketFD, level::Cint, optname::Cint, ptr::Ptr{Cvoid}, len::Integer)::Int
+    _throw_enosys("get_sockopt_bytes!")
 end
 
 function get_socket_error(fd::SocketFD)::Int32

--- a/src/3_netcommon.jl
+++ b/src/3_netcommon.jl
@@ -241,9 +241,9 @@ end
     return err.errnum == Int(Base.Libc.ENOTCONN) || err.errnum == Int(Base.Libc.EINVAL)
 end
 
-function _finalizer_close!(fd::FD)
+function _finalizer_close!(pfd::IOPoll.FD)
     try
-        Base.close(fd.pfd)
+        Base.close(pfd)
     catch
     end
     return nothing
@@ -253,12 +253,14 @@ end
 # libuv finalizer behind `Sockets.TCPSocket`: a leaked `Conn`/`Listener` must
 # not leak its descriptor. Finalizers cannot task-switch, and a full close
 # takes poller locks and drains in-flight operations, so the real close runs on
-# a spawned task; a finalizable FD has no live references, so that close never
-# actually waits. Explicit `close` remains the documented path — this only
-# reclaims descriptors the program forgot.
-function _netfd_finalizer(fd::FD)
-    IOPoll._fdlock_closing(fd.pfd.fdlock) && return nothing
-    t = Task(() -> _finalizer_close!(fd))
+# a spawned task. Attach the finalizer to the poll FD, not its net metadata
+# wrapper: every active operation retains the poll FD through its final
+# unlock/decref, so the safety net cannot close a descriptor that is still in
+# use after the wrapper's last field access. Explicit `close` remains the
+# documented path — this only reclaims descriptors the program forgot.
+function _netfd_finalizer(pfd::IOPoll.FD)
+    IOPoll._fdlock_closing(pfd.fdlock) && return nothing
+    t = Task(() -> _finalizer_close!(pfd))
     t.sticky = false
     schedule(t)
     return nothing
@@ -275,9 +277,8 @@ function _new_netfd(
     # datagram sockets do neither (an empty datagram is valid data).
     is_stream = sotype == SocketOps.SOCK_STREAM
     pfd = IOPoll.FD(sysfd; is_stream = is_stream, zero_read_is_eof = is_stream, is_file = false)
-    fd = FD(pfd, family, sotype, net, is_connected, nothing, nothing)
-    finalizer(_netfd_finalizer, fd)
-    return fd
+    finalizer(_netfd_finalizer, pfd)
+    return FD(pfd, family, sotype, net, is_connected, nothing, nothing)
 end
 
 """

--- a/src/3_netcommon.jl
+++ b/src/3_netcommon.jl
@@ -241,6 +241,29 @@ end
     return err.errnum == Int(Base.Libc.ENOTCONN) || err.errnum == Int(Base.Libc.EINVAL)
 end
 
+function _finalizer_close!(fd::FD)
+    try
+        Base.close(fd.pfd)
+    catch
+    end
+    return nothing
+end
+
+# GC safety net mirroring Go's `runtime.SetFinalizer((*netFD).Close)` and the
+# libuv finalizer behind `Sockets.TCPSocket`: a leaked `Conn`/`Listener` must
+# not leak its descriptor. Finalizers cannot task-switch, and a full close
+# takes poller locks and drains in-flight operations, so the real close runs on
+# a spawned task; a finalizable FD has no live references, so that close never
+# actually waits. Explicit `close` remains the documented path — this only
+# reclaims descriptors the program forgot.
+function _netfd_finalizer(fd::FD)
+    IOPoll._fdlock_closing(fd.pfd.fdlock) && return nothing
+    t = Task(() -> _finalizer_close!(fd))
+    t.sticky = false
+    schedule(t)
+    return nothing
+end
+
 function _new_netfd(
         sysfd::SocketOps.SocketFD;
         family::Cint = SocketOps.AF_INET,
@@ -252,7 +275,9 @@ function _new_netfd(
     # datagram sockets do neither (an empty datagram is valid data).
     is_stream = sotype == SocketOps.SOCK_STREAM
     pfd = IOPoll.FD(sysfd; is_stream = is_stream, zero_read_is_eof = is_stream, is_file = false)
-    return FD(pfd, family, sotype, net, is_connected, nothing, nothing)
+    fd = FD(pfd, family, sotype, net, is_connected, nothing, nothing)
+    finalizer(_netfd_finalizer, fd)
+    return fd
 end
 
 """

--- a/src/3_tcp.jl
+++ b/src/3_tcp.jl
@@ -525,6 +525,43 @@ function listen(local_addr::SocketAddr; backlog::Integer = 128, reuseaddr::Bool 
     )
 end
 
+@inline _with_port(addr::SocketAddrV4, port::Integer)::SocketAddrV4 = SocketAddrV4(addr.ip, port)
+@inline function _with_port(addr::SocketAddrV6, port::Integer)::SocketAddrV6
+    return SocketAddrV6(addr.ip, port; scope_id = Int(addr.scope_id))
+end
+
+@inline function _is_port_taken_errno(errnum::Integer)::Bool
+    return errnum == Int(Base.Libc.EADDRINUSE) || errnum == Int(Base.Libc.EACCES)
+end
+
+"""
+    listenany(hint::SocketAddr; backlog=128, reuseaddr=true) -> (UInt16, Listener)
+
+Bind a listener on the first available port at or above `hint`'s port,
+returning the bound port and the listener (the `Sockets.listenany` idiom).
+
+Ports that are in use (`EADDRINUSE`) or forbidden (`EACCES`) are skipped by
+incrementing the port; running out of ports rethrows the last error. A hint
+port of `0` binds an ephemeral port directly.
+"""
+function listenany(hint::SocketAddr; backlog::Integer = 128, reuseaddr::Bool = true)::Tuple{UInt16, Listener}
+    addr = hint
+    while true
+        listener = try
+            listen(addr; backlog = backlog, reuseaddr = reuseaddr)
+        catch err
+            ex = err::Exception
+            (ex isa SystemError && _is_port_taken_errno(ex.errnum)) || rethrow(ex)
+            next_port = Int(addr.port) + 1
+            next_port > 0xffff && rethrow(ex)
+            addr = _with_port(addr, next_port)
+            continue
+        end
+        bound = local_addr(listener)
+        return ((bound::SocketEndpoint).port, listener)
+    end
+end
+
 """
     accept(listener)
 
@@ -1054,18 +1091,144 @@ function set_nodelay!(conn::Conn, enabled::Bool = true)
 end
 
 """
-    set_keepalive!(conn, enabled=true)
+    set_keepalive!(conn, enabled=true; idle_secs=nothing, interval_secs=nothing, count=nothing)
 
-Enable or disable `SO_KEEPALIVE` on `conn`.
+Enable or disable `SO_KEEPALIVE` on `conn`, optionally tuning the probe
+schedule (the shape of Go's `KeepAliveConfig`):
+
+- `idle_secs`: idle time before the first probe (`TCP_KEEPIDLE`;
+  `TCP_KEEPALIVE` on Darwin)
+- `interval_secs`: time between unanswered probes (`TCP_KEEPINTVL`)
+- `count`: unanswered probes before the connection is dropped (`TCP_KEEPCNT`)
+
+Tuning values are applied only when provided. Platforms without a given knob
+surface the kernel's `SystemError` (notably OpenBSD, and Windows releases
+before Server 2016 / Windows 10 1709).
 """
-function set_keepalive!(conn::Conn, enabled::Bool = true)
+function set_keepalive!(
+        conn::Conn,
+        enabled::Bool = true;
+        idle_secs::Union{Nothing, Integer} = nothing,
+        interval_secs::Union{Nothing, Integer} = nothing,
+        count::Union{Nothing, Integer} = nothing,
+    )
     IOPoll.set_sockopt_int!(
         conn.fd.pfd,
         SocketOps.SOL_SOCKET,
         SocketOps.SO_KEEPALIVE,
         enabled ? 1 : 0,
     )
+    if idle_secs !== nothing
+        idle_secs > 0 || throw(ArgumentError("idle_secs must be positive"))
+        IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.IPPROTO_TCP, SocketOps.TCP_KEEPIDLE, Int(idle_secs))
+    end
+    if interval_secs !== nothing
+        interval_secs > 0 || throw(ArgumentError("interval_secs must be positive"))
+        IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.IPPROTO_TCP, SocketOps.TCP_KEEPINTVL, Int(interval_secs))
+    end
+    if count !== nothing
+        count > 0 || throw(ArgumentError("count must be positive"))
+        IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.IPPROTO_TCP, SocketOps.TCP_KEEPCNT, Int(count))
+    end
     return nothing
+end
+
+"""
+    set_quickack!(conn, enabled=true)
+
+Toggle `TCP_QUICKACK` (Linux). On other platforms this is a silent no-op,
+matching `Sockets.quickack`, so cross-platform callers can set it
+unconditionally. The kernel may clear the flag again after some transfers;
+latency-sensitive callers re-assert it as needed.
+"""
+function set_quickack!(conn::Conn, enabled::Bool = true)
+    @static if Sys.islinux()
+        IOPoll.set_sockopt_int!(
+            conn.fd.pfd,
+            SocketOps.IPPROTO_TCP,
+            SocketOps.TCP_QUICKACK,
+            enabled ? 1 : 0,
+        )
+    end
+    return nothing
+end
+
+"""
+    set_linger!(conn, timeout_secs)
+
+Configure `SO_LINGER`, following Go's `SetLinger`: a negative timeout disables
+lingering (`close` returns immediately and the OS flushes in the background —
+the default), `0` discards unsent data on close with a RST, and a positive
+timeout blocks `close` until the data is flushed or the timeout expires.
+"""
+function set_linger!(conn::Conn, timeout_secs::Integer)
+    lg = if timeout_secs < 0
+        SocketOps.Linger(0, 0)
+    else
+        timeout_secs > 0xffff && throw(ArgumentError("linger timeout must be at most 65535 seconds"))
+        SocketOps.Linger(1, timeout_secs)
+    end
+    IOPoll.set_sockopt_bytes!(conn.fd.pfd, SocketOps.SOL_SOCKET, SocketOps.SO_LINGER, Ref(lg))
+    return nothing
+end
+
+"""
+    set_read_buffer!(conn, nbytes)
+
+Set the kernel receive buffer size (`SO_RCVBUF`). The kernel may round the
+value, enforce minimums, or (on Linux) double it to leave bookkeeping room.
+"""
+function set_read_buffer!(conn::Conn, nbytes::Integer)
+    nbytes > 0 || throw(ArgumentError("buffer size must be positive"))
+    IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.SOL_SOCKET, SocketOps.SO_RCVBUF, Int(nbytes))
+    return nothing
+end
+
+"""
+    set_write_buffer!(conn, nbytes)
+
+Set the kernel send buffer size (`SO_SNDBUF`). The kernel may round the
+value, enforce minimums, or (on Linux) double it to leave bookkeeping room.
+"""
+function set_write_buffer!(conn::Conn, nbytes::Integer)
+    nbytes > 0 || throw(ArgumentError("buffer size must be positive"))
+    IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.SOL_SOCKET, SocketOps.SO_SNDBUF, Int(nbytes))
+    return nothing
+end
+
+"""
+    rawfd(conn) -> RawFD or Base.WindowsRawSocket
+
+Return the OS-level socket descriptor backing `conn` (a `RawFD` on POSIX, a
+`Base.WindowsRawSocket` on Windows) for FFI and interop uses such as
+subprocess stdio redirection.
+
+Reseau retains ownership: the descriptor is non-blocking and registered with
+the internal poller; callers must not close it, change its flags, or use it
+after `close(conn)`. Throws `NetClosingError` if the socket is already
+closing.
+"""
+function rawfd(conn::Conn)
+    return _rawfd(conn.fd)
+end
+
+"""
+    rawfd(listener) -> RawFD or Base.WindowsRawSocket
+
+Listener variant of [`rawfd`](@ref). The same ownership rules apply.
+"""
+function rawfd(listener::Listener)
+    return _rawfd(listener.fd)
+end
+
+function _rawfd(fd::FD)
+    IOPoll._fdlock_closing(fd.pfd.fdlock) && throw(IOPoll.NetClosingError())
+    sysfd = fd.pfd.sysfd
+    @static if Sys.iswindows()
+        return Base.WindowsRawSocket(Ptr{Cvoid}(sysfd))
+    else
+        return RawFD(sysfd)
+    end
 end
 
 """

--- a/src/3_tcp.jl
+++ b/src/3_tcp.jl
@@ -1200,6 +1200,7 @@ the default), `0` discards unsent data on close with a RST, and a positive
 timeout asks the OS to keep sending in the background. On some systems,
 including Linux, a positive timeout may block `close` until data is sent or
 discarded. Remaining data may be discarded after the timeout on some systems.
+Nonnegative timeouts must not exceed 65535 seconds.
 """
 function set_linger!(conn::Conn, timeout_secs::Integer)
     lg = if timeout_secs < 0
@@ -1245,8 +1246,9 @@ Return the OS-level socket descriptor backing `conn` (a `RawFD` on POSIX, a
 Reseau retains ownership: the descriptor is non-blocking and registered with
 the internal poller; callers must not close it, change its flags, or use it
 after `close(conn)`. The result is a borrowed snapshot. Keep `conn` reachable,
-for example with `GC.@preserve`, for the full external operation. Throws
-`NetClosingError` if the socket is already closing.
+for example with `GC.@preserve`, and prevent a concurrent `close(conn)` for the
+full external operation. Throws `NetClosingError` if the socket is already
+closing.
 """
 function rawfd(conn::Conn)
     return _rawfd(conn.fd)

--- a/src/3_tcp.jl
+++ b/src/3_tcp.jl
@@ -493,6 +493,12 @@ Create a TCP listener from a bound local address.
 
 This is the direct-address equivalent of the `listen(network, address; ...)`
 overloads on the same `TCP.listen` generic.
+
+`reuseaddr` sets `SO_REUSEADDR` so a restarting server can rebind a port whose
+previous listener is still in TIME_WAIT. On Windows it is a deliberate no-op:
+Windows allows the TIME_WAIT rebind without the option, and `SO_REUSEADDR`
+there instead permits binding over an *active* listener (silently starving it
+of connections). Go and libuv make the same choice.
 """
 function _listen_socketaddr_impl(
         local_addr::SocketAddr,
@@ -504,7 +510,16 @@ function _listen_socketaddr_impl(
     fd = open_tcp_fd!(; family = family, net = network)
     try
         family == SocketOps.AF_INET6 && _set_ipv6_only!(fd, network === :tcp6)
-        reuseaddr && SocketOps.set_sockopt_int(fd.pfd.sysfd, SocketOps.SOL_SOCKET, SocketOps.SO_REUSEADDR, 1)
+        @static if !Sys.iswindows()
+            # POSIX SO_REUSEADDR permits rebinding a port stuck in TIME_WAIT.
+            # Windows gives the same TIME_WAIT rebinding without the option,
+            # and setting it there instead means "bind over an active
+            # listener" — a hijack that silently starves the original of
+            # connections. Go and libuv likewise never set SO_REUSEADDR on
+            # Windows TCP listeners, so `reuseaddr` is a deliberate no-op
+            # there.
+            reuseaddr && SocketOps.set_sockopt_int(fd.pfd.sysfd, SocketOps.SOL_SOCKET, SocketOps.SO_REUSEADDR, 1)
+        end
         SocketOps.bind_socket(fd.pfd.sysfd, _to_sockaddr(local_addr))
         SocketOps.listen_socket(fd.pfd.sysfd, backlog)
         IOPoll.register!(fd.pfd)
@@ -544,18 +559,15 @@ Ports that are in use (`EADDRINUSE`) or forbidden (`EACCES`) are skipped by
 incrementing the port; running out of ports rethrows the last error. A hint
 port of `0` binds an ephemeral port directly.
 
-On Windows the probe always binds exclusively (`reuseaddr` is ignored there):
-Windows treats `SO_REUSEADDR` as permission to bind over an existing listener
-instead of failing with `EADDRINUSE`, which would defeat the availability
-probe — the hijacked listener never receives connections. Sockets (via libuv)
-and Go likewise never set `SO_REUSEADDR` on Windows TCP listeners.
+`reuseaddr` follows [`listen`](@ref) semantics, including its Windows no-op:
+exclusive Windows binds are exactly what keeps `EADDRINUSE` (and therefore
+this availability probe) reliable there.
 """
 function listenany(hint::SocketAddr; backlog::Integer = 128, reuseaddr::Bool = true)::Tuple{UInt16, Listener}
-    probe_reuseaddr = @static Sys.iswindows() ? false : reuseaddr
     addr = hint
     while true
         listener = try
-            listen(addr; backlog = backlog, reuseaddr = probe_reuseaddr)
+            listen(addr; backlog = backlog, reuseaddr = reuseaddr)
         catch err
             ex = err::Exception
             (ex isa SystemError && _is_port_taken_errno(ex.errnum)) || rethrow(ex)

--- a/src/3_tcp.jl
+++ b/src/3_tcp.jl
@@ -543,12 +543,19 @@ returning the bound port and the listener (the `Sockets.listenany` idiom).
 Ports that are in use (`EADDRINUSE`) or forbidden (`EACCES`) are skipped by
 incrementing the port; running out of ports rethrows the last error. A hint
 port of `0` binds an ephemeral port directly.
+
+On Windows the probe always binds exclusively (`reuseaddr` is ignored there):
+Windows treats `SO_REUSEADDR` as permission to bind over an existing listener
+instead of failing with `EADDRINUSE`, which would defeat the availability
+probe — the hijacked listener never receives connections. Sockets (via libuv)
+and Go likewise never set `SO_REUSEADDR` on Windows TCP listeners.
 """
 function listenany(hint::SocketAddr; backlog::Integer = 128, reuseaddr::Bool = true)::Tuple{UInt16, Listener}
+    probe_reuseaddr = @static Sys.iswindows() ? false : reuseaddr
     addr = hint
     while true
         listener = try
-            listen(addr; backlog = backlog, reuseaddr = reuseaddr)
+            listen(addr; backlog = backlog, reuseaddr = probe_reuseaddr)
         catch err
             ex = err::Exception
             (ex isa SystemError && _is_port_taken_errno(ex.errnum)) || rethrow(ex)

--- a/src/3_tcp.jl
+++ b/src/3_tcp.jl
@@ -550,10 +550,12 @@ end
 end
 
 """
+    listenany(hint::Integer; backlog=128, reuseaddr=true) -> (UInt16, Listener)
     listenany(hint::SocketAddr; backlog=128, reuseaddr=true) -> (UInt16, Listener)
 
 Bind a listener on the first available port at or above `hint`'s port,
 returning the bound port and the listener (the `Sockets.listenany` idiom).
+The integer form binds to the IPv4 loopback address.
 
 Ports that are in use (`EADDRINUSE`) or forbidden (`EACCES`) are skipped by
 incrementing the port; running out of ports rethrows the last error. A hint
@@ -563,6 +565,10 @@ port of `0` binds an ephemeral port directly.
 exclusive Windows binds are exactly what keeps `EADDRINUSE` (and therefore
 this availability probe) reliable there.
 """
+function listenany(hint::Integer; backlog::Integer = 128, reuseaddr::Bool = true)::Tuple{UInt16, Listener}
+    return listenany(loopback_addr(hint); backlog = backlog, reuseaddr = reuseaddr)
+end
+
 function listenany(hint::SocketAddr; backlog::Integer = 128, reuseaddr::Bool = true)::Tuple{UInt16, Listener}
     addr = hint
     while true
@@ -1131,25 +1137,33 @@ function set_keepalive!(
         interval_secs::Union{Nothing, Integer} = nothing,
         count::Union{Nothing, Integer} = nothing,
     )
+    idle = _positive_sockopt_value("idle_secs", idle_secs)
+    interval = _positive_sockopt_value("interval_secs", interval_secs)
+    probes = _positive_sockopt_value("count", count)
     IOPoll.set_sockopt_int!(
         conn.fd.pfd,
         SocketOps.SOL_SOCKET,
         SocketOps.SO_KEEPALIVE,
         enabled ? 1 : 0,
     )
-    if idle_secs !== nothing
-        idle_secs > 0 || throw(ArgumentError("idle_secs must be positive"))
-        IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.IPPROTO_TCP, SocketOps.TCP_KEEPIDLE, Int(idle_secs))
+    if idle !== nothing
+        IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.IPPROTO_TCP, SocketOps.TCP_KEEPIDLE, idle)
     end
-    if interval_secs !== nothing
-        interval_secs > 0 || throw(ArgumentError("interval_secs must be positive"))
-        IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.IPPROTO_TCP, SocketOps.TCP_KEEPINTVL, Int(interval_secs))
+    if interval !== nothing
+        IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.IPPROTO_TCP, SocketOps.TCP_KEEPINTVL, interval)
     end
-    if count !== nothing
-        count > 0 || throw(ArgumentError("count must be positive"))
-        IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.IPPROTO_TCP, SocketOps.TCP_KEEPCNT, Int(count))
+    if probes !== nothing
+        IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.IPPROTO_TCP, SocketOps.TCP_KEEPCNT, probes)
     end
     return nothing
+end
+
+@inline _positive_sockopt_value(::AbstractString, ::Nothing)::Nothing = nothing
+
+function _positive_sockopt_value(name::AbstractString, value::Integer)::Cint
+    0 < value <= typemax(Cint) ||
+        throw(ArgumentError("$name must be in [1, $(typemax(Cint))]"))
+    return Cint(value)
 end
 
 """
@@ -1168,6 +1182,11 @@ function set_quickack!(conn::Conn, enabled::Bool = true)
             SocketOps.TCP_QUICKACK,
             enabled ? 1 : 0,
         )
+    else
+        # Match Sockets' no-op while preserving its open-socket check.
+        IOPoll._with_fd_ref(conn.fd.pfd) do _
+            nothing
+        end
     end
     return nothing
 end
@@ -1178,7 +1197,9 @@ end
 Configure `SO_LINGER`, following Go's `SetLinger`: a negative timeout disables
 lingering (`close` returns immediately and the OS flushes in the background —
 the default), `0` discards unsent data on close with a RST, and a positive
-timeout blocks `close` until the data is flushed or the timeout expires.
+timeout asks the OS to keep sending in the background. On some systems,
+including Linux, a positive timeout may block `close` until data is sent or
+discarded. Remaining data may be discarded after the timeout on some systems.
 """
 function set_linger!(conn::Conn, timeout_secs::Integer)
     lg = if timeout_secs < 0
@@ -1198,8 +1219,8 @@ Set the kernel receive buffer size (`SO_RCVBUF`). The kernel may round the
 value, enforce minimums, or (on Linux) double it to leave bookkeeping room.
 """
 function set_read_buffer!(conn::Conn, nbytes::Integer)
-    nbytes > 0 || throw(ArgumentError("buffer size must be positive"))
-    IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.SOL_SOCKET, SocketOps.SO_RCVBUF, Int(nbytes))
+    size = _positive_sockopt_value("buffer size", nbytes)
+    IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.SOL_SOCKET, SocketOps.SO_RCVBUF, size)
     return nothing
 end
 
@@ -1210,8 +1231,8 @@ Set the kernel send buffer size (`SO_SNDBUF`). The kernel may round the
 value, enforce minimums, or (on Linux) double it to leave bookkeeping room.
 """
 function set_write_buffer!(conn::Conn, nbytes::Integer)
-    nbytes > 0 || throw(ArgumentError("buffer size must be positive"))
-    IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.SOL_SOCKET, SocketOps.SO_SNDBUF, Int(nbytes))
+    size = _positive_sockopt_value("buffer size", nbytes)
+    IOPoll.set_sockopt_int!(conn.fd.pfd, SocketOps.SOL_SOCKET, SocketOps.SO_SNDBUF, size)
     return nothing
 end
 
@@ -1219,13 +1240,13 @@ end
     rawfd(conn) -> RawFD or Base.WindowsRawSocket
 
 Return the OS-level socket descriptor backing `conn` (a `RawFD` on POSIX, a
-`Base.WindowsRawSocket` on Windows) for FFI and interop uses such as
-subprocess stdio redirection.
+`Base.WindowsRawSocket` on Windows) for FFI and interop.
 
 Reseau retains ownership: the descriptor is non-blocking and registered with
 the internal poller; callers must not close it, change its flags, or use it
-after `close(conn)`. Throws `NetClosingError` if the socket is already
-closing.
+after `close(conn)`. The result is a borrowed snapshot. Keep `conn` reachable,
+for example with `GC.@preserve`, for the full external operation. Throws
+`NetClosingError` if the socket is already closing.
 """
 function rawfd(conn::Conn)
     return _rawfd(conn.fd)
@@ -1241,12 +1262,12 @@ function rawfd(listener::Listener)
 end
 
 function _rawfd(fd::FD)
-    IOPoll._fdlock_closing(fd.pfd.fdlock) && throw(IOPoll.NetClosingError())
-    sysfd = fd.pfd.sysfd
-    @static if Sys.iswindows()
-        return Base.WindowsRawSocket(Ptr{Cvoid}(sysfd))
-    else
-        return RawFD(sysfd)
+    return IOPoll._with_fd_ref(fd.pfd) do sysfd
+        @static if Sys.iswindows()
+            return Base.WindowsRawSocket(Ptr{Cvoid}(sysfd))
+        else
+            return RawFD(sysfd)
+        end
     end
 end
 

--- a/src/4_host_resolvers.jl
+++ b/src/4_host_resolvers.jl
@@ -2499,6 +2499,20 @@ function listen(
     )::TCP.Listener
     return listen(HostResolver(), network, address; backlog = backlog, reuseaddr = reuseaddr)
 end
+
+"""
+    listen(address; backlog=128, reuseaddr=true) -> TCP.Listener
+
+Shorthand for `listen("tcp", address; ...)`, mirroring `connect(address)`.
+An empty host (`":9000"`) listens on the wildcard address.
+"""
+function listen(
+        address::AbstractString;
+        backlog::Integer = 128,
+        reuseaddr::Bool = true,
+    )::TCP.Listener
+    return listen("tcp", address; backlog = backlog, reuseaddr = reuseaddr)
+end
 ##########################
 # UDP string-address entrypoints
 ##########################

--- a/src/iopoll/fd.jl
+++ b/src/iopoll/fd.jl
@@ -590,6 +590,32 @@ function set_sockopt_int!(
     return nothing
 end
 
+"""
+    set_sockopt_bytes!(fd, level, optname, ref)
+
+Set a socket option wider than a `Cint` (e.g. `SO_LINGER`) from `ref` while
+preventing concurrent descriptor destruction and reuse.
+"""
+function set_sockopt_bytes!(
+        fd::FD,
+        level::Cint,
+        optname::Cint,
+        ref::Base.RefValue{T},
+    ) where {T}
+    _with_fd_ref(fd) do sysfd
+        GC.@preserve ref begin
+            SocketOps.set_sockopt_bytes(
+                sysfd,
+                level,
+                optname,
+                Ptr{Cvoid}(Base.unsafe_convert(Ptr{T}, ref)),
+                sizeof(T),
+            )
+        end
+    end
+    return nothing
+end
+
 function _fd_read_lock!(fd::FD)
     _fdlock_rwlock!(fd.fdlock, true, true) || throw(_closing_error(fd.is_file))
     return nothing

--- a/src/socket_ops/darwin.jl
+++ b/src/socket_ops/darwin.jl
@@ -340,6 +340,52 @@ function set_sockopt_int(fd::Cint, level::Cint, optname::Cint, value::Integer)
     end
 end
 
+
+"""
+    set_sockopt_bytes(fd, level, optname, ptr, len)
+
+Write a socket option wider than a `Cint` (e.g. `SO_LINGER`) from a raw byte
+buffer. The caller must keep the memory behind `ptr` rooted for the call.
+"""
+function set_sockopt_bytes(fd::Cint, level::Cint, optname::Cint, ptr::Ptr{Cvoid}, len::Integer)::Nothing
+    while true
+        ret = @ccall setsockopt(
+            fd::Cint,
+            level::Cint,
+            optname::Cint,
+            ptr::Ptr{Cvoid},
+            SockLen(len)::SockLen,
+        )::Cint
+        ret == 0 && return nothing
+        errno = _errno_i32()
+        errno == Int32(Base.Libc.EINTR) && continue
+        _throw_errno("setsockopt", errno)
+    end
+end
+
+"""
+    get_sockopt_bytes!(fd, level, optname, ptr, len) -> Int
+
+Read a socket option into a raw byte buffer, returning the number of bytes the
+kernel wrote. The caller must keep the memory behind `ptr` rooted for the call.
+"""
+function get_sockopt_bytes!(fd::Cint, level::Cint, optname::Cint, ptr::Ptr{Cvoid}, len::Integer)::Int
+    len_ref = Ref{SockLen}(SockLen(len))
+    while true
+        ret = @ccall getsockopt(
+            fd::Cint,
+            level::Cint,
+            optname::Cint,
+            ptr::Ptr{Cvoid},
+            len_ref::Ref{SockLen},
+        )::Cint
+        ret == 0 && return Int(len_ref[])
+        errno = _errno_i32()
+        errno == Int32(Base.Libc.EINTR) && continue
+        _throw_errno("getsockopt", errno)
+    end
+end
+
 """
     get_socket_error(fd) -> Int32
 

--- a/src/socket_ops/linux.jl
+++ b/src/socket_ops/linux.jl
@@ -334,6 +334,52 @@ function set_sockopt_int(fd::Cint, level::Cint, optname::Cint, value::Integer)
     end
 end
 
+
+"""
+    set_sockopt_bytes(fd, level, optname, ptr, len)
+
+Write a socket option wider than a `Cint` (e.g. `SO_LINGER`) from a raw byte
+buffer. The caller must keep the memory behind `ptr` rooted for the call.
+"""
+function set_sockopt_bytes(fd::Cint, level::Cint, optname::Cint, ptr::Ptr{Cvoid}, len::Integer)::Nothing
+    while true
+        ret = @ccall setsockopt(
+            fd::Cint,
+            level::Cint,
+            optname::Cint,
+            ptr::Ptr{Cvoid},
+            SockLen(len)::SockLen,
+        )::Cint
+        ret == 0 && return nothing
+        errno = _errno_i32()
+        errno == Int32(Base.Libc.EINTR) && continue
+        _throw_errno("setsockopt", errno)
+    end
+end
+
+"""
+    get_sockopt_bytes!(fd, level, optname, ptr, len) -> Int
+
+Read a socket option into a raw byte buffer, returning the number of bytes the
+kernel wrote. The caller must keep the memory behind `ptr` rooted for the call.
+"""
+function get_sockopt_bytes!(fd::Cint, level::Cint, optname::Cint, ptr::Ptr{Cvoid}, len::Integer)::Int
+    len_ref = Ref{SockLen}(SockLen(len))
+    while true
+        ret = @ccall getsockopt(
+            fd::Cint,
+            level::Cint,
+            optname::Cint,
+            ptr::Ptr{Cvoid},
+            len_ref::Ref{SockLen},
+        )::Cint
+        ret == 0 && return Int(len_ref[])
+        errno = _errno_i32()
+        errno == Int32(Base.Libc.EINTR) && continue
+        _throw_errno("getsockopt", errno)
+    end
+end
+
 """
     get_socket_error(fd) -> Int32
 

--- a/src/socket_ops/windows.jl
+++ b/src/socket_ops/windows.jl
@@ -899,6 +899,52 @@ function set_sockopt_int(fd::SocketFD, level::Cint, optname::Cint, value::Intege
     _throw_errno("setsockopt", _map_wsa_errno(_wsa_get_last_error()))
 end
 
+
+"""
+    set_sockopt_bytes(fd, level, optname, ptr, len)
+
+Write a socket option wider than a `Cint` (e.g. `SO_LINGER`) from a raw byte
+buffer. The caller must keep the memory behind `ptr` rooted for the call.
+"""
+function set_sockopt_bytes(fd::SocketFD, level::Cint, optname::Cint, ptr::Ptr{Cvoid}, len::Integer)::Nothing
+    ret = ccall(
+        (:setsockopt, _WS2_32),
+        Cint,
+        (UInt, Cint, Cint, Ptr{UInt8}, Cint),
+        _socket_value(fd),
+        level,
+        optname,
+        Ptr{UInt8}(ptr),
+        Cint(len),
+    )
+    ret == 0 && return nothing
+    _throw_errno("setsockopt", _map_wsa_errno(_wsa_get_last_error()))
+end
+
+"""
+    get_sockopt_bytes!(fd, level, optname, ptr, len) -> Int
+
+Read a socket option into a raw byte buffer, returning the number of bytes the
+OS wrote. The caller must keep the memory behind `ptr` rooted for the call.
+"""
+function get_sockopt_bytes!(fd::SocketFD, level::Cint, optname::Cint, ptr::Ptr{Cvoid}, len::Integer)::Int
+    len_ref = Ref{Cint}(Cint(len))
+    ret = GC.@preserve len_ref begin
+        ccall(
+            (:getsockopt, _WS2_32),
+            Cint,
+            (UInt, Cint, Cint, Ptr{UInt8}, Ref{Cint}),
+            _socket_value(fd),
+            level,
+            optname,
+            Ptr{UInt8}(ptr),
+            len_ref,
+        )
+    end
+    ret == 0 && return Int(len_ref[])
+    _throw_errno("getsockopt", _map_wsa_errno(_wsa_get_last_error()))
+end
+
 """
     get_socket_error(fd) -> Int32
 

--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -1032,6 +1032,30 @@ end
         close(listener)
     end
 
+    @testset "listen reuseaddr semantics" begin
+        listener = TCP.listen(TCP.loopback_addr(0); reuseaddr = true)
+        got = Reseau.SocketOps.get_sockopt_int(
+            listener.fd.pfd.sysfd,
+            Reseau.SocketOps.SOL_SOCKET,
+            Reseau.SocketOps.SO_REUSEADDR,
+        )
+        @static if Sys.iswindows()
+            # reuseaddr is a deliberate no-op on Windows: SO_REUSEADDR there
+            # means "bind over an active listener", not TIME_WAIT rebinding.
+            @test got == 0
+        else
+            @test got != 0
+        end
+        close(listener)
+        bare = TCP.listen(TCP.loopback_addr(0); reuseaddr = false)
+        @test Reseau.SocketOps.get_sockopt_int(
+            bare.fd.pfd.sysfd,
+            Reseau.SocketOps.SOL_SOCKET,
+            Reseau.SocketOps.SO_REUSEADDR,
+        ) == 0
+        close(bare)
+    end
+
     @testset "listenany" begin
         taken = TCP.listen(TCP.loopback_addr(0))
         hint_port = Int((TCP.addr(taken)::TCP.SocketAddrV4).port)

--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -1188,10 +1188,18 @@ end
         listener = TCP.listen(TCP.loopback_addr(0))
         conn = TCP.connect(TCP.addr(listener))
         server = TCP.accept(listener)
+
+        # The TCP metadata wrapper may become unreachable while an operation
+        # still retains its poll FD. Finalizing that wrapper must not close the
+        # live descriptor.
+        finalize(conn.fd)
+        yield()
+        @test isopen(conn)
+
         # Trigger the GC safety net deterministically. The finalizer schedules
         # the blocking close on a task; spin-yield until it lands (park
         # detection pattern from test/README.md).
-        finalize(conn.fd)
+        finalize(conn.fd.pfd)
         while isopen(conn)
             yield()
         end
@@ -1200,8 +1208,9 @@ end
 
         # A finalizer firing after an explicit close is a no-op.
         close(server)
-        finalize(server.fd)
+        finalize(server.fd.pfd)
         @test !isopen(server)
+
         close(listener)
     end
 end

--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -1016,6 +1016,71 @@ end
     end
 
 @testset "TCP stdlib-parity additions" begin
+    @testset "platform socket constants and layouts" begin
+        @test Reseau.SocketOps.IPPROTO_TCP == 6
+        @static if Sys.islinux()
+            @test Reseau.SocketOps.SOL_SOCKET == 1
+            @test Reseau.SocketOps.SO_REUSEADDR == 2
+            @test Reseau.SocketOps.SO_KEEPALIVE == 9
+            @test Reseau.SocketOps.SO_LINGER == 0x000d
+            @test Reseau.SocketOps.SO_RCVBUF == 0x0008
+            @test Reseau.SocketOps.SO_SNDBUF == 0x0007
+            @test Reseau.SocketOps.TCP_KEEPIDLE == 4
+            @test Reseau.SocketOps.TCP_KEEPINTVL == 5
+            @test Reseau.SocketOps.TCP_KEEPCNT == 6
+            @test Reseau.SocketOps.TCP_QUICKACK == 12
+        elseif Sys.iswindows()
+            @test Reseau.SocketOps.SOL_SOCKET == 0xffff
+            @test Reseau.SocketOps.SO_REUSEADDR == 4
+            @test Reseau.SocketOps.SO_KEEPALIVE == 8
+            @test Reseau.SocketOps.SO_LINGER == 0x0080
+            @test Reseau.SocketOps.SO_RCVBUF == 0x1002
+            @test Reseau.SocketOps.SO_SNDBUF == 0x1001
+            @test Reseau.SocketOps.TCP_KEEPIDLE == 3
+            @test Reseau.SocketOps.TCP_KEEPINTVL == 17
+            @test Reseau.SocketOps.TCP_KEEPCNT == 16
+        elseif Sys.isapple()
+            @test Reseau.SocketOps.SOL_SOCKET == 0xffff
+            @test Reseau.SocketOps.SO_REUSEADDR == 4
+            @test Reseau.SocketOps.SO_KEEPALIVE == 8
+            @test Reseau.SocketOps.SO_LINGER == 0x0080
+            @test Reseau.SocketOps.SO_RCVBUF == 0x1002
+            @test Reseau.SocketOps.SO_SNDBUF == 0x1001
+            @test Reseau.SocketOps.TCP_KEEPIDLE == 0x10
+            @test Reseau.SocketOps.TCP_KEEPINTVL == 0x101
+            @test Reseau.SocketOps.TCP_KEEPCNT == 0x102
+        elseif Sys.isnetbsd()
+            @test Reseau.SocketOps.TCP_KEEPIDLE == 3
+            @test Reseau.SocketOps.TCP_KEEPINTVL == 5
+            @test Reseau.SocketOps.TCP_KEEPCNT == 6
+        elseif Sys.isopenbsd()
+            @test Reseau.SocketOps.TCP_KEEPIDLE == -1
+            @test Reseau.SocketOps.TCP_KEEPINTVL == -1
+            @test Reseau.SocketOps.TCP_KEEPCNT == -1
+        else
+            # FreeBSD and DragonFly BSD use these values.
+            @test Reseau.SocketOps.SOL_SOCKET == 0xffff
+            @test Reseau.SocketOps.SO_REUSEADDR == 4
+            @test Reseau.SocketOps.SO_KEEPALIVE == 8
+            @test Reseau.SocketOps.SO_LINGER == 0x0080
+            @test Reseau.SocketOps.SO_RCVBUF == 0x1002
+            @test Reseau.SocketOps.SO_SNDBUF == 0x1001
+            @test Reseau.SocketOps.TCP_KEEPIDLE == 0x100
+            @test Reseau.SocketOps.TCP_KEEPINTVL == 0x200
+            @test Reseau.SocketOps.TCP_KEEPCNT == 0x400
+        end
+
+        @static if Sys.iswindows()
+            @test sizeof(Reseau.SocketOps.Linger) == 4
+            @test fieldtype(Reseau.SocketOps.Linger, 1) === UInt16
+            @test fieldtype(Reseau.SocketOps.Linger, 2) === UInt16
+        else
+            @test sizeof(Reseau.SocketOps.Linger) == 8
+            @test fieldtype(Reseau.SocketOps.Linger, 1) === Cint
+            @test fieldtype(Reseau.SocketOps.Linger, 2) === Cint
+        end
+    end
+
     @testset "single-string listen" begin
         listener = TCP.listen("127.0.0.1:0"; backlog = 64)
         addr = TCP.addr(listener)

--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -1059,7 +1059,7 @@ end
     @testset "listenany" begin
         taken = TCP.listen(TCP.loopback_addr(0))
         hint_port = Int((TCP.addr(taken)::TCP.SocketAddrV4).port)
-        port, listener = TCP.listenany(TCP.loopback_addr(hint_port))
+        port, listener = TCP.listenany(hint_port)
         @test port != hint_port
         @test isopen(listener)
         conn = TCP.connect(TCP.loopback_addr(Int(port)))
@@ -1069,9 +1069,13 @@ end
         close(listener)
         close(taken)
 
-        eport, elistener = TCP.listenany(TCP.loopback_addr(0))
+        eport, elistener = TCP.listenany(0)
         @test eport != 0
         close(elistener)
+
+        aport, alistener = TCP.listenany(TCP.loopback_addr(0))
+        @test aport != 0
+        close(alistener)
     end
 
     @testset "keepalive tuning" begin
@@ -1089,6 +1093,8 @@ end
         @test_throws ArgumentError TCP.set_keepalive!(conn; idle_secs = 0)
         @test_throws ArgumentError TCP.set_keepalive!(conn; interval_secs = -1)
         @test_throws ArgumentError TCP.set_keepalive!(conn; count = 0)
+        @test_throws ArgumentError TCP.set_keepalive!(conn; count = Int(typemax(Cint)) + 1)
+        @test Reseau.SocketOps.get_sockopt_int(sysfd, Reseau.SocketOps.SOL_SOCKET, Reseau.SocketOps.SO_KEEPALIVE) == 0
         close(conn)
         close(server)
         close(listener)
@@ -1140,6 +1146,7 @@ end
         @test Reseau.SocketOps.get_sockopt_int(sysfd, Reseau.SocketOps.SOL_SOCKET, Reseau.SocketOps.SO_SNDBUF) >= 65536
         @test_throws ArgumentError TCP.set_read_buffer!(conn, 0)
         @test_throws ArgumentError TCP.set_write_buffer!(conn, -1)
+        @test_throws ArgumentError TCP.set_read_buffer!(conn, Int(typemax(Cint)) + 1)
         close(conn)
         close(server)
         close(listener)
@@ -1160,6 +1167,7 @@ end
             ) != 0
         end
         close(conn)
+        @test_throws Reseau.IOPoll.NetClosingError TCP.set_quickack!(conn)
         close(server)
         close(listener)
     end

--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -1014,3 +1014,170 @@ end
             @test string(scoped) == "[::1%7]:1"
         end
     end
+
+@testset "TCP stdlib-parity additions" begin
+    @testset "single-string listen" begin
+        listener = TCP.listen("127.0.0.1:0"; backlog = 64)
+        addr = TCP.addr(listener)
+        @test addr isa TCP.SocketAddrV4
+        @test addr.port != 0
+        conn = TCP.connect(addr)
+        server = TCP.accept(listener)
+        write(conn, b"shorthand")
+        buf = Vector{UInt8}(undef, 9)
+        read!(server, buf)
+        @test buf == b"shorthand"
+        close(conn)
+        close(server)
+        close(listener)
+    end
+
+    @testset "listenany" begin
+        taken = TCP.listen(TCP.loopback_addr(0))
+        hint_port = Int((TCP.addr(taken)::TCP.SocketAddrV4).port)
+        port, listener = TCP.listenany(TCP.loopback_addr(hint_port))
+        @test port != hint_port
+        @test isopen(listener)
+        conn = TCP.connect(TCP.loopback_addr(Int(port)))
+        server = TCP.accept(listener)
+        close(conn)
+        close(server)
+        close(listener)
+        close(taken)
+
+        eport, elistener = TCP.listenany(TCP.loopback_addr(0))
+        @test eport != 0
+        close(elistener)
+    end
+
+    @testset "keepalive tuning" begin
+        listener = TCP.listen(TCP.loopback_addr(0))
+        conn = TCP.connect(TCP.addr(listener))
+        server = TCP.accept(listener)
+        TCP.set_keepalive!(conn, true; idle_secs = 30, interval_secs = 7, count = 3)
+        sysfd = conn.fd.pfd.sysfd
+        @test Reseau.SocketOps.get_sockopt_int(sysfd, Reseau.SocketOps.SOL_SOCKET, Reseau.SocketOps.SO_KEEPALIVE) != 0
+        @test Reseau.SocketOps.get_sockopt_int(sysfd, Reseau.SocketOps.IPPROTO_TCP, Reseau.SocketOps.TCP_KEEPIDLE) == 30
+        @test Reseau.SocketOps.get_sockopt_int(sysfd, Reseau.SocketOps.IPPROTO_TCP, Reseau.SocketOps.TCP_KEEPINTVL) == 7
+        @test Reseau.SocketOps.get_sockopt_int(sysfd, Reseau.SocketOps.IPPROTO_TCP, Reseau.SocketOps.TCP_KEEPCNT) == 3
+        TCP.set_keepalive!(conn, false)
+        @test Reseau.SocketOps.get_sockopt_int(sysfd, Reseau.SocketOps.SOL_SOCKET, Reseau.SocketOps.SO_KEEPALIVE) == 0
+        @test_throws ArgumentError TCP.set_keepalive!(conn; idle_secs = 0)
+        @test_throws ArgumentError TCP.set_keepalive!(conn; interval_secs = -1)
+        @test_throws ArgumentError TCP.set_keepalive!(conn; count = 0)
+        close(conn)
+        close(server)
+        close(listener)
+    end
+
+    @testset "linger" begin
+        listener = TCP.listen(TCP.loopback_addr(0))
+        conn = TCP.connect(TCP.addr(listener))
+        server = TCP.accept(listener)
+        sysfd = conn.fd.pfd.sysfd
+        read_linger = () -> begin
+            lg = Ref(Reseau.SocketOps.Linger(0, 0))
+            GC.@preserve lg Reseau.SocketOps.get_sockopt_bytes!(
+                sysfd,
+                Reseau.SocketOps.SOL_SOCKET,
+                Reseau.SocketOps.SO_LINGER,
+                Ptr{Cvoid}(Base.unsafe_convert(Ptr{Reseau.SocketOps.Linger}, lg)),
+                sizeof(Reseau.SocketOps.Linger),
+            )
+            lg[]
+        end
+        TCP.set_linger!(conn, 4)
+        lg = read_linger()
+        @test lg.l_onoff != 0
+        @test lg.l_linger == 4
+        TCP.set_linger!(conn, -1)
+        @test read_linger().l_onoff == 0
+        TCP.set_linger!(conn, 0)
+        lg = read_linger()
+        @test lg.l_onoff != 0
+        @test lg.l_linger == 0
+        TCP.set_linger!(conn, -1)
+        @test_throws ArgumentError TCP.set_linger!(conn, 65536)
+        close(conn)
+        close(server)
+        close(listener)
+    end
+
+    @testset "buffer sizes" begin
+        listener = TCP.listen(TCP.loopback_addr(0))
+        conn = TCP.connect(TCP.addr(listener))
+        server = TCP.accept(listener)
+        sysfd = conn.fd.pfd.sysfd
+        TCP.set_read_buffer!(conn, 65536)
+        TCP.set_write_buffer!(conn, 65536)
+        # Kernels may round or (Linux) double the requested size, but never
+        # shrink below the request.
+        @test Reseau.SocketOps.get_sockopt_int(sysfd, Reseau.SocketOps.SOL_SOCKET, Reseau.SocketOps.SO_RCVBUF) >= 65536
+        @test Reseau.SocketOps.get_sockopt_int(sysfd, Reseau.SocketOps.SOL_SOCKET, Reseau.SocketOps.SO_SNDBUF) >= 65536
+        @test_throws ArgumentError TCP.set_read_buffer!(conn, 0)
+        @test_throws ArgumentError TCP.set_write_buffer!(conn, -1)
+        close(conn)
+        close(server)
+        close(listener)
+    end
+
+    @testset "quickack" begin
+        listener = TCP.listen(TCP.loopback_addr(0))
+        conn = TCP.connect(TCP.addr(listener))
+        server = TCP.accept(listener)
+        TCP.set_quickack!(conn)
+        TCP.set_quickack!(conn, false)
+        @static if Sys.islinux()
+            TCP.set_quickack!(conn, true)
+            @test Reseau.SocketOps.get_sockopt_int(
+                conn.fd.pfd.sysfd,
+                Reseau.SocketOps.IPPROTO_TCP,
+                Reseau.SocketOps.TCP_QUICKACK,
+            ) != 0
+        end
+        close(conn)
+        close(server)
+        close(listener)
+    end
+
+    @testset "rawfd" begin
+        listener = TCP.listen(TCP.loopback_addr(0))
+        conn = TCP.connect(TCP.addr(listener))
+        server = TCP.accept(listener)
+        raw = TCP.rawfd(conn)
+        lraw = TCP.rawfd(listener)
+        @static if Sys.iswindows()
+            @test raw isa Base.WindowsRawSocket
+            @test lraw isa Base.WindowsRawSocket
+        else
+            @test raw isa RawFD
+            @test lraw isa RawFD
+            @test raw != lraw
+        end
+        close(conn)
+        @test_throws Reseau.IOPoll.NetClosingError TCP.rawfd(conn)
+        close(server)
+        close(listener)
+    end
+
+    @testset "finalizer reclaims leaked descriptors" begin
+        listener = TCP.listen(TCP.loopback_addr(0))
+        conn = TCP.connect(TCP.addr(listener))
+        server = TCP.accept(listener)
+        # Trigger the GC safety net deterministically. The finalizer schedules
+        # the blocking close on a task; spin-yield until it lands (park
+        # detection pattern from test/README.md).
+        finalize(conn.fd)
+        while isopen(conn)
+            yield()
+        end
+        @test !isopen(conn)
+        close(conn)  # explicit close after finalizer-close stays idempotent
+
+        # A finalizer firing after an explicit close is a no-op.
+        close(server)
+        finalize(server.fd)
+        @test !isopen(server)
+        close(listener)
+    end
+end


### PR DESCRIPTION
## What

The P0 gap-closure items from the Sockets-vs-Reseau replacement audit, as a single focused PR (independent of the UDP work in #148):

- **`TCP.listen("host:port")`** — the single-string shorthand the README and resolution docs already advertise now exists instead of MethodErroring (`connect` had it; `listen` didn't). Chose implementation over doc removal: it mirrors `connect(address)` and the docs were right about what the API *should* be.
- **netFD finalizer** — a GC safety net mirroring Go's `runtime.SetFinalizer((*netFD).Close)` and the libuv finalizer behind `Sockets.TCPSocket`: a leaked `Conn`/`Listener` no longer leaks its descriptor. Finalizers can't task-switch and a full close takes poller locks and drains in-flight ops, so the finalizer schedules the real close on a task. The finalizer is attached to the poll FD retained by active operations, so it cannot close a descriptor that is still in use after the TCP metadata wrapper's last field access. Explicit `close` remains the documented path.
- **Keepalive tuning** — `set_keepalive!(conn, enabled; idle_secs, interval_secs, count)`, the shape of Go's `KeepAliveConfig`, with per-OS constants (Darwin's `TCP_KEEPALIVE` spelling for idle; the modern Windows `TCP_KEEP*` setsockopt names). This retires the raw `uv_tcp_keepalive` ccall HTTP 1.x does today.
- **`set_linger!`** — Go `SetLinger` semantics (negative disables, `0` = RST discard, positive asks the OS to continue sending and may block `close` on some systems). Backed by a new byte-buffer sockopt layer (`set_sockopt_bytes`/`get_sockopt_bytes!` on all three backends, plus a platform `Linger` struct honoring Windows' `u_short` layout) — the same plumbing multicast joins will need later.
- **`set_read_buffer!` / `set_write_buffer!`** — `SO_RCVBUF`/`SO_SNDBUF`.
- **`set_quickack!`** — `TCP_QUICKACK` on Linux, silent no-op elsewhere matching `Sockets.quickack`, so Distributed-style callers need no platform guard.
- **`listenany(hint) -> (port, listener)`** — the Sockets ephemeral-port idiom (HTTP, IJulia, GR, Distributed), skipping `EADDRINUSE`/`EACCES` ports upward from the hint.
- **`rawfd(conn)` / `rawfd(listener)`** — public accessor for the OS descriptor (`RawFD` on POSIX, `Base.WindowsRawSocket` on Windows) with documented borrowed-lifetime and ownership rules; throws `NetClosingError` on a closing socket.

## Tests

Deterministic assertions in `tcp_tests.jl` cover platform constants and `Linger` layouts, the string-listen round trip, `listenany` port bumping plus both hint-0 forms, getsockopt roundtrip verification for every option, invalid-option atomicity, closed-socket behavior, `rawfd` types and post-close `NetClosingError`, and deterministic `finalize()`-driven leak reclamation using the repo's spin-yield park-detection pattern.

## Notes for review

- The finalizer attaches in `_new_netfd`, so outbound, listener, and accepted sockets all get it.
- `set_sockopt_bytes` intentionally lands in this PR rather than a multicast follow-up so `SO_LINGER` doesn't block on it; the UDP branch can reuse it.
- No listener variants of the option setters yet (Distributed calls `nagle`/`quickack` on servers too) — easy follow-up if wanted, kept out to hold scope.

Co-authored by Codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)
