### PR TITLE
perf(iopoll): keep parked poll waits on their own thread

### DIFF
--- a/src/iopoll/types.jl
+++ b/src/iopoll/types.jl
@@ -132,6 +132,10 @@ end
 Park the current Julia task until the waiter is notified.
 Concurrent waits on the same `PollWaiter` are forbidden.
 
+While parked the task is temporarily pinned to the thread it parks on, so the
+notifier's wake is delivered to that thread's run queue instead of the shared
+one. The task's previous stickiness is restored before this function returns.
+
 Returns the `PollWakeReason` that woke the waiter.
 
 Throws `ArgumentError` if two tasks try to wait on the same waiter
@@ -139,16 +143,17 @@ simultaneously, or if the waiter state machine is observed in an invalid state.
 """
 function pollwait!(waiter::PollWaiter)::PollWakeReason.T
     task = current_task()
-    # Intentionally preserve the caller's task stickiness. The poller wakes this
-    # task via `schedule(task)`; for a migratable task that drops it into the
-    # global run-queue, waking a cold parked worker whose cost scales with
-    # nthreads. Stickiness is the caller's choice (`@async` to pin a hot reader,
-    # `Threads.@spawn` to stay migratable) — don't override it here.
-    #
     # Consume an already-latched wake without parking, or claim the empty slot
     # by publishing this task in the word. Publishing the task IS the park
     # commitment: from here on any notifier that swaps it for a token owns
     # exactly one `schedule` of this task.
+    #
+    # While parked, adopt stickiness so the poller's `schedule(task)` lands on
+    # this thread's local queue. Waking a migratable task drops it on the shared
+    # run queue instead, and every polling thread goes looking for it; under a
+    # paced load that costs about half a core per interactive thread. Stickiness
+    # is restored on every wake, so a runnable task is migratable again by the
+    # time it leaves here and idle threads can still steal it.
     while true
         state = @atomic :acquire waiter.state
         if state === nothing
@@ -161,9 +166,12 @@ function pollwait!(waiter::PollWaiter)::PollWakeReason.T
             throw(ArgumentError("concurrent wait on PollWaiter"))
         end
     end
+    was_sticky = task.sticky
     try
         while true
+            task.sticky = true
             wait()
+            task.sticky = was_sticky
             # The token carries its reason in the same atomic word, so consuming
             # it cannot race a separate reason publication. A failed consume can
             # only mean the CANCELED→READY upgrade landed mid-consume: re-read
@@ -184,6 +192,7 @@ function pollwait!(waiter::PollWaiter)::PollWakeReason.T
             end
         end
     catch
+        task.sticky = was_sticky
         _abort_pollwait!(waiter, task)
         rethrow()
     end

--- a/test/iopoll_runtime_tests.jl
+++ b/test/iopoll_runtime_tests.jl
@@ -203,6 +203,9 @@ end
             end
             schedule(interrupted_task, InterruptException(); error = true)
             @test_throws TaskFailedException fetch(interrupted_task)
+            # The interrupt unwinds through the park's catch, which must put
+            # the caller's stickiness back before rethrowing.
+            @test !interrupted_task.sticky
             @test (@atomic :acquire interrupted_waiter.state) === nothing
             @test !NP.pollnotify!(interrupted_waiter, NP.PollWakeReason.READY)
             @test NP.pollwait!(interrupted_waiter) == NP.PollWakeReason.READY
@@ -254,6 +257,54 @@ end
             end
         end
         _el_log_test_progress("DONE: pollwait wake reason precedence")
+        _el_log_test_progress("START: pollwait parking preserves caller scheduling")
+        @testset "pollwait parking preserves caller scheduling" begin
+            # A migratable waiter adopts stickiness only while parked, so the
+            # poller's wake lands on the thread it parked on. Once woken it has
+            # to be migratable again.
+            waiter = NP.PollWaiter()
+            waiter_task = Threads.@spawn begin
+                before = Threads.threadid()
+                reason = NP.pollwait!(waiter)
+                (reason, before, Threads.threadid())
+            end
+            while !((@atomic :acquire waiter.state) isa Task) && !istaskdone(waiter_task)
+                yield()
+            end
+            # A regression that never adopts stickiness spins here; the CI job
+            # timeout is the guard, as in the lost-wakeup loop above.
+            while !waiter_task.sticky && !istaskdone(waiter_task)
+                yield()
+            end
+            @test waiter_task.sticky
+            @test NP.pollnotify!(waiter, NP.PollWakeReason.READY)
+            reason, before, after = fetch(waiter_task)
+            @test reason == NP.PollWakeReason.READY
+            @test before == after
+            @test !waiter_task.sticky
+
+            # A caller that asked for stickiness keeps it. The park must not
+            # hand back a different scheduling choice than the task started
+            # with, and spawning the sticky task must not leave its parent
+            # sticky either.
+            parent = current_task()
+            parent_sticky = parent.sticky
+            waiter = NP.PollWaiter()
+            sticky_task = @async NP.pollwait!(waiter)
+            parent.sticky = parent_sticky
+            try
+                while !((@atomic :acquire waiter.state) isa Task) && !istaskdone(sticky_task)
+                    yield()
+                end
+                @test sticky_task.sticky
+                @test NP.pollnotify!(waiter, NP.PollWakeReason.READY)
+                @test fetch(sticky_task) == NP.PollWakeReason.READY
+                @test sticky_task.sticky
+            finally
+                parent.sticky = parent_sticky
+            end
+        end
+        _el_log_test_progress("DONE: pollwait parking preserves caller scheduling")
         _el_log_test_progress("START: backend delay semantics")
         @testset "backend delay semantics" begin
             state = NP.Poller()


### PR DESCRIPTION
Hello @quinnj, **I did this with AI help, so I'm not sure if it is correct** 
 
## How this came about

I was playing with `httpjl` entry on [HttpArena](https://www.http-arena.com
) (HTTP.jl + Reseau) trying to improve the performance. Its paced profiles were burning absurd CPU: at a pinned 10,000 req/s the server used 31 cores — about half a core per interactive thread — while aiohttp served the same load with one. The handler clearly wasn't the problem, so I went looking in Reseau (using AI)

Reproducing locally with the benchmark's own tools (zrk pinned at 10K/s, gcannon for saturation) made the shape obvious: CPU per request scaled linearly with thread count at fixed work (t=1: 0.47 cores, t=8: 4.29, t=16:
6.83), while idle connections cost nothing. Julia's profiler put 74-90% of samples in `Base.poptask`, reached from `pollwait!`: waking a migratable task drops it on the shared run queue, so every polling thread goes looking for it. The comment already in `pollwait!` named that cost.

I first tried keeping connection tasks sticky in HTTP.jl, then a per-thread dispatcher pool. Both fixed the paced-load CPU but cost 17% saturated throughput — sticky tasks can't be stolen. So the fix belongs in Reseau: borrow stickiness only while parked, restore it on wake.

| same machine, same workloads | before | after |
|---|---|---|
| 10K req/s, 8 interactive threads | 4.29 cores | 1.34 cores |
| 10K req/s, 16 interactive threads | 6.83 cores | 1.74 cores |
| baseline, 4096 conns | 157.4K rps | 162.5K rps |

Saturation is unchanged, the paced profiles are 3-4x cheaper, and the new tests cover migratable and sticky callers plus the interrupt path. Setup for anyone reproducing: the HttpArena `httpjl` app, zrk 2.3.0 with
`-c 1024 -R 10000`, CPU from `/proc/<pid>/stat`. Focused iopoll tests pass at t=1 and t=4; the full suite passes on Linux t=1.