### PR TITLE
Opt-in bounded direct wait: halve quiet-path readiness latency

### DIFF
--- a/src/3_tcp.jl
+++ b/src/3_tcp.jl
@@ -1085,6 +1085,22 @@ function set_read_deadline!(conn::Conn, deadline_ns::Integer)
 end
 
 """
+    set_direct_wait!(conn, budget_ns)
+
+Set the bounded direct-wait budget for `conn` in nanoseconds; `0` (the default) disables
+it. See `IOPoll.set_direct_wait!`: with a positive budget, a task waiting for readiness
+first blocks its own OS thread in `poll(2)` for up to the budget before parking on the
+central poller, delivering readiness inside the budget with a single kernel wake (about
+half the quiet-path round-trip latency). Other tasks scheduled on that thread wait up to
+the budget, so this is for latency-sensitive request/response clients, not for servers
+multiplexing many connections.
+"""
+function set_direct_wait!(conn::Conn, budget_ns::Integer)
+    IOPoll.set_direct_wait!(conn.fd.pfd, budget_ns)
+    return nothing
+end
+
+"""
     set_write_deadline!(conn, deadline_ns)
 
 Set only the write deadline on `conn`.

--- a/src/5_tls.jl
+++ b/src/5_tls.jl
@@ -2511,6 +2511,17 @@ function set_read_deadline!(conn::Conn, deadline_ns::Integer)
 end
 
 """
+    set_direct_wait!(conn, budget_ns)
+
+Set the bounded direct-wait budget on the underlying transport; see
+`TCP.set_direct_wait!`.
+"""
+function set_direct_wait!(conn::Conn, budget_ns::Integer)
+    TCP.set_direct_wait!(conn.tcp, budget_ns)
+    return nothing
+end
+
+"""
     set_write_deadline!(conn, deadline_ns)
 
 Set the write deadline on the underlying transport. See `set_deadline!` for the

--- a/src/iopoll/fd.jl
+++ b/src/iopoll/fd.jl
@@ -371,6 +371,77 @@ function preparewrite(pd::PollState, is_file::Bool = false)
     return nothing
 end
 
+# ---- bounded direct wait ----
+# Readiness through the central poller costs two thread wakes: the kernel wakes the poller
+# thread out of its backend wait, and the poller then wakes the parked task's scheduler
+# thread. A blocking client pays exactly one. `set_direct_wait!` lets latency-sensitive
+# request/response callers opt in to a bounded `poll(2)` on the *waiting task's own OS
+# thread* before falling back to parking: readiness inside the budget arrives as a single
+# kernel wake to the right thread, halving quiet-path round-trip latency. The price is that
+# other tasks scheduled on that thread wait up to the budget, so it is off by default and
+# bounded by construction. No-op on Windows (the IOCP backend arms explicit probe
+# operations instead of readiness polls).
+
+struct _CPollFd
+    fd::SysFD
+    events::Cshort
+    revents::Cshort
+end
+
+const _POLLIN = Cshort(0x0001)
+const _POLLOUT = Cshort(0x0004)
+const _NFDS_T = Sys.islinux() ? Culong : Cuint
+
+# One bounded direct poll. `:ready` — readiness (or an error condition the caller's next
+# syscall will surface); `:timeout` — budget elapsed, park instead; `:recheck` — return to
+# the top of the wait loop (EINTR, or an already-expired deadline).
+function _direct_wait!(pd::PollState, mode::PollMode.T, budget_ns::Int64)::Symbol
+    @static if Sys.iswindows()
+        return :timeout
+    else
+        timeout_ns = budget_ns
+        deadline = _mode_has_read(mode) ? (@atomic :acquire pd.rd_ns) : (@atomic :acquire pd.wd_ns)
+        if deadline > 0
+            remaining = deadline - Int64(time_ns())
+            remaining <= 0 && return :recheck
+            timeout_ns = min(timeout_ns, remaining)
+        end
+        timeout_ms = Cint(clamp(cld(timeout_ns, Int64(1_000_000)), Int64(1), Int64(typemax(Cint))))
+        events = _mode_has_read(mode) ? _POLLIN : _POLLOUT
+        pfd = Ref(_CPollFd(pd.sysfd, events, Cshort(0)))
+        n = GC.@preserve pfd begin
+            @gcsafe_ccall poll(pfd::Ptr{_CPollFd}, _NFDS_T(1)::_NFDS_T, timeout_ms::Cint)::Cint
+        end
+        if n < 0
+            errno = Int32(Base.Libc.errno())
+            errno == Int32(Base.Libc.EINTR) && return :recheck
+            # let the parking path surface persistent descriptor problems
+            return :timeout
+        end
+        return n == 0 ? :timeout : :ready
+    end
+end
+
+"""
+    set_direct_wait!(fd, budget_ns)
+
+Set the bounded direct-wait budget for `fd` in nanoseconds; `0` (the default) disables it.
+
+With a positive budget, a task waiting for readiness on `fd` first blocks its own OS
+thread in `poll(2)` for up to the budget (bounded further by any armed deadline) before
+parking on the central poller. Readiness inside the budget is delivered with a single
+kernel wake — about half the quiet-path round-trip latency of the parked path — at the
+cost of other tasks scheduled on that thread waiting up to the budget. Intended for
+latency-sensitive request/response clients; leave disabled for servers multiplexing many
+connections. The timeout has millisecond granularity (budgets round up to 1ms). No effect
+on Windows.
+"""
+function set_direct_wait!(fd::FD, budget_ns::Integer)
+    budget_ns >= 0 || throw(ArgumentError("direct-wait budget must be >= 0"))
+    @atomic :release fd.pd.direct_wait_ns = Int64(budget_ns)
+    return nothing
+end
+
 """
 Block until read readiness, retrying internally if a canceled wake becomes
 stale before the waiter task resumes.
@@ -384,9 +455,16 @@ Throws:
 - `NotPollableError` if the backend reports a permanent readiness error
 """
 function waitread(pd::PollState, is_file::Bool = false)
+    direct_budget = @atomic :acquire pd.direct_wait_ns
     while true
         _convert_poll_error!(_check_error(pd, PollMode.READ), is_file)
         pollable(pd) || throw(ArgumentError("waiting for unsupported file type"))
+        if direct_budget > 0
+            outcome = _direct_wait!(pd, PollMode.READ, direct_budget)
+            outcome == :ready && return nothing
+            outcome == :recheck && continue
+            direct_budget = Int64(0)   # budget spent: park from here on
+        end
         registration = _poll_registration(pd)
         arm_waiter!(registration, PollMode.READ)
         reason = pollwait!(registration.read_waiter)
@@ -404,9 +482,16 @@ stale before the waiter task resumes.
 Returns `nothing`.
 """
 function waitwrite(pd::PollState, is_file::Bool = false)
+    direct_budget = @atomic :acquire pd.direct_wait_ns
     while true
         _convert_poll_error!(_check_error(pd, PollMode.WRITE), is_file)
         pollable(pd) || throw(ArgumentError("waiting for unsupported file type"))
+        if direct_budget > 0
+            outcome = _direct_wait!(pd, PollMode.WRITE, direct_budget)
+            outcome == :ready && return nothing
+            outcome == :recheck && continue
+            direct_budget = Int64(0)   # budget spent: park from here on
+        end
         registration = _poll_registration(pd)
         arm_waiter!(registration, PollMode.WRITE)
         reason = pollwait!(registration.write_waiter)

--- a/src/iopoll/types.jl
+++ b/src/iopoll/types.jl
@@ -291,6 +291,7 @@ mutable struct PollState
     @atomic wd_ns::Int64
     @atomic rseq::UInt64
     @atomic wseq::UInt64
+    @atomic direct_wait_ns::Int64
     function PollState(sysfd::SysFD = INVALID_FD, token::UInt64 = UInt64(0))
         return new(
             ReentrantLock(),
@@ -303,6 +304,7 @@ mutable struct PollState
             Int64(0),
             UInt64(0),
             UInt64(0),
+            Int64(0),
         )
     end
 end

--- a/test/tcp_tests.jl
+++ b/test/tcp_tests.jl
@@ -603,6 +603,53 @@ end
                 IP.shutdown!()
             end
         end
+        @testset "bounded direct wait" begin
+            IP.shutdown!()
+            listener = nothing
+            client = nothing
+            server = nothing
+            try
+                listener = NC.listen(NC.loopback_addr(0); backlog = 8)
+                laddr = NC.addr(listener)::NC.SocketAddrV4
+                accept_task = errormonitor(@async NC.accept(listener))
+                client = NC.connect(NC.loopback_addr(Int(laddr.port)))
+                server = fetch(accept_task)
+                @test_throws ArgumentError NC.set_direct_wait!(server, -1)
+                NC.set_direct_wait!(server, Int64(0))
+                @test (@atomic :acquire server.fd.pfd.pd.direct_wait_ns) == 0
+                # data already queued: the direct poll observes readiness immediately
+                NC.set_direct_wait!(server, Int64(50_000_000))
+                @test write(client, UInt8[0x11]) == 1
+                buf = Vector{UInt8}(undef, 1)
+                @test read!(server, buf) === buf
+                @test buf[1] == 0x11
+                # data arrives while blocked inside the direct-poll budget
+                writer = errormonitor(@async (sleep(0.01); write(client, UInt8[0x22])))
+                @test read!(server, buf) === buf
+                @test buf[1] == 0x22
+                wait(writer)
+                # arrival after the budget: falls back to the parked path and still succeeds
+                NC.set_direct_wait!(server, Int64(1_000_000))
+                writer = errormonitor(@async (sleep(0.05); write(client, UInt8[0x33])))
+                @test read!(server, buf) === buf
+                @test buf[1] == 0x33
+                wait(writer)
+                # a read deadline earlier than the budget bounds the direct poll and fires
+                NC.set_direct_wait!(server, Int64(10_000_000_000))
+                NC.set_read_deadline!(server, Int64(time_ns()) + Int64(80_000_000))
+                start_ns = time_ns()
+                @test_throws NC.DeadlineExceededError read!(server, buf)
+                elapsed_ms = (time_ns() - start_ns) ÷ 1_000_000
+                @test 40 <= elapsed_ms <= 5_000
+                NC.set_read_deadline!(server, Int64(0))
+                NC.set_direct_wait!(server, Int64(0))
+            finally
+                _close_quiet!(server)
+                _close_quiet!(client)
+                _close_quiet!(listener)
+                IP.shutdown!()
+            end
+        end
         @testset "combined deadline applies to both read and write state" begin
             IP.shutdown!()
             listener = nothing


### PR DESCRIPTION
## Opt-in bounded direct wait: halve quiet-path readiness latency

### The wakeup delta, decomposed

Readiness through the central poller costs **two thread wakes** where a blocking client
pays one: the kernel wakes the poller thread out of its backend wait, and the poller then
wakes the parked task's scheduler thread. Timestamp probes at the three hop boundaries
(quiet macOS ARM, 5-byte loopback echo against a *blocking-syscall* peer so only the
client side runs through Reseau):

| segment | median | p90 |
|---|---|---|
| write → poller's `kevent` returns (echo + wake #1) | 16.5µs | 45.3µs |
| dispatch (poller lock + token lookup + CAS + `schedule`) | **0.2µs** | 0.2µs |
| `schedule` → task resumed (wake #2) | **17.4µs** | 22.4µs |

Two conclusions: the poller's own dispatch path is already essentially free (no
micro-optimization there is worth anything), and the entire delta vs a blocking client is
wake #2 — Julia runtime cost (`JULIA_THREAD_SLEEP_THRESHOLD` doesn't help; the woken
thread sleeps in the libuv loop, not the spin-gated scheduler sleep). No poller-side
tuning can remove it, but the *waiting thread* can be made to receive the kernel wake
directly.

### The knob

`set_direct_wait!(fd | TCP.Conn | TLS.Conn, budget_ns)` (default `0` = off, exactly
today's behavior): a task waiting for readiness first blocks **its own OS thread** in
`poll(2)` for up to the budget — bounded further by any armed deadline — and only then
falls back to parking on the central poller. Readiness inside the budget arrives as a
single kernel wake to the right thread; a timeout parks exactly as today, so long waits
are unchanged and the budget is spent once per wait.

The trade is explicit: other tasks scheduled on that thread wait up to the budget. That
is why it is opt-in and bounded — meant for latency-sensitive request/response *clients*
(database drivers, RPC), not for servers multiplexing many connections. EINTR re-enters
the wait loop; Windows is a documented no-op (the IOCP backend arms explicit probe
operations instead of readiness polls); the `poll` timeout has ms granularity, which only
affects the fallback point, not wake latency.

### Measurements (macOS ARM, quiet system, interleaved measurement)

- Loopback echo round trip: **35.6µs → 20.6µs** median (−42%), p90 **68.9 → 25.2µs** —
  at the blocking-client floor.
- With 0/50/120/300µs of simulated server processing, the win holds at **13–16µs per
  round trip** regardless of block duration.
- End-to-end MySQL.jl 2.0 against Dockerized `mysql:8.4`: COM_PING ~150 → ~135µs,
  20k-row `executemany` **−13%**.

### Tests

A "bounded direct wait" testset in `tcp_tests.jl`: setter validation, readiness already
queued, arrival inside the budget, arrival after the budget (falls back to the parked
path), and a read deadline earlier than the budget bounding the direct poll and firing on
time. Full `Pkg.test` green locally, including all trim workloads (the direct wait is a
plain `@gcsafe_ccall poll` — trim-safe by construction).

Independent of #151 (different functions; both branch from v1.4.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
