### PR TITLE
Add support for 32-bit Windows (i686-w64-mingw32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,18 @@ jobs:
             os: windows-latest
             arch: x64
             threads: 1
+          # 32-bit Windows (i686-w64-mingw32) is the only supported target where
+          # Win32/Winsock is __stdcall rather than the platform's single default
+          # calling convention, so it is the only configuration that can catch a
+          # Win32 `ccall` that is missing one.
+          - version: 'min'
+            os: windows-latest
+            arch: x86
+            threads: 1
+          - version: '1'
+            os: windows-latest
+            arch: x86
+            threads: 1
           - version: '1'
             os: macOS-latest
             arch: aarch64

--- a/src/0_compat.jl
+++ b/src/0_compat.jl
@@ -18,6 +18,39 @@ else
     bytememory(n::Integer)::ByteMemory = Memory{UInt8}(undef, Int(n))
 end
 
+# The calling convention for Win32/Winsock entry points.
+#
+# On 32-bit Windows every Win32 function is `__stdcall`: the callee pops the
+# arguments before it returns. Julia's default `ccall` convention is cdecl,
+# where the caller pops them instead, so a plain `ccall` into Win32 leaves the
+# stack skewed by the argument size on every single call. The damage accumulates
+# and surfaces as an access violation somewhere unrelated, which makes it look
+# like a Julia bug rather than an ABI mismatch.
+#
+# On 64-bit Windows, and on every other supported platform, there is only one
+# calling convention, so this resolves to the default and nothing changes.
+const WIN32_CCONV = (Sys.iswindows() && Sys.WORD_SIZE == 32) ? :stdcall : :cdecl
+
+"""
+    @win32_cconv ccall((:Func, "Ws2_32"), Ret, (ArgTypes...), args...)
+
+Apply [`WIN32_CCONV`](@ref) to a `ccall` written in positional form.
+
+Julia requires the calling convention to be a literal in the `ccall` surface
+syntax, so it cannot be supplied by a constant at the call site. This macro
+splices it in at macro-expansion time, leaving the wrapped expression otherwise
+untouched. Use it for every Win32/Winsock call that is not already going
+through [`@gcsafe_win32_ccall`](@ref).
+"""
+macro win32_cconv(expr)
+    (Meta.isexpr(expr, :call) && expr.args[1] === :ccall) ||
+        throw(ArgumentError("@win32_cconv expects a positional `ccall(...)` expression"))
+    args = copy(expr.args)
+    # ccall(target, [cconv,] rettype, (argtypes...), args...)
+    insert!(args, 3, WIN32_CCONV)
+    return esc(Expr(:call, args...))
+end
+
 # Compat wrapper for `@ccall gc_safe = true` on Julia versions that do not
 # understand the native syntax yet.
 
@@ -34,13 +67,25 @@ the built-in form. On older Julia versions it wraps the inner `ccall` with
 """
 macro gcsafe_ccall end
 
+"""
+    @gcsafe_win32_ccall ...
+
+[`@gcsafe_ccall`](@ref) for Win32/Winsock entry points: identical, except that
+the call is made with [`WIN32_CCONV`](@ref) instead of the platform default.
+
+Safe to use on shared code paths that call the same symbol on other platforms
+(`inet_pton`, for instance) — off 32-bit Windows the convention is the default
+one, so those callers are unaffected.
+"""
+macro gcsafe_win32_ccall end
+
 if HAS_CCALL_GCSAFE
-    macro gcsafe_ccall(expr)
+    function _gcsafe_ccall_lower(convention, expr)
         exprs = Any[:(gc_safe = true), expr]
-        return Base.ccall_macro_lower((:ccall), Base.ccall_macro_parse(exprs)...)
+        return Base.ccall_macro_lower(convention, Base.ccall_macro_parse(exprs)...)
     end
 else
-    function _gcsafe_ccall_macro_lower(func, rettype, types, args, nreq)
+    function _gcsafe_ccall_macro_lower(convention, func, rettype, types, args, nreq)
         _ = nreq
 
         cconvert_exprs = Any[]
@@ -59,14 +104,39 @@ else
             push!(unsafe_convert_exprs, :($var = Base.unsafe_convert($(esc(typ)), $arg)))
         end
 
+        # `convention === nothing` keeps the platform default by omitting the
+        # argument entirely, which is what every non-Win32 caller wants.
+        #
+        # Otherwise the convention goes in as a bare symbol in the `ccall`
+        # surface syntax, escaped so that it survives macro hygiene: the
+        # expression this macro returns is otherwise unescaped, and an
+        # unescaped symbol here would come out qualified as `Reseau.stdcall`,
+        # which lowering does not recognise as a convention and instead reads
+        # as the return type.
+        #
+        # The `Expr(:cconv, convention, nreq)` node that
+        # `Base.ccall_macro_lower` emits is deliberately not used: on Julia
+        # 1.10 and 1.11 that node only accepts the `:ccall` marker, and any
+        # other convention fails to lower ("expected QuoteNode, got a value of
+        # type Expr"). Escaped surface syntax works on every supported version.
+        inner_ccall = if convention === nothing
+            :(ccall(
+                $(esc(func)), $(esc(rettype)), $(Expr(:tuple, map(esc, types)...)),
+                $(unsafe_convert_args...)
+            ))
+        else
+            Expr(
+                :call, :ccall, esc(func), esc(convention),
+                esc(rettype), Expr(:tuple, map(esc, types)...),
+                unsafe_convert_args...,
+            )
+        end
+
         call = quote
             $(unsafe_convert_exprs...)
 
             gc_state = @ccall(jl_gc_safe_enter()::Int8)
-            ret = ccall(
-                $(esc(func)), $(esc(rettype)), $(Expr(:tuple, map(esc, types)...)),
-                $(unsafe_convert_args...)
-            )
+            ret = $inner_ccall
             @ccall(jl_gc_safe_leave(gc_state::Int8)::Cvoid)
             ret
         end
@@ -78,7 +148,15 @@ else
         end
     end
 
-    macro gcsafe_ccall(expr)
-        return _gcsafe_ccall_macro_lower(Base.ccall_macro_parse(expr)...)
+    function _gcsafe_ccall_lower(convention, expr)
+        return _gcsafe_ccall_macro_lower(convention, Base.ccall_macro_parse(expr)...)
     end
+end
+
+macro gcsafe_ccall(expr)
+    return _gcsafe_ccall_lower(HAS_CCALL_GCSAFE ? :ccall : nothing, expr)
+end
+
+macro gcsafe_win32_ccall(expr)
+    return _gcsafe_ccall_lower(WIN32_CCONV, expr)
 end

--- a/src/1_socket_ops.jl
+++ b/src/1_socket_ops.jl
@@ -18,7 +18,7 @@ A few conventions are worth keeping in mind when reading the code:
 """
 module SocketOps
 
-using ..Reseau: @gcsafe_ccall
+using ..Reseau: @gcsafe_ccall, @gcsafe_win32_ccall, @win32_cconv
 
 const SockLen = @static Sys.iswindows() ? Cint : UInt32
 const SocketFD = @static Sys.iswindows() ? UInt : Cint

--- a/src/2_iopoll.jl
+++ b/src/2_iopoll.jl
@@ -15,7 +15,7 @@ handles directly.
 """
 module IOPoll
 
-using ..Reseau: ByteMemory, MutableByteBuffer, @gcsafe_ccall
+using ..Reseau: ByteMemory, MutableByteBuffer, @gcsafe_ccall, @gcsafe_win32_ccall, @win32_cconv
 using ..Reseau.SocketOps
 
 include("iopoll/types.jl")

--- a/src/4_host_resolvers.jl
+++ b/src/4_host_resolvers.jl
@@ -17,7 +17,7 @@ resolution logic remains factored into its own file.
 """
 module HostResolvers
 
-using ..Reseau: @gcsafe_ccall
+using ..Reseau: @gcsafe_ccall, @gcsafe_win32_ccall, @win32_cconv
 using ..Reseau.SocketOps
 using ..Reseau.IOPoll
 
@@ -441,7 +441,7 @@ function _ccall_getaddrinfo(hostname::String, hints::Ref{_AddrInfo}, result_ptr:
     # on this adopted worker thread cannot stall a stop-the-world GC elsewhere
     # in the process.
     return @static if Sys.iswindows()
-        @gcsafe_ccall "Ws2_32".getaddrinfo(
+        @gcsafe_win32_ccall "Ws2_32".getaddrinfo(
             hostname::Cstring,
             null_service::Cstring,
             hints::Ptr{_AddrInfo},
@@ -711,7 +711,7 @@ end
             size_ref = Ref(size)
             buf = Vector{UInt8}(undef, Int(size_ref[]))
             rc = GC.@preserve buf size_ref begin
-                ccall(
+                @win32_cconv ccall(
                     (:GetAdaptersAddresses, _IPHLPAPI),
                     UInt32,
                     (UInt32, UInt32, Ptr{Cvoid}, Ptr{_WindowsIpAdapterAddresses}, Ref{UInt32}),
@@ -830,7 +830,7 @@ function _native_getaddrinfo(hostname::AbstractString; flags::Cint = Cint(0))::V
     finally
         if future.addr_info_ptr != C_NULL
             @static if Sys.iswindows()
-                ccall((:freeaddrinfo, "Ws2_32"), Cvoid, (Ptr{_AddrInfo},), future.addr_info_ptr)
+                @win32_cconv ccall((:freeaddrinfo, "Ws2_32"), Cvoid, (Ptr{_AddrInfo},), future.addr_info_ptr)
             else
                 ccall(:freeaddrinfo, Cvoid, (Ptr{_AddrInfo},), future.addr_info_ptr)
             end
@@ -906,7 +906,7 @@ function _parse_ipv4_literal(host::AbstractString)::Union{Nothing, NTuple{4, UIn
     h = String(host)
     bytes = Vector{UInt8}(undef, 4)
     rc = GC.@preserve bytes begin
-        @gcsafe_ccall inet_pton(
+        @gcsafe_win32_ccall inet_pton(
             SocketOps.AF_INET::Cint,
             h::Cstring,
             pointer(bytes)::Ptr{UInt8},
@@ -925,7 +925,7 @@ function _parse_ipv6_literal(host::AbstractString)::Union{Nothing, NTuple{16, UI
     occursin('%', h) && return nothing
     bytes = Vector{UInt8}(undef, 16)
     rc = GC.@preserve bytes begin
-        @gcsafe_ccall inet_pton(
+        @gcsafe_win32_ccall inet_pton(
             SocketOps.AF_INET6::Cint,
             h::Cstring,
             pointer(bytes)::Ptr{UInt8},

--- a/src/iopoll/iocp.jl
+++ b/src/iopoll/iocp.jl
@@ -181,11 +181,11 @@ end
 end
 
 @inline function _win_get_last_error()::UInt32
-    return ccall((:GetLastError, _KERNEL32), UInt32, ())
+    return @win32_cconv ccall((:GetLastError, _KERNEL32), UInt32, ())
 end
 
 @inline function _wsa_get_last_error()::Int32
-    return Int32(ccall((:WSAGetLastError, _WS2_32), Cint, ()))
+    return Int32(@win32_cconv ccall((:WSAGetLastError, _WS2_32), Cint, ()))
 end
 
 @inline function _map_win_errno(err::UInt32)::Int32
@@ -234,7 +234,7 @@ function _load_connectex_ptr(fd::SysFD)::Ptr{Cvoid}
         out_ref = Ref{Ptr{Cvoid}}(C_NULL)
         bytes_ref = Ref{UInt32}(UInt32(0))
         rc = GC.@preserve guid_ref out_ref bytes_ref begin
-            @gcsafe_ccall _WS2_32.WSAIoctl(
+            @gcsafe_win32_ccall _WS2_32.WSAIoctl(
                 _socket_value(fd)::UInt,
                 _SIO_GET_EXTENSION_FUNCTION_POINTER::UInt32,
                 guid_ref::Ref{Guid},
@@ -258,7 +258,7 @@ end
     bytes_ref = Ref{UInt32}(UInt32(0))
     flags_ref = Ref{UInt32}(UInt32(0))
     ok = GC.@preserve op bytes_ref flags_ref begin
-        @gcsafe_ccall _WS2_32.WSAGetOverlappedResult(
+        @gcsafe_win32_ccall _WS2_32.WSAGetOverlappedResult(
             _socket_value(fd)::UInt,
             Base.unsafe_convert(Ptr{Overlapped}, op.storage)::Ptr{Overlapped},
             bytes_ref::Ref{UInt32},
@@ -287,7 +287,7 @@ function _socket_can_skip_completion_port_on_success(fd::SysFD)::Bool
     info_ref = Ref{WSAProtocolInfo}()
     size_ref = Ref{Cint}(Cint(sizeof(WSAProtocolInfo)))
     rc = GC.@preserve info_ref size_ref begin
-        ccall(
+        @win32_cconv ccall(
             (:getsockopt, _WS2_32),
             Cint,
             (UInt, Cint, Cint, Ptr{UInt8}, Ref{Cint}),
@@ -307,7 +307,7 @@ function _maybe_set_completion_modes!(fd::SysFD)::Bool
     if _socket_can_skip_completion_port_on_success(fd)
         modes |= _FILE_SKIP_COMPLETION_PORT_ON_SUCCESS
     end
-    ok = @gcsafe_ccall _KERNEL32.SetFileCompletionNotificationModes(
+    ok = @gcsafe_win32_ccall _KERNEL32.SetFileCompletionNotificationModes(
         _socket_handle(fd)::Ptr{Cvoid},
         modes::UInt8,
     )::Int32
@@ -348,7 +348,7 @@ its buffer roots must remain live and the storage must not be reused.
 """
 function _cancel_iocp_op!(reg::IocpRegistration, op::IocpOp; strict::Bool = false)::Bool
     (@atomic :acquire op.active) || return false
-    ok = @gcsafe_ccall _KERNEL32.CancelIoEx(
+    ok = @gcsafe_win32_ccall _KERNEL32.CancelIoEx(
         _socket_handle(reg.fd)::Ptr{Cvoid},
         _op_ptr(op)::Ptr{Cvoid},
     )::Int32
@@ -407,7 +407,7 @@ function _submit_iocp_op!(
         flags = Ref{UInt32}(UInt32(0))
         rc = GC.@preserve op wsabuf bytes flags begin
             if op.mode == PollMode.READ
-                @gcsafe_ccall _WS2_32.WSARecv(
+                @gcsafe_win32_ccall _WS2_32.WSARecv(
                     _socket_value(reg.fd)::UInt,
                     wsabuf::Ref{WSABUF},
                     UInt32(1)::UInt32,
@@ -417,7 +417,7 @@ function _submit_iocp_op!(
                     C_NULL::Ptr{Cvoid},
                 )::Cint
             else
-                @gcsafe_ccall _WS2_32.WSASend(
+                @gcsafe_win32_ccall _WS2_32.WSASend(
                     _socket_value(reg.fd)::UInt,
                     wsabuf::Ref{WSABUF},
                     UInt32(1)::UInt32,
@@ -433,7 +433,7 @@ function _submit_iocp_op!(
         bytes = Ref{UInt32}(UInt32(0))
         flags = Ref{UInt32}(UInt32(0))
         rc = GC.@preserve op wsabuf bytes flags begin
-            @gcsafe_ccall _WS2_32.WSARecv(
+            @gcsafe_win32_ccall _WS2_32.WSARecv(
                 _socket_value(reg.fd)::UInt,
                 wsabuf::Ref{WSABUF},
                 UInt32(1)::UInt32,
@@ -447,7 +447,7 @@ function _submit_iocp_op!(
         wsabuf = Ref(WSABUF(nbytes, ptr))
         bytes = Ref{UInt32}(UInt32(0))
         rc = GC.@preserve op wsabuf bytes begin
-            @gcsafe_ccall _WS2_32.WSASend(
+            @gcsafe_win32_ccall _WS2_32.WSASend(
                 _socket_value(reg.fd)::UInt,
                 wsabuf::Ref{WSABUF},
                 UInt32(1)::UInt32,
@@ -467,7 +467,7 @@ function _submit_iocp_op!(
         addrlen = request.addrlen
         addrlen[] = Cint(length(addrbuf))
         rc = GC.@preserve op wsabuf bytes flags addrbuf addrlen begin
-            @gcsafe_ccall _WS2_32.WSARecvFrom(
+            @gcsafe_win32_ccall _WS2_32.WSARecvFrom(
                 _socket_value(reg.fd)::UInt,
                 wsabuf::Ref{WSABUF},
                 UInt32(1)::UInt32,
@@ -486,7 +486,7 @@ function _submit_iocp_op!(
         bytes = Ref{UInt32}(UInt32(0))
         addrbuf = request.addrbuf
         rc = GC.@preserve op wsabuf bytes addrbuf begin
-            @gcsafe_ccall _WS2_32.WSASendTo(
+            @gcsafe_win32_ccall _WS2_32.WSASendTo(
                 _socket_value(reg.fd)::UInt,
                 wsabuf::Ref{WSABUF},
                 UInt32(1)::UInt32,
@@ -510,7 +510,7 @@ function _submit_iocp_op!(
         bytes_ref = Ref{UInt32}(UInt32(0))
         addrbuf = request.addrbuf
         rc = GC.@preserve op addrbuf bytes_ref begin
-            ccall(
+            @win32_cconv ccall(
                 connectex_ptr,
                 Int32,
                 (UInt, Ptr{Cvoid}, Cint, Ptr{UInt8}, UInt32, Ref{UInt32}, Ptr{Cvoid}),
@@ -529,7 +529,7 @@ function _submit_iocp_op!(
         bytes_ref = Ref{UInt32}(UInt32(0))
         addrbuf = request.addrbuf
         rc = GC.@preserve op addrbuf bytes_ref begin
-            @gcsafe_ccall _MSWSOCK.AcceptEx(
+            @gcsafe_win32_ccall _MSWSOCK.AcceptEx(
                 _socket_value(reg.fd)::UInt,
                 _socket_value(request.acceptfd)::UInt,
                 pointer(addrbuf)::Ptr{UInt8},
@@ -845,7 +845,7 @@ function _iocp_finish_accept!(registration::Registration)::Tuple{SysFD, Vector{U
 end
 
 function _backend_init!(state::Poller)::Int32
-    port = @gcsafe_ccall _KERNEL32.CreateIoCompletionPort(
+    port = @gcsafe_win32_ccall _KERNEL32.CreateIoCompletionPort(
         _INVALID_HANDLE_VALUE::Ptr{Cvoid},
         C_NULL::Ptr{Cvoid},
         UInt(0)::UInt,
@@ -918,7 +918,7 @@ function _drain_pending_ops_on_close!(backend::IocpBackendState)
     while _iocp_any_op_active(backend)
         ov_ref[] = C_NULL
         ok = GC.@preserve bytes_ref key_ref ov_ref begin
-            @gcsafe_ccall _KERNEL32.GetQueuedCompletionStatus(
+            @gcsafe_win32_ccall _KERNEL32.GetQueuedCompletionStatus(
                 backend.port::Ptr{Cvoid},
                 bytes_ref::Ref{UInt32},
                 key_ref::Ref{UInt},
@@ -960,7 +960,7 @@ function _backend_close!(state::Poller)
             # Retire kernel ownership of every OVERLAPPED before closing the port
             # and dropping the registration objects the GC would otherwise free.
             _drain_pending_ops_on_close!(backend)
-            _ = @gcsafe_ccall _KERNEL32.CloseHandle(
+            _ = @gcsafe_win32_ccall _KERNEL32.CloseHandle(
                 backend.port::Ptr{Cvoid},
             )::Int32
         end
@@ -978,7 +978,7 @@ function _backend_open_fd!(
     _ = mode
     backend = _iocp_backend(state)
     backend === nothing && return Int32(Base.Libc.ENOSYS)
-    associated = @gcsafe_ccall _KERNEL32.CreateIoCompletionPort(
+    associated = @gcsafe_win32_ccall _KERNEL32.CreateIoCompletionPort(
         _socket_handle(fd)::Ptr{Cvoid},
         backend.port::Ptr{Cvoid},
         UInt(token)::UInt,
@@ -1031,7 +1031,7 @@ function _backend_wake!(state::Poller)::Int32
     backend === nothing && return Int32(Base.Libc.ENOSYS)
     _, ok = @atomicreplace(backend.wake_sig, UInt32(0) => UInt32(1))
     ok || return Int32(0)
-    posted = @gcsafe_ccall _KERNEL32.PostQueuedCompletionStatus(
+    posted = @gcsafe_win32_ccall _KERNEL32.PostQueuedCompletionStatus(
         backend.port::Ptr{Cvoid},
         UInt32(0)::UInt32,
         _WAKE_KEY::UInt,
@@ -1067,7 +1067,7 @@ function _backend_poll_once!(state::Poller, delay_ns::Int64)::Int32
     removed = Ref{UInt32}(UInt32(0))
     wait_ms = _iocp_timeout_ms(delay_ns)
     ok = GC.@preserve entries removed begin
-        @gcsafe_ccall _KERNEL32.GetQueuedCompletionStatusEx(
+        @gcsafe_win32_ccall _KERNEL32.GetQueuedCompletionStatusEx(
             backend.port::Ptr{Cvoid},
             pointer(entries)::Ptr{OverlappedEntry},
             UInt32(length(entries))::UInt32,

--- a/src/iopoll/runtime.jl
+++ b/src/iopoll/runtime.jl
@@ -82,13 +82,26 @@ function _spawn_detached_thread(
     _ = name
     thread_arg = arg === nothing ? C_NULL : pointer_from_objref(arg)
     @static if Sys.iswindows()
-        handle = ccall(
+        # NOTE (32-bit Windows): `LPTHREAD_START_ROUTINE` is `__stdcall`, while
+        # `@cfunction` emits a cdecl callback and cannot be asked for anything
+        # else -- codegen builds the thunk with `CallingConv::C` and discards
+        # the convention slot of `Expr(:cfunction, ...)`.
+        #
+        # This is an ABI nonconformance with no known observable effect. Both
+        # conventions pass arguments the same way on i686, so `thread_arg`
+        # arrives intact; they differ only in who pops, and the entry point
+        # returns straight into the thread-exit thunk, which never relies on the
+        # restored stack pointer. It is invoked once per thread, so nothing
+        # accumulates. Fixing it properly means not needing a stdcall callback
+        # at all -- `uv_thread_create` takes a cdecl `uv_thread_cb` and would
+        # also collapse this branch and the pthread one into a single path.
+        handle = @win32_cconv ccall(
             (:CreateThread, "kernel32"), Ptr{Cvoid},
             (Ptr{Cvoid}, Csize_t, Ptr{Cvoid}, Ptr{Cvoid}, UInt32, Ptr{UInt32}),
             C_NULL, Csize_t(0), thread_fn[], thread_arg, UInt32(0), C_NULL,
         )
         handle == C_NULL && throw(ArgumentError("error creating poller thread"))
-        _ = ccall((:CloseHandle, "kernel32"), Int32, (Ptr{Cvoid},), handle)
+        _ = @win32_cconv ccall((:CloseHandle, "kernel32"), Int32, (Ptr{Cvoid},), handle)
     else
         pthread_ref = Ref{_pthread_t}(0)
         create_ret = ccall(

--- a/src/socket_ops/windows.jl
+++ b/src/socket_ops/windows.jl
@@ -141,11 +141,11 @@ end
 end
 
 @inline function _wsa_get_last_error()::Int32
-    return Int32(ccall((:WSAGetLastError, _WS2_32), Cint, ()))
+    return Int32(@win32_cconv ccall((:WSAGetLastError, _WS2_32), Cint, ()))
 end
 
 @inline function _win_get_last_error()::UInt32
-    return ccall((:GetLastError, _KERNEL32), UInt32, ())
+    return @win32_cconv ccall((:GetLastError, _KERNEL32), UInt32, ())
 end
 
 @inline function _map_win32_errno(err::UInt32)::Int32
@@ -293,7 +293,7 @@ function _load_extension_ptr!(sock::SocketFD, guid::Guid)::Ptr{Cvoid}
     out_ref = Ref{Ptr{Cvoid}}(C_NULL)
     bytes_ref = Ref{UInt32}(UInt32(0))
     rc = GC.@preserve guid_ref out_ref bytes_ref begin
-        @gcsafe_ccall _WS2_32.WSAIoctl(
+        @gcsafe_win32_ccall _WS2_32.WSAIoctl(
             _socket_value(sock)::UInt,
             _SIO_GET_EXTENSION_FUNCTION_POINTER::UInt32,
             guid_ref::Ref{Guid},
@@ -323,7 +323,7 @@ function set_udp_connreset!(sock::SocketFD, enabled::Bool)::Nothing
     in_ref = Ref{UInt32}(enabled ? UInt32(1) : UInt32(0))
     bytes_ref = Ref{UInt32}(UInt32(0))
     rc = GC.@preserve in_ref bytes_ref begin
-        @gcsafe_ccall _WS2_32.WSAIoctl(
+        @gcsafe_win32_ccall _WS2_32.WSAIoctl(
             _socket_value(sock)::UInt,
             _SIO_UDP_CONNRESET::UInt32,
             in_ref::Ref{UInt32},
@@ -373,7 +373,7 @@ function _recv_msg_simple!(fd::SocketFD, msg_ref::Ref{MsgHdr}, flags::Cint)::Css
     bytes_ref = Ref{UInt32}(UInt32(0))
     flags_ref = Ref{UInt32}(_cint_bits_u32(flags))
     n = GC.@preserve bufs bytes_ref flags_ref begin
-        ccall(
+        @win32_cconv ccall(
             (:WSARecv, _WS2_32),
             Cint,
             (UInt, Ptr{WSABuf}, UInt32, Ref{UInt32}, Ref{UInt32}, Ptr{Cvoid}, Ptr{Cvoid}),
@@ -404,7 +404,7 @@ function _send_msg_simple!(fd::SocketFD, msg_ref::Ref{MsgHdr}, flags::Cint)::Css
     bufs = _wsabufs_from_msghdr(msg)
     bytes_ref = Ref{UInt32}(UInt32(0))
     n = GC.@preserve bufs bytes_ref begin
-        ccall(
+        @win32_cconv ccall(
             (:WSASend, _WS2_32),
             Cint,
             (UInt, Ptr{WSABuf}, UInt32, Ref{UInt32}, UInt32, Ptr{Cvoid}, Ptr{Cvoid}),
@@ -428,7 +428,7 @@ function _recv_msg_ext!(fd::SocketFD, msg_ref::Ref{MsgHdr}, flags::Cint)::Cssize
     wmsg = Ref(_wsamsg_from_msghdr(msg, bufs, flags))
     bytes_ref = Ref{UInt32}(UInt32(0))
     n = GC.@preserve bufs wmsg bytes_ref begin
-        ccall(
+        @win32_cconv ccall(
             recv_ptr,
             Cint,
             (UInt, Ref{WSAMsg}, Ref{UInt32}, Ptr{Cvoid}, Ptr{Cvoid}),
@@ -451,7 +451,7 @@ function _send_msg_ext!(fd::SocketFD, msg_ref::Ref{MsgHdr}, flags::Cint)::Cssize
     wmsg = Ref(_wsamsg_from_msghdr(msg, bufs, flags))
     bytes_ref = Ref{UInt32}(UInt32(0))
     n = GC.@preserve bufs wmsg bytes_ref begin
-        ccall(
+        @win32_cconv ccall(
             send_ptr,
             Cint,
             (UInt, Ref{WSAMsg}, UInt32, Ref{UInt32}, Ptr{Cvoid}, Ptr{Cvoid}),
@@ -494,7 +494,7 @@ function ensure_winsock!()
             UInt16(0),
             C_NULL,
         ))
-        rc = @gcsafe_ccall _WS2_32.WSAStartup(
+        rc = @gcsafe_win32_ccall _WS2_32.WSAStartup(
             UInt16(0x0202)::UInt16,
             wsa_data::Ref{_WSAData},
         )::Cint
@@ -513,7 +513,7 @@ end
 
 function fd_is_cloexec(fd::SocketFD)::Bool
     flags = Ref{UInt32}(UInt32(0))
-    ok = ccall((:GetHandleInformation, _KERNEL32), Int32, (Ptr{Cvoid}, Ref{UInt32}), _socket_handle(fd), flags)
+    ok = @win32_cconv ccall((:GetHandleInformation, _KERNEL32), Int32, (Ptr{Cvoid}, Ref{UInt32}), _socket_handle(fd), flags)
     if ok == 0
         _throw_errno("GetHandleInformation", _map_win32_errno(_win_get_last_error()))
     end
@@ -525,7 +525,7 @@ function fd_is_nonblocking(fd::SocketFD)::Bool
 end
 
 function set_close_on_exec!(fd::SocketFD)
-    ok = ccall(
+    ok = @win32_cconv ccall(
         (:SetHandleInformation, _KERNEL32),
         Int32,
         (Ptr{Cvoid}, UInt32, UInt32),
@@ -546,7 +546,7 @@ Toggle WinSock non-blocking mode and update the Julia-side bookkeeping used by
 function set_nonblocking!(fd::SocketFD, enabled::Bool = true)
     ensure_winsock!()
     arg = Ref{UInt32}(enabled ? UInt32(1) : UInt32(0))
-    ret = ccall((:ioctlsocket, _WS2_32), Cint, (UInt, Clong, Ref{UInt32}), _socket_value(fd), Clong(_FIONBIO), arg)
+    ret = @win32_cconv ccall((:ioctlsocket, _WS2_32), Cint, (UInt, Clong, Ref{UInt32}), _socket_value(fd), Clong(_FIONBIO), arg)
     ret == 0 || _throw_errno("ioctlsocket(FIONBIO)", _map_wsa_errno(_wsa_get_last_error()))
     _set_fd_nonblocking_state!(fd, enabled)
     return nothing
@@ -566,7 +566,7 @@ function open_socket(family::Integer, sotype::Integer, proto::Integer = 0)::Sock
     ensure_winsock!()
     raw_type = Cint(sotype)
     flags = UInt32(_WSA_FLAG_OVERLAPPED | _WSA_FLAG_NO_HANDLE_INHERIT)
-    sock = ccall(
+    sock = @win32_cconv ccall(
         (:WSASocketW, _WS2_32),
         UInt,
         (Cint, Cint, Cint, Ptr{Cvoid}, UInt32, UInt32),
@@ -597,7 +597,7 @@ already invalid.
 """
 function close_socket_nothrow(fd::SocketFD)::Int32
     _clear_fd_state!(fd)
-    ret = @gcsafe_ccall _WS2_32.closesocket(
+    ret = @gcsafe_win32_ccall _WS2_32.closesocket(
         _socket_value(fd)::UInt,
     )::Cint
     ret == 0 && return Int32(0)
@@ -629,7 +629,7 @@ function bind_socket(fd::SocketFD, addr::SockAddrIn6)
 end
 
 function bind_socket(fd::SocketFD, addr::Ptr{Cvoid}, addrlen::SockLen)
-    ret = @gcsafe_ccall _WS2_32.bind(
+    ret = @gcsafe_win32_ccall _WS2_32.bind(
         _socket_value(fd)::UInt,
         addr::Ptr{Cvoid},
         Cint(addrlen)::Cint,
@@ -639,7 +639,7 @@ function bind_socket(fd::SocketFD, addr::Ptr{Cvoid}, addrlen::SockLen)
 end
 
 function listen_socket(fd::SocketFD, backlog::Integer)
-    ret = @gcsafe_ccall _WS2_32.listen(
+    ret = @gcsafe_win32_ccall _WS2_32.listen(
         _socket_value(fd)::UInt,
         Cint(backlog)::Cint,
     )::Cint
@@ -671,7 +671,7 @@ to `EINPROGRESS` so the transport layer can use the same poll-driven connect
 completion path as it does on Unix.
 """
 function connect_socket(fd::SocketFD, addr::Ptr{Cvoid}, addrlen::SockLen)::Int32
-    ret = @gcsafe_ccall "Ws2_32".connect(
+    ret = @gcsafe_win32_ccall "Ws2_32".connect(
         _socket_value(fd)::UInt,
         addr::Ptr{Cvoid},
         Cint(addrlen)::Cint,
@@ -747,7 +747,7 @@ function try_accept_socket(fd::SocketFD)::Tuple{SocketFD, AcceptPeer, Int32}
     addrbuf = Ref{NTuple{_ACCEPT_ADDRBUF_LEN, UInt8}}()
     addrlen = Ref{SockLen}(SockLen(_ACCEPT_ADDRBUF_LEN))
     new_sock = GC.@preserve addrbuf begin
-        @gcsafe_ccall "Ws2_32".accept(
+        @gcsafe_win32_ccall "Ws2_32".accept(
             _socket_value(fd)::UInt,
             Base.unsafe_convert(Ptr{Cvoid}, addrbuf)::Ptr{Cvoid},
             addrlen::Ref{SockLen},
@@ -781,7 +781,7 @@ function accept_socket(fd::SocketFD)::SocketFD
 end
 
 function _set_sockopt_ptr!(fd::SocketFD, optname::Cint, ptr::Ptr{UInt8}, optlen::Integer)
-    ret = ccall(
+    ret = @win32_cconv ccall(
         (:setsockopt, _WS2_32),
         Cint,
         (UInt, Cint, Cint, Ptr{UInt8}, Cint),
@@ -837,7 +837,7 @@ function finish_accept_ex!(listener_fd::SocketFD, acceptfd::SocketFD, addrbuf::V
     remote_ptr = Ref{Ptr{UInt8}}(C_NULL)
     remote_len = Ref{Cint}(0)
     GC.@preserve addrbuf begin
-        @gcsafe_ccall _MSWSOCK.GetAcceptExSockaddrs(
+        @gcsafe_win32_ccall _MSWSOCK.GetAcceptExSockaddrs(
             pointer(addrbuf)::Ptr{UInt8},
             UInt32(0)::UInt32,
             UInt32(_ACCEPT_ADDRBUF_LEN)::UInt32,
@@ -861,7 +861,7 @@ function get_sockopt_int(fd::SocketFD, level::Cint, optname::Cint)::Int32
     value = Ref{Cint}(0)
     optlen = Ref{Cint}(Cint(sizeof(Cint)))
     ret = GC.@preserve value begin
-        ccall(
+        @win32_cconv ccall(
             (:getsockopt, _WS2_32),
             Cint,
             (UInt, Cint, Cint, Ptr{UInt8}, Ref{Cint}),
@@ -884,7 +884,7 @@ Write an integer socket option.
 function set_sockopt_int(fd::SocketFD, level::Cint, optname::Cint, value::Integer)
     raw = Ref{Cint}(Cint(value))
     ret = GC.@preserve raw begin
-        ccall(
+        @win32_cconv ccall(
             (:setsockopt, _WS2_32),
             Cint,
             (UInt, Cint, Cint, Ptr{UInt8}, Cint),
@@ -907,7 +907,7 @@ Write a socket option wider than a `Cint` (e.g. `SO_LINGER`) from a raw byte
 buffer. The caller must keep the memory behind `ptr` rooted for the call.
 """
 function set_sockopt_bytes(fd::SocketFD, level::Cint, optname::Cint, ptr::Ptr{Cvoid}, len::Integer)::Nothing
-    ret = ccall(
+    ret = @win32_cconv ccall(
         (:setsockopt, _WS2_32),
         Cint,
         (UInt, Cint, Cint, Ptr{UInt8}, Cint),
@@ -930,7 +930,7 @@ OS wrote. The caller must keep the memory behind `ptr` rooted for the call.
 function get_sockopt_bytes!(fd::SocketFD, level::Cint, optname::Cint, ptr::Ptr{Cvoid}, len::Integer)::Int
     len_ref = Ref{Cint}(Cint(len))
     ret = GC.@preserve len_ref begin
-        ccall(
+        @win32_cconv ccall(
             (:getsockopt, _WS2_32),
             Cint,
             (UInt, Cint, Cint, Ptr{UInt8}, Ref{Cint}),
@@ -957,7 +957,7 @@ end
 function get_socket_name_in(fd::SocketFD)::SockAddrIn
     addr = Ref{SockAddrIn}()
     addrlen = Ref{SockLen}(SockLen(sizeof(SockAddrIn)))
-    ret = ccall(
+    ret = @win32_cconv ccall(
         (:getsockname, _WS2_32),
         Cint,
         (UInt, Ptr{Cvoid}, Ref{SockLen}),
@@ -972,7 +972,7 @@ end
 function get_socket_name_in6(fd::SocketFD)::SockAddrIn6
     addr = Ref{SockAddrIn6}()
     addrlen = Ref{SockLen}(SockLen(sizeof(SockAddrIn6)))
-    ret = ccall(
+    ret = @win32_cconv ccall(
         (:getsockname, _WS2_32),
         Cint,
         (UInt, Ptr{Cvoid}, Ref{SockLen}),
@@ -987,7 +987,7 @@ end
 function get_peer_name_in(fd::SocketFD)::SockAddrIn
     addr = Ref{SockAddrIn}()
     addrlen = Ref{SockLen}(SockLen(sizeof(SockAddrIn)))
-    ret = ccall(
+    ret = @win32_cconv ccall(
         (:getpeername, _WS2_32),
         Cint,
         (UInt, Ptr{Cvoid}, Ref{SockLen}),
@@ -1002,7 +1002,7 @@ end
 function get_peer_name_in6(fd::SocketFD)::SockAddrIn6
     addr = Ref{SockAddrIn6}()
     addrlen = Ref{SockLen}(SockLen(sizeof(SockAddrIn6)))
-    ret = ccall(
+    ret = @win32_cconv ccall(
         (:getpeername, _WS2_32),
         Cint,
         (UInt, Ptr{Cvoid}, Ref{SockLen}),
@@ -1020,7 +1020,7 @@ end
 Half-close or fully close the directions designated by `how`.
 """
 function shutdown_socket(fd::SocketFD, how::Integer)
-    ret = @gcsafe_ccall _WS2_32.shutdown(
+    ret = @gcsafe_win32_ccall _WS2_32.shutdown(
         _socket_value(fd)::UInt,
         Cint(how)::Cint,
     )::Cint
@@ -1037,7 +1037,7 @@ inspection to the caller.
 """
 function read_once!(fd::SocketFD, ptr::Ptr{UInt8}, nbytes::Csize_t)::Cssize_t
     n = Int(min(nbytes, Csize_t(typemax(Cint))))
-    ret = @gcsafe_ccall "Ws2_32".recv(
+    ret = @gcsafe_win32_ccall "Ws2_32".recv(
         _socket_value(fd)::UInt,
         ptr::Ptr{UInt8},
         Cint(n)::Cint,
@@ -1054,7 +1054,7 @@ Perform one raw `send` call and surface short writes or errors to the caller.
 """
 function write_once!(fd::SocketFD, ptr::Ptr{UInt8}, nbytes::Csize_t)::Cssize_t
     n = Int(min(nbytes, Csize_t(typemax(Cint))))
-    ret = @gcsafe_ccall "Ws2_32".send(
+    ret = @gcsafe_win32_ccall "Ws2_32".send(
         _socket_value(fd)::UInt,
         ptr::Ptr{UInt8},
         Cint(n)::Cint,
@@ -1073,7 +1073,7 @@ function recv_from!(
         fromlen::Ptr{SockLen} = Ptr{SockLen}(C_NULL),
     )::Cssize_t
     n = Int(min(nbytes, Csize_t(typemax(Cint))))
-    ret = @gcsafe_ccall "Ws2_32".recvfrom(
+    ret = @gcsafe_win32_ccall "Ws2_32".recvfrom(
         _socket_value(fd)::UInt,
         ptr::Ptr{UInt8},
         Cint(n)::Cint,
@@ -1094,7 +1094,7 @@ function send_to!(
         tolen::SockLen = SockLen(0),
     )::Cssize_t
     n = Int(min(nbytes, Csize_t(typemax(Cint))))
-    ret = @gcsafe_ccall "Ws2_32".sendto(
+    ret = @gcsafe_win32_ccall "Ws2_32".sendto(
         _socket_value(fd)::UInt,
         ptr::Ptr{UInt8},
         Cint(n)::Cint,

--- a/test/internal_poll_tests.jl
+++ b/test/internal_poll_tests.jl
@@ -1,5 +1,6 @@
 using Test
 using Reseau
+using Reseau: @win32_cconv
 
 const IP = Reseau.IOPoll
 const SO = Reseau.SocketOps
@@ -604,7 +605,7 @@ end
                         unlock(state.lock)
                     end
 
-                    posted = ccall(
+                    posted = @win32_cconv ccall(
                         (:PostQueuedCompletionStatus, "Kernel32"),
                         Int32,
                         (Ptr{Cvoid}, UInt32, UInt, Ptr{Cvoid}),
@@ -621,7 +622,7 @@ end
                     # There is deliberately no matching OS request, so
                     # CancelIoEx returns ERROR_NOT_FOUND even though a packet
                     # for this OVERLAPPED is queued.
-                    raw_cancel = ccall(
+                    raw_cancel = @win32_cconv ccall(
                         (:CancelIoEx, "Kernel32"),
                         Int32,
                         (Ptr{Cvoid}, Ptr{Cvoid}),
@@ -648,7 +649,7 @@ end
                     key_ref = Ref{UInt}(UInt(0))
                     ov_ref = Ref{Ptr{Cvoid}}(C_NULL)
                     empty_result = GC.@preserve bytes_ref key_ref ov_ref begin
-                        ccall(
+                        @win32_cconv ccall(
                             (:GetQueuedCompletionStatus, "Kernel32"),
                             Int32,
                             (Ptr{Cvoid}, Ref{UInt32}, Ref{UInt}, Ref{Ptr{Cvoid}}, UInt32),


### PR DESCRIPTION
Every Win32/Winsock entry point is `__stdcall`, where the callee pops the arguments. Julia's default `ccall` convention is cdecl, where the caller pops them, so a plain `ccall` into Win32 skews the stack by the argument size on every call; the damage accumulates and surfaces as an access violation somewhere unrelated. On 64-bit Windows there is only one calling convention, so this was invisible there.

`WIN32_CCONV` resolves to `:stdcall` only on `i686-w64-mingw32` and to the platform default everywhere else, so shared call sites such as `inet_pton` are unaffected. It reaches the 64 Win32 call sites through two new macros, because the convention has to be a literal in the `ccall` surface syntax and so cannot come from a constant at the call site:

- `@win32_cconv` wraps a positional `ccall` and leaves its arguments untouched.
- `@gcsafe_win32_ccall` is `@gcsafe_ccall` with the Win32 convention.

`@gcsafe_ccall` itself expands exactly as before for every non-Win32 caller.

CI gains `windows-latest` jobs at `arch: x86` on `min` and `1`. `i686-w64-mingw32` is the only supported target where Win32/Winsock uses `__stdcall` rather than the platform's single default calling convention, so no existing job can catch a Win32 `ccall` that is missing one.

The two thread entry points handed to `CreateThread` are left as they are. `LPTHREAD_START_ROUTINE` is `__stdcall` too, and `@cfunction` cannot emit anything else, but that mismatch has no known observable effect: both conventions pass arguments identically on i686, they differ only in who pops, and the entry point returns straight into the thread-exit thunk, which never relies on the restored stack pointer. It is invoked once per thread, so nothing accumulates. Documented at the call site, along with the `uv_thread_create` route that would remove the need for a stdcall callback entirely.

Note that i686-w64-mingw32 is still listed as a tier 1 platform: https://julialang.org/downloads/support/#supported_platforms