### PR TITLE
Fetch the TLS 1.3 client certificate at CertificateRequest time like Go

### DIFF
--- a/src/5_tls.jl
+++ b/src/5_tls.jl
@@ -1294,12 +1294,7 @@ function _native_tls13_client_handshake!(conn::Conn)::Nothing
     native_state = _native_tls13_state(conn)
     io = _TLS13HandshakeRecordIO(conn.tcp, native_state)
     try
-        identity = _tls_local_identity(conn.config; is_server = false)
-        if identity !== nothing
-            state.client_certificate_chain = copy((identity::_TLSLocalIdentity).certificate_chain)
-            state.client_private_key = identity.private_key
-        end
-        _client_handshake_tls13!(state, io)
+        _client_handshake_tls13!(state, io, conn.config)
         _finish_native_tls13_client_handshake!(conn, state, cache_key)
     finally
         _securezero_tls13_client_handshake_state!(state)
@@ -1435,14 +1430,6 @@ function _native_tls_auto_client_handshake!(conn::Conn)::Nothing
     native_state13 = _native_tls13_state(conn)
     io13 = _TLS13HandshakeRecordIO(conn.tcp, native_state13)
     try
-        # The TLS 1.3 continuation signs CertificateVerify from this state, so the local
-        # identity has to be loaded before the peer can pick that version; the TLS 1.2
-        # continuation loads its own from `conn.config`.
-        identity = _tls_local_identity(conn.config; is_server = false)
-        if identity !== nothing
-            state13.client_certificate_chain = copy((identity::_TLSLocalIdentity).certificate_chain)
-            state13.client_private_key = identity.private_key
-        end
         _write_client_hello!(state13, io13)
         raw_server_hello = _read_handshake_bytes!(io13)
         parsed_server_hello = _unmarshal_handshake_message_or_fail(raw_server_hello)
@@ -1456,7 +1443,7 @@ function _native_tls_auto_client_handshake!(conn::Conn)::Nothing
         native_state13.version = negotiated_version
         if negotiated_version == TLS1_3_VERSION
             _check_server_hello_or_hrr!(state13)
-            _client_handshake_tls13_after_server_hello!(state13, io13)
+            _client_handshake_tls13_after_server_hello!(state13, io13, conn.config)
             _finish_native_tls13_client_handshake!(conn, state13, cache_key)
             return nothing
         end

--- a/src/5_tls.jl
+++ b/src/5_tls.jl
@@ -1435,6 +1435,14 @@ function _native_tls_auto_client_handshake!(conn::Conn)::Nothing
     native_state13 = _native_tls13_state(conn)
     io13 = _TLS13HandshakeRecordIO(conn.tcp, native_state13)
     try
+        # The TLS 1.3 continuation signs CertificateVerify from this state, so the local
+        # identity has to be loaded before the peer can pick that version; the TLS 1.2
+        # continuation loads its own from `conn.config`.
+        identity = _tls_local_identity(conn.config; is_server = false)
+        if identity !== nothing
+            state13.client_certificate_chain = copy((identity::_TLSLocalIdentity).certificate_chain)
+            state13.client_private_key = identity.private_key
+        end
         _write_client_hello!(state13, io13)
         raw_server_hello = _read_handshake_bytes!(io13)
         parsed_server_hello = _unmarshal_handshake_message_or_fail(raw_server_hello)

--- a/src/tls/handshake_client_tls12.jl
+++ b/src/tls/handshake_client_tls12.jl
@@ -514,6 +514,7 @@ function _tls12_prepare_client_identity!(state::_TLS12ClientHandshakeState, conf
         in(certificate_type, state.certificate_request.certificate_types) || return nothing
         signature_algorithm = _tls12_select_signature_algorithm(private_key, state.certificate_request.supported_signature_algorithms)
         signature_algorithm === nothing && return nothing
+        _tls_chain_signed_by_acceptable_ca(certificate_chain, state.certificate_request.certificate_authorities) || return nothing
         state.client_certificate_chain = certificate_chain
         state.client_private_key = private_key
         state.client_signature_algorithm = signature_algorithm

--- a/src/tls/handshake_client_tls13.jl
+++ b/src/tls/handshake_client_tls13.jl
@@ -258,34 +258,38 @@ function _tls13_verify_server_certificate_signature!(verifier::_TLS13OpenSSLCert
     return nothing
 end
 
-function _tls_select_signature_algorithm(pkey::Ptr{Cvoid}, supported_signature_algorithms::AbstractVector{UInt16})::UInt16
+# Mirrors Go's signatureSchemesForPublicKey at TLS 1.3: PKCS#1 v1.5 is gone and
+# each ECDSA scheme is bound to one curve. An unsupported local key type or curve
+# is a configuration error rather than a negotiation outcome, so it raises.
+function _tls13_signature_schemes_for_pkey(pkey::Ptr{Cvoid})::Vector{UInt16}
     pkey_type = _tls13_pkey_type_name(pkey)
     if pkey_type == "RSA"
-        for alg in (
-                _TLS_SIGNATURE_RSA_PSS_RSAE_SHA256,
-                _TLS_SIGNATURE_RSA_PSS_RSAE_SHA384,
-                _TLS_SIGNATURE_RSA_PSS_RSAE_SHA512,
-            )
-            in(alg, supported_signature_algorithms) && return alg
-        end
+        return UInt16[
+            _TLS_SIGNATURE_RSA_PSS_RSAE_SHA256,
+            _TLS_SIGNATURE_RSA_PSS_RSAE_SHA384,
+            _TLS_SIGNATURE_RSA_PSS_RSAE_SHA512,
+        ]
     elseif pkey_type == "EC"
         curve_nid = _tls13_ec_group_curve_nid(pkey)
-        if curve_nid == _init_p256_group_nid!()
-            in(_TLS_SIGNATURE_ECDSA_SECP256R1_SHA256, supported_signature_algorithms) &&
-                return _TLS_SIGNATURE_ECDSA_SECP256R1_SHA256
-        elseif curve_nid == _init_p384_group_nid!()
-            in(_TLS_SIGNATURE_ECDSA_SECP384R1_SHA384, supported_signature_algorithms) &&
-                return _TLS_SIGNATURE_ECDSA_SECP384R1_SHA384
-        elseif curve_nid == _init_p521_group_nid!()
-            in(_TLS_SIGNATURE_ECDSA_SECP521R1_SHA512, supported_signature_algorithms) &&
-                return _TLS_SIGNATURE_ECDSA_SECP521R1_SHA512
-        else
-            throw(ArgumentError("tls: unsupported EC certificate curve $(curve_nid) for TLS 1.3 signature selection"))
-        end
+        curve_nid == _init_p256_group_nid!() && return UInt16[_TLS_SIGNATURE_ECDSA_SECP256R1_SHA256]
+        curve_nid == _init_p384_group_nid!() && return UInt16[_TLS_SIGNATURE_ECDSA_SECP384R1_SHA384]
+        curve_nid == _init_p521_group_nid!() && return UInt16[_TLS_SIGNATURE_ECDSA_SECP521R1_SHA512]
+        throw(ArgumentError("tls: unsupported EC certificate curve $(curve_nid) for TLS 1.3 signature selection"))
     elseif pkey_type == "ED25519"
-        in(_TLS_SIGNATURE_ED25519, supported_signature_algorithms) && return _TLS_SIGNATURE_ED25519
+        return UInt16[_TLS_SIGNATURE_ED25519]
     end
-    throw(ArgumentError("tls: peer does not support a usable TLS 1.3 certificate signature algorithm"))
+    throw(ArgumentError("tls: unsupported TLS 1.3 certificate key type $(pkey_type)"))
+end
+
+# Mirrors Go's selectSignatureScheme: pick in the peer's preference order, as our
+# own order is not configurable. `nothing` means the peer cannot use this key;
+# the server treats that as fatal and the client withholds its certificate.
+function _tls_select_signature_algorithm(pkey::Ptr{Cvoid}, peer_signature_algorithms::AbstractVector{UInt16})::Union{Nothing, UInt16}
+    supported = _tls13_signature_schemes_for_pkey(pkey)
+    for alg in peer_signature_algorithms
+        in(alg, supported) && return alg
+    end
+    return nothing
 end
 
 function _securezero_tls13_key_share_provider!(provider::_TLS13OpenSSLKeyShareProvider)::Nothing
@@ -827,19 +831,36 @@ function _read_server_finished!(state::_TLS13ClientHandshakeState, io)::Nothing
     return nothing
 end
 
-function _send_client_certificate!(state::_TLS13ClientHandshakeState, io)::Nothing
-    state.have_certificate_request || return nothing
-    msg = if isempty(state.client_certificate_chain)
-        _CertificateMsgTLS13()
-    else
-        out = _CertificateMsgTLS13()
-        out.certificates = [copy(cert) for cert in state.client_certificate_chain]
-        state.client_signature_algorithm = _tls_select_signature_algorithm(
-            state.client_private_key,
-            state.certificate_request.supported_signature_algorithms,
-        )
-        out
+# Mirrors Go's getClientCertificate plus CertificateRequestInfo.SupportsCertificate:
+# the local identity is fetched from `config` only once the server has asked for
+# it, and it is withheld (an empty Certificate follows) when the request's
+# signature_algorithms cannot use its key or, when the request names acceptable
+# CAs, no certificate in the chain was issued by one of them.
+function _tls13_prepare_client_identity!(state::_TLS13ClientHandshakeState, config)::Nothing
+    identity = _tls_local_identity(config; is_server = false)
+    identity === nothing && return nothing
+    certificate_chain = copy((identity::_TLSLocalIdentity).certificate_chain)
+    private_key = identity.private_key
+    keep_identity = false
+    try
+        signature_algorithm = _tls_select_signature_algorithm(private_key, state.certificate_request.supported_signature_algorithms)
+        signature_algorithm === nothing && return nothing
+        _tls_chain_signed_by_acceptable_ca(certificate_chain, state.certificate_request.certificate_authorities) || return nothing
+        state.client_certificate_chain = certificate_chain
+        state.client_private_key = private_key
+        state.client_signature_algorithm = signature_algorithm::UInt16
+        keep_identity = true
+        return nothing
+    finally
+        keep_identity || _free_evp_pkey!(private_key)
     end
+end
+
+function _send_client_certificate!(state::_TLS13ClientHandshakeState, io, config)::Nothing
+    state.have_certificate_request || return nothing
+    _tls13_prepare_client_identity!(state, config)
+    msg = _CertificateMsgTLS13()
+    msg.certificates = [copy(cert) for cert in state.client_certificate_chain]
     state.client_certificate = msg
     state.have_client_certificate = true
     raw = _marshal_certificate_tls13(msg)
@@ -891,7 +912,7 @@ function _read_post_handshake_messages!(state::_TLS13ClientHandshakeState, io)::
     return nothing
 end
 
-function _client_handshake_tls13_after_server_hello!(state::_TLS13ClientHandshakeState, io)::Nothing
+function _client_handshake_tls13_after_server_hello!(state::_TLS13ClientHandshakeState, io, config)::Nothing
     _tls_set_negotiated_record_version!(io, TLS1_3_VERSION)
     if state.server_hello.random == _HELLO_RETRY_REQUEST_RANDOM
         _tls13_send_dummy_change_cipher_spec!(io)
@@ -910,7 +931,7 @@ function _client_handshake_tls13_after_server_hello!(state::_TLS13ClientHandshak
     _read_server_certificate!(state, io)
     _read_server_finished!(state, io)
     _tls13_on_server_finished!(io, state)
-    _send_client_certificate!(state, io)
+    _send_client_certificate!(state, io, config)
     _send_client_finished!(state, io)
     _tls13_on_client_finished!(io, state)
     state.complete = true
@@ -918,9 +939,9 @@ function _client_handshake_tls13_after_server_hello!(state::_TLS13ClientHandshak
     return nothing
 end
 
-function _client_handshake_tls13!(state::_TLS13ClientHandshakeState, io)::Nothing
+function _client_handshake_tls13!(state::_TLS13ClientHandshakeState, io, config)::Nothing
     state.complete && throw(ArgumentError("tls13 client handshake already complete"))
     _write_client_hello!(state, io)
     _read_server_hello!(state, io)
-    return _client_handshake_tls13_after_server_hello!(state, io)
+    return _client_handshake_tls13_after_server_hello!(state, io, config)
 end

--- a/src/tls/handshake_common.jl
+++ b/src/tls/handshake_common.jl
@@ -71,3 +71,22 @@ function _tls_server_session_client_auth_ok(
     end
     return true
 end
+
+# The acceptable-CA half of Go's CertificateRequestInfo.SupportsCertificate: an
+# empty certificate_authorities list accepts any chain, otherwise some certificate
+# in the chain must have been issued by one of the named CAs. Unlike Go, a local
+# certificate our parser cannot read raises instead of silently withholding the
+# identity: that is a misconfiguration, not a negotiation outcome.
+function _tls_chain_signed_by_acceptable_ca(
+    certificate_chain::Vector{Vector{UInt8}},
+    acceptable_cas::Vector{Vector{UInt8}},
+)::Bool
+    isempty(acceptable_cas) && return true
+    for cert_der in certificate_chain
+        issuer_raw = _tls_parse_der_certificate_info(cert_der).issuer_raw
+        for ca in acceptable_cas
+            issuer_raw == ca && return true
+        end
+    end
+    return false
+end

--- a/src/tls/handshake_server_tls13.jl
+++ b/src/tls/handshake_server_tls13.jl
@@ -301,7 +301,12 @@ function _tls13_select_server_cipher_suite(client_hello::_ClientHelloMsg)::_TLS1
 end
 
 function _tls13_select_server_signature_algorithm(pkey::Ptr{Cvoid}, client_hello::_ClientHelloMsg)::UInt16
-    return _tls_select_signature_algorithm(pkey, client_hello.supported_signature_algorithms)
+    signature_algorithm = _tls_select_signature_algorithm(pkey, client_hello.supported_signature_algorithms)
+    # Go's pickCertificate: a certificate the client's signature_algorithms
+    # cannot use is a handshake_failure, not an internal error.
+    signature_algorithm === nothing &&
+        _tls_fail(_TLS_ALERT_HANDSHAKE_FAILURE, "tls: peer doesn't support any of the certificate's signature algorithms")
+    return signature_algorithm::UInt16
 end
 
 function _tls13_find_client_key_share(client_hello::_ClientHelloMsg, group::UInt16)::Union{Nothing, _TLSKeyShare}

--- a/test/tls_handshake_client_tls13_tests.jl
+++ b/test/tls_handshake_client_tls13_tests.jl
@@ -7,6 +7,8 @@ const _TLS_KEY_PATH = joinpath(@__DIR__, "resources", "unittests.key")
 const _TLS13_TEST_CERT_PEM = read(_TLS_CERT_PATH)
 const _TLS13_TEST_KEY_PEM = read(_TLS_KEY_PATH)
 const _TLS13_TEST_CERT_DER = TLHC._tls13_openssl_certificate_der(_TLS13_TEST_CERT_PEM)
+const _TLS13_TEST_NO_IDENTITY_CONFIG = TLHC.Config()
+const _TLS13_TEST_IDENTITY_CONFIG = TLHC.Config(cert_file = _TLS_CERT_PATH, key_file = _TLS_KEY_PATH)
 const _TLS13_TEST_CLIENT_X25519_PRIVATE_KEY = UInt8[
     0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
     0x10, 0x32, 0x54, 0x76, 0x98, 0xba, 0xdc, 0xfe,
@@ -305,7 +307,7 @@ end
 function _compute_tls13_real_certificate_server_flight(
     client_hello::TLHC._ClientHelloMsg;
     hello_retry::Bool = false,
-    certificate_request::Bool = false,
+    certificate_request::Union{Nothing, TLHC._CertificateRequestMsgTLS13} = nothing,
     key_share_provider = _tls13_openssl_key_share_provider(include_p256 = hello_retry),
 )
     TLHC._tls13_prepare_initial_client_hello!(key_share_provider, client_hello)
@@ -347,9 +349,8 @@ function _compute_tls13_real_certificate_server_flight(
     push!(inbound, encrypted_extensions_bytes)
     TLHC._transcript_update!(transcript, encrypted_extensions_bytes)
 
-    cert_req = nothing
-    if certificate_request
-        cert_req = _tls13_server_certificate_request()
+    cert_req = certificate_request
+    if cert_req !== nothing
         cert_req_bytes = TLHC._marshal_handshake_message(cert_req)
         push!(inbound, cert_req_bytes)
         TLHC._transcript_update!(transcript, cert_req_bytes)
@@ -379,7 +380,7 @@ function _compute_tls13_real_certificate_server_flight(
     TLHC._transcript_update!(transcript_for_client, transcript_bytes)
 
     client_certificate_bytes = nothing
-    if certificate_request
+    if cert_req !== nothing
         client_certificate_bytes = TLHC._marshal_certificate_tls13(TLHC._CertificateMsgTLS13())
         TLHC._transcript_update!(transcript_for_client, client_certificate_bytes)
         push!(outbound, client_certificate_bytes)
@@ -513,10 +514,26 @@ end
             @test TLHC._tls_select_signature_algorithm(p256_cert_pkey, offered_ecdsa) == TLHC._TLS_SIGNATURE_ECDSA_SECP256R1_SHA256
             @test TLHC._tls_select_signature_algorithm(p384_cert_pkey, offered_ecdsa) == TLHC._TLS_SIGNATURE_ECDSA_SECP384R1_SHA384
             @test TLHC._tls_select_signature_algorithm(p521_cert_pkey, offered_ecdsa) == TLHC._TLS_SIGNATURE_ECDSA_SECP521R1_SHA512
-            @test_throws ArgumentError TLHC._tls_select_signature_algorithm(
+            # Go's selectSignatureScheme: no usable scheme is a negotiation outcome, not an error.
+            @test TLHC._tls_select_signature_algorithm(
                 p384_cert_pkey,
                 UInt16[TLHC._TLS_SIGNATURE_ECDSA_SECP256R1_SHA256],
-            )
+            ) === nothing
+            rsa_cert_pkey = (TLHC._tls_local_identity(_TLS13_TEST_IDENTITY_CONFIG; is_server = false)::TLHC._TLSLocalIdentity).private_key
+            try
+                # Picked in the peer's preference order, not ours.
+                @test TLHC._tls_select_signature_algorithm(
+                    rsa_cert_pkey,
+                    UInt16[TLHC._TLS_SIGNATURE_RSA_PSS_RSAE_SHA384, TLHC._TLS_SIGNATURE_RSA_PSS_RSAE_SHA256],
+                ) == TLHC._TLS_SIGNATURE_RSA_PSS_RSAE_SHA384
+                # PKCS#1 v1.5 is not a TLS 1.3 signature scheme.
+                @test TLHC._tls_select_signature_algorithm(
+                    rsa_cert_pkey,
+                    UInt16[TLHC._TLS_SIGNATURE_RSA_PKCS1_SHA256, TLHC._TLS_SIGNATURE_ECDSA_SECP256R1_SHA256],
+                ) === nothing
+            finally
+                TLHC._free_evp_pkey!(rsa_cert_pkey)
+            end
 
             signed = collect(UInt8(0x10):UInt8(0x4f))
             signature = TLHC._tls13_openssl_sign_from_pem(TLHC._TLS_SIGNATURE_RSA_PSS_RSAE_SHA256, signed, _TLS13_TEST_KEY_PEM)
@@ -547,7 +564,7 @@ end
 
         state = _tls13_psk_handshake_state(_tls13_psk_client_hello(), psk)
         io = _HandshakeMessageFlightIO(expected.inbound)
-        TLHC._client_handshake_tls13!(state, io)
+        TLHC._client_handshake_tls13!(state, io, _TLS13_TEST_NO_IDENTITY_CONFIG)
 
         @test state.complete
         @test state.using_psk
@@ -581,7 +598,7 @@ end
             psk,
         )
         io = _HandshakeMessageFlightIO(expected.inbound)
-        TLHC._client_handshake_tls13!(state, io)
+        TLHC._client_handshake_tls13!(state, io, _TLS13_TEST_NO_IDENTITY_CONFIG)
 
         @test state.complete
         @test state.using_psk
@@ -601,7 +618,7 @@ end
 
         state = TLHC._TLS13ClientHandshakeState(client_hello, TLHC._TLS13_AES_128_GCM_SHA256_ID, key_share_provider, _tls13_certificate_verifier())
         io = _HandshakeMessageFlightIO(expected.inbound)
-        TLHC._client_handshake_tls13!(state, io)
+        TLHC._client_handshake_tls13!(state, io, _TLS13_TEST_NO_IDENTITY_CONFIG)
 
         @test state.complete
         @test !state.using_psk
@@ -626,12 +643,12 @@ end
         expected = _compute_tls13_real_certificate_server_flight(
             _tls13_cert_client_hello(supported_curves = UInt16[0x001d, 0x0017]);
             hello_retry = true,
-            certificate_request = true,
+            certificate_request = _tls13_server_certificate_request(),
         )
 
         state = TLHC._TLS13ClientHandshakeState(client_hello, TLHC._TLS13_AES_128_GCM_SHA256_ID, key_share_provider, _tls13_certificate_verifier())
         io = _HandshakeMessageFlightIO(expected.inbound)
-        TLHC._client_handshake_tls13!(state, io)
+        TLHC._client_handshake_tls13!(state, io, _TLS13_TEST_NO_IDENTITY_CONFIG)
 
         @test state.complete
         @test !state.using_psk
@@ -642,6 +659,101 @@ end
         @test io.outbound == expected.outbound
         @test length(io.outbound) == 4
         @test state.peer_new_session_tickets == [expected.ticket]
+    end
+
+    @testset "client identity is fetched from the config at CertificateRequest time" begin
+        # Mirrors Go's getClientCertificate/SupportsCertificate: the identity is
+        # looked up only once the server asks for it, and withheld when the
+        # request's signature_algorithms or acceptable CAs cannot use it.
+        own_subject = TLHC._tls_parse_der_certificate_info(_TLS13_TEST_CERT_DER).subject_raw  # self-signed
+        other_ca = TLHC._tls_parse_der_certificate_info(
+            TLHC._tls13_openssl_certificate_der(read(joinpath(@__DIR__, "resources", "native_tls_ca.crt"))),
+        ).subject_raw
+
+        function certificate_request_with(;
+            signature_algorithms::Vector{UInt16} = UInt16[TLHC._TLS_SIGNATURE_RSA_PSS_RSAE_SHA256],
+            authorities::Vector{Vector{UInt8}} = Vector{UInt8}[],
+        )
+            msg = TLHC._CertificateRequestMsgTLS13()
+            msg.supported_signature_algorithms = signature_algorithms
+            msg.supported_signature_algorithms_cert = copy(signature_algorithms)
+            msg.certificate_authorities = authorities
+            return msg
+        end
+
+        function run_client(config, cert_req)
+            expected = _compute_tls13_real_certificate_server_flight(_tls13_cert_client_hello(); certificate_request = cert_req)
+            state = TLHC._TLS13ClientHandshakeState(
+                _tls13_cert_client_hello(),
+                TLHC._TLS13_AES_128_GCM_SHA256_ID,
+                _tls13_openssl_key_share_provider(),
+                _tls13_certificate_verifier(),
+            )
+            io = _HandshakeMessageFlightIO(expected.inbound)
+            try
+                TLHC._client_handshake_tls13!(state, io, config)
+                @test state.complete
+                @test state.have_certificate_request
+                # Snapshot before securezero: the outbound ClientHello aliases state.client_hello_raw.
+                outbound = [copy(raw) for raw in io.outbound]
+                return expected, outbound, copy(state.client_certificate_chain), state.client_signature_algorithm
+            finally
+                TLHC._securezero_tls13_client_handshake_state!(state)
+            end
+        end
+
+        @testset "presented when the request accepts it: $label" for (label, cert_req) in (
+            ("no acceptable CAs named", certificate_request_with()),
+            ("issued by an acceptable CA", certificate_request_with(authorities = [copy(own_subject)])),
+            (
+                "peer preference order",
+                certificate_request_with(
+                    signature_algorithms = UInt16[TLHC._TLS_SIGNATURE_RSA_PSS_RSAE_SHA384, TLHC._TLS_SIGNATURE_RSA_PSS_RSAE_SHA256],
+                ),
+            ),
+        )
+            expected, outbound, chain, signature_algorithm = run_client(_TLS13_TEST_IDENTITY_CONFIG, cert_req)
+            @test chain == [_TLS13_TEST_CERT_DER]
+            @test signature_algorithm == cert_req.supported_signature_algorithms[1]
+            # ClientHello, Certificate, CertificateVerify, Finished.
+            @test length(outbound) == 4
+            certificate = TLHC._unmarshal_certificate_tls13(outbound[2])
+            @test certificate !== nothing
+            certificate === nothing || @test certificate.certificates == [_TLS13_TEST_CERT_DER]
+            verify = TLHC._unmarshal_certificate_verify(outbound[3])
+            @test verify !== nothing
+            if verify !== nothing
+                @test verify.signature_algorithm == signature_algorithm
+                # CertificateVerify signs the transcript through the client Certificate.
+                transcript = TLHC._TranscriptHash(TLHC._HASH_SHA256)
+                TLHC._transcript_update!(transcript, outbound[1])
+                for raw in expected.inbound[1:6]
+                    TLHC._transcript_update!(transcript, raw)
+                end
+                TLHC._transcript_update!(transcript, outbound[2])
+                signed = TLHC._tls13_signed_message(TLHC._TLS13_CLIENT_SIGNATURE_CONTEXT, transcript)
+                pubkey = TLHC._tls_parse_der_certificate_info(_TLS13_TEST_CERT_DER).public_key
+                @test TLHC._tls13_openssl_verify_signature(pubkey, verify.signature_algorithm, signed, verify.signature)
+            end
+        end
+
+        @testset "withheld when the request cannot use it: $label" for (label, cert_req) in (
+            ("no usable signature algorithm", certificate_request_with(signature_algorithms = UInt16[TLHC._TLS_SIGNATURE_ECDSA_SECP256R1_SHA256])),
+            ("not issued by an acceptable CA", certificate_request_with(authorities = [copy(other_ca)])),
+        )
+            expected, outbound, chain, signature_algorithm = run_client(_TLS13_TEST_IDENTITY_CONFIG, cert_req)
+            @test isempty(chain)
+            @test signature_algorithm == UInt16(0)
+            # An empty Certificate and no CertificateVerify: byte-for-byte what a
+            # client without an identity sends.
+            @test outbound == expected.outbound
+        end
+
+        @testset "absent when the config has no identity" begin
+            expected, outbound, chain, _ = run_client(_TLS13_TEST_NO_IDENTITY_CONFIG, certificate_request_with())
+            @test isempty(chain)
+            @test outbound == expected.outbound
+        end
     end
 
     @testset "HelloRetryRequest drops PSK binders when the selected suite hash changes" begin
@@ -915,7 +1027,7 @@ end
         io = _HandshakeMessageFlightIO(inbound)
 
         err = try
-            TLHC._client_handshake_tls13!(state, io)
+            TLHC._client_handshake_tls13!(state, io, _TLS13_TEST_NO_IDENTITY_CONFIG)
             nothing
         catch ex
             ex
@@ -942,7 +1054,7 @@ end
         io = _HandshakeMessageFlightIO(inbound)
 
         err = try
-            TLHC._client_handshake_tls13!(state, io)
+            TLHC._client_handshake_tls13!(state, io, _TLS13_TEST_NO_IDENTITY_CONFIG)
             nothing
         catch ex
             ex
@@ -976,7 +1088,7 @@ end
         )
         io = _HandshakeMessageFlightIO(inbound)
         err = try
-            TLHC._client_handshake_tls13!(state, io)
+            TLHC._client_handshake_tls13!(state, io, _TLS13_TEST_NO_IDENTITY_CONFIG)
             nothing
         catch ex
             ex
@@ -1013,7 +1125,7 @@ end
         )
         io = _HandshakeMessageFlightIO(inbound)
         err = try
-            TLHC._client_handshake_tls13!(state, io)
+            TLHC._client_handshake_tls13!(state, io, _TLS13_TEST_NO_IDENTITY_CONFIG)
             nothing
         catch ex
             ex
@@ -1039,7 +1151,7 @@ end
         io = _HandshakeMessageFlightIO(inbound)
 
         err = try
-            TLHC._client_handshake_tls13!(state, io)
+            TLHC._client_handshake_tls13!(state, io, _TLS13_TEST_NO_IDENTITY_CONFIG)
             nothing
         catch ex
             ex
@@ -1061,7 +1173,7 @@ end
         state = _tls13_psk_handshake_state(_tls13_psk_client_hello(), psk)
 
         err = try
-            TLHC._client_handshake_tls13!(state, io)
+            TLHC._client_handshake_tls13!(state, io, _TLS13_TEST_NO_IDENTITY_CONFIG)
             nothing
         catch ex
             ex

--- a/test/tls_native_tls13_tests.jl
+++ b/test/tls_native_tls13_tests.jl
@@ -273,6 +273,31 @@ end
         end
     end
 
+    @testset "server fails the handshake when the client cannot use its certificate key" begin
+        # Go's pickCertificate: selectSignatureScheme failing is handshake_failure.
+        server_config = _tls13_native_server_config()
+        state = TLN._TLS13ServerHandshakeState(server_config)
+        try
+            hello = TLN._tls13_client_hello(_tls13_native_client_config())
+            # The server certificate carries an RSA key; only ECDSA is offered.
+            hello.supported_signature_algorithms = UInt16[TLN._TLS_SIGNATURE_ECDSA_SECP256R1_SHA256]
+            TLN._tls13_set_client_hello!(state, TLN._marshal_client_hello(hello))
+            err = try
+                TLN._prepare_server_negotiation!(state, _TLS13ServerFlightIO(Vector{UInt8}[]), server_config)
+                nothing
+            catch ex
+                ex
+            end
+            @test err isa TLN._TLSAlertError
+            if err isa TLN._TLSAlertError
+                @test err.alert == TLN._TLS_ALERT_HANDSHAKE_FAILURE
+                @test !err.from_peer
+            end
+        finally
+            TLN._securezero_tls13_server_handshake_state!(state)
+        end
+    end
+
     @testset "native client sends the selected fatal alert on the wire" begin
         IPN.shutdown!()
         listener = nothing

--- a/test/tls_public_api_tests.jl
+++ b/test/tls_public_api_tests.jl
@@ -1153,6 +1153,77 @@ end
             @test client_state2.curve == "X25519"
             @test server_state2.curve == "X25519"
         end
+        @testset "mixed-version native client presents its certificate when TLS 1.3 is negotiated" begin
+            function run_once(server_cfg::TL.Config, client_cfg::TL.Config)
+                listener = nothing
+                client = nothing
+                accept_task = nothing
+                try
+                    listener = TL.listen("tcp", "127.0.0.1:0", server_cfg; backlog = 16)
+                    laddr = TL.addr(listener)::NC.SocketAddrV4
+                    accept_task = errormonitor(Threads.@spawn begin
+                        conn = TL.accept(listener)
+                        try
+                            TL.handshake!(conn)
+                            write(conn, UInt8[0x53])
+                            read(conn, 1) == UInt8[0x63] || error("unexpected TLS client ack")
+                            return TL.connection_state(conn)
+                        finally
+                            _tls_close_quiet!(conn)
+                        end
+                    end)
+                    client = _tls_connect("tcp", "127.0.0.1:$(Int(laddr.port))", client_cfg)
+                    read(client, 1) == UInt8[0x53] || error("unexpected TLS server byte")
+                    write(client, UInt8[0x63]) == 1 || error("unexpected TLS client ack write")
+                    _tls_wait_task_done(accept_task)
+                    return TL.connection_state(client), fetch(accept_task)::TL.ConnectionState
+                finally
+                    _tls_close_quiet!(client)
+                    _tls_close_quiet!(listener)
+                    IP.shutdown!()
+                end
+            end
+
+            # The client allows both versions (the default), so the mixed-version driver runs.
+            client_cfg = TL.Config(
+                verify_peer = true,
+                verify_hostname = true,
+                server_name = "localhost",
+                ca_file = _TLS_NATIVE_CA_PATH,
+                cert_file = _TLS_NATIVE_CLIENT_CERT_PATH,
+                key_file = _TLS_NATIVE_CLIENT_KEY_PATH,
+                handshake_timeout_ns = 10_000_000_000,
+            )
+            for (label, version_kwargs) in (
+                ("exact TLS 1.3 server", (; min_version = TL.TLS1_3_VERSION, max_version = TL.TLS1_3_VERSION)),
+                ("mixed-version server", (;)),
+            )
+                @testset "$(label)" begin
+                    server_cfg = _tls_server_config(;
+                        handshake_timeout_ns = 10_000_000_000,
+                        cert_file = _TLS_NATIVE_SERVER_CERT_PATH,
+                        key_file = _TLS_NATIVE_SERVER_KEY_PATH,
+                        client_auth = TL.ClientAuthMode.RequireAndVerifyClientCert,
+                        client_ca_file = _TLS_NATIVE_CA_PATH,
+                        version_kwargs...,
+                    )
+                    client_state1, server_state1 = run_once(server_cfg, client_cfg)
+                    @test client_state1.version == "TLSv1.3"
+                    @test server_state1.version == "TLSv1.3"
+                    @test client_state1.using_native_tls13
+                    @test server_state1.using_native_tls13
+                    @test !client_state1.did_resume
+                    @test !server_state1.did_resume
+                    @test client_state1.has_resumable_session
+                    # Resumption keeps working with a client identity loaded into the TLS 1.3 state.
+                    client_state2, server_state2 = run_once(server_cfg, client_cfg)
+                    @test client_state2.version == "TLSv1.3"
+                    @test server_state2.version == "TLSv1.3"
+                    @test client_state2.did_resume
+                    @test server_state2.did_resume
+                end
+            end
+        end
         @testset "mixed-version native server supports TLS 1.2 mTLS and resumption against an exact TLS 1.2 client" begin
             function run_once(server_cfg::TL.Config, client_cfg::TL.Config)
                 listener = nothing


### PR DESCRIPTION
## What

Mutual TLS silently failed on TLS 1.3 for every client that allows both TLS 1.2 and TLS 1.3 — the default `Config`. The mixed-version driver (`_native_tls_auto_client_handshake!`) built its TLS 1.3 handshake state without loading the local identity, so when the server negotiated TLS 1.3 and requested a client certificate, `_send_client_certificate!` found an empty chain and sent an empty `Certificate`; a `RequireAnyClientCert`/`RequireAndVerifyClientCert` server then answered with alert 116 (`certificate_required`). Pinning `tls_version="TLSv1.3"` or negotiating TLS 1.2 worked, which is why it went unnoticed.

## Why this shape

The root cause is structural, not a missed line. Go fetches the client certificate lazily from the config when the `CertificateRequest` arrives — `getClientCertificate` → `CertificateRequestInfo.SupportsCertificate` — in both versions (`handshake_client.go:728`, `handshake_client_tls13.go:748`). The TLS 1.2 port mirrors that (`_tls12_prepare_client_identity!` takes `config`), but the TLS 1.3 state machine had no access to the config and relied on each driver to preload the identity; there are two drivers and one forgot.

This PR threads `config` through the TLS 1.3 client handshake and fetches the identity in `_send_client_certificate!` (`_tls13_prepare_client_identity!`), deleting both driver preloads. The rest of Go's `getClientCertificate` comes along:

- **Signature algorithms** — a key the request's `signature_algorithms` cannot use now withholds the certificate (empty `Certificate`, no `CertificateVerify`), as `SupportsCertificate` does, instead of raising `ArgumentError`. Selection follows the peer's preference order (`selectSignatureScheme`); `_tls_select_signature_algorithm` returns `nothing` rather than throwing, and the server maps that to `handshake_failure` (`pickCertificate`) rather than an internal error.
- **Acceptable CAs** — `certificate_authorities` is honored: a chain with no certificate issued by one of the named CAs is withheld. The TLS 1.2 client path gets the same check via a shared `_tls_chain_signed_by_acceptable_ca`.

One deliberate deviation: a local certificate our x509 parser cannot read raises instead of silently withholding the identity (Go skips the chain). That is a misconfiguration, not a negotiation outcome, and the silent form is exactly the alert-116 symptom this PR fixes.

Ownership is unchanged: `_tls_local_identity` returns an up-ref'd key, the handshake state owns it, and `_securezero_tls13_client_handshake_state!` frees it.

## Tests

- `tls_public_api_tests.jl`: "mixed-version native client presents its certificate when TLS 1.3 is negotiated" — unpinned client with a certificate against a `RequireAndVerifyClientCert` server, exact TLS 1.3 and mixed-version, plus a resumed second handshake. Fails on `main` with alert 116, passes here.
- `tls_handshake_client_tls13_tests.jl`: detached-state tests for the lazy path — certificate + verifying `CertificateVerify` signature when the request accepts it (no CAs, matching CA, peer-order signature scheme), empty `Certificate` when it cannot (unusable signature algorithms, non-matching CA), and with no identity configured; `_tls_select_signature_algorithm` returns `nothing`/peer-order cases.
- `tls_native_tls13_tests.jl`: server answers `handshake_failure` when the client's `signature_algorithms` cannot use the server key.

Full suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
